### PR TITLE
Feat: Comprehensive Testing of Contributor Reputation contract

### DIFF
--- a/packages/soroban/contracts/contributor-reputation-contract/src/credentials.rs
+++ b/packages/soroban/contracts/contributor-reputation-contract/src/credentials.rs
@@ -5,14 +5,14 @@ use soroban_sdk::{Address, Env};
 pub fn mint_credential_token(env: Env, caller: Address, user_id: u64) -> Result<u64, Error> {
     caller.require_auth();
 
-    // Verify user exists
-    let mut user: User = env
+    // Verify user exists and is verified
+    let user: User = env
         .storage()
         .instance()
         .get(&DataKey::User(user_id))
         .ok_or(Error::UserNotFound)?;
-    if user.verified {
-        return Err(Error::AlreadyVerified);
+    if !user.verified {
+        return Err(Error::UserNotFound);
     }
 
     // Get next token ID
@@ -34,10 +34,6 @@ pub fn mint_credential_token(env: Env, caller: Address, user_id: u64) -> Result<
     env.storage()
         .instance()
         .set(&DataKey::Credential(token_id), &token);
-
-    // Mark user as verified
-    user.verified = true;
-    env.storage().instance().set(&DataKey::User(user_id), &user);
 
     Ok(token_id)
 }

--- a/packages/soroban/contracts/contributor-reputation-contract/src/credentials.rs
+++ b/packages/soroban/contracts/contributor-reputation-contract/src/credentials.rs
@@ -12,7 +12,7 @@ pub fn mint_credential_token(env: Env, caller: Address, user_id: u64) -> Result<
         .get(&DataKey::User(user_id))
         .ok_or(Error::UserNotFound)?;
     if !user.verified {
-        return Err(Error::UserNotFound);
+        return Err(Error::NotVerified);
     }
 
     // Get next token ID

--- a/packages/soroban/contracts/contributor-reputation-contract/src/lib.rs
+++ b/packages/soroban/contracts/contributor-reputation-contract/src/lib.rs
@@ -87,7 +87,7 @@ impl ContributorReputation {
         caller: Address,
         user_id: u64,
         verification_details: String,
-    ) -> Result<u64, Error> {
+    ) -> Result<(), Error> {
         verify::verify_user(env, caller, user_id, verification_details)
     }
 

--- a/packages/soroban/contracts/contributor-reputation-contract/src/verify.rs
+++ b/packages/soroban/contracts/contributor-reputation-contract/src/verify.rs
@@ -1,4 +1,3 @@
-use crate::credentials::mint_credential_token;
 use crate::error::Error;
 use crate::types::*;
 use soroban_sdk::{Address, Env, String};
@@ -8,7 +7,7 @@ pub fn verify_user(
     caller: Address,
     user_id: u64,
     verification_details: String,
-) -> Result<u64, Error> {
+) -> Result<(), Error> {
     caller.require_auth();
 
     // Verify user exists and is not already verified
@@ -31,8 +30,7 @@ pub fn verify_user(
     user.verified = true;
     env.storage().instance().set(&DataKey::User(user_id), &user);
 
-    // Mint credential token for the user
-    mint_credential_token(env, caller, user_id)
+    Ok(())
 }
 
 pub fn verify_content(


### PR DESCRIPTION
- Closes: #98 

1. In `mint_credential_token`:

     - Fixed logic to check that user is verified before minting

     - Removed the redundant verification status update (now handled in verify_user)

     - Simplified the flow to just minting tokens for verified users

2. In `verify_user`:

     - Properly separates verification and token minting

     - Checks that user isn't already verified

     - Updates user verification status before minting token

     - Validates input details
3. Fixed all and added new tests to meet the correctness below:
     - All key functions and error branches are tested.
     - Each test asserts proper state mutation or rejection.
     - Credential tokens are verifiably non-transferable.
     - Test suite must pass with `cargo test`.