### PR TITLE
feat: integrate ci to nextjs packages

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,0 +1,40 @@
+name: Nextjs Frontend CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Bun
+      run: |
+        curl -fsSL https://bun.sh/install | bash
+        echo "$HOME/.bun/bin" >> $GITHUB_PATH
+
+    - name: Cache bun dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('packages/nextjs/bun.lockb') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      run: bun install
+      working-directory: packages/nextjs
+
+    - name: Lint code
+      run: bun run lint
+      working-directory: packages/nextjs
+
+    - name: Build Bun Nextjs
+      run: bun run build
+      working-directory: packages/nextjs
+


### PR DESCRIPTION
- Install the bun package manager.
- Successfully run the `bun install` command.
- Successfully executes the `bun run build` command.
- Successfully runs the `bun run lint` command.