### PR TITLE
The community section of the landing page

### DIFF
--- a/packages/nextjs/src/app/(landing)/page.tsx
+++ b/packages/nextjs/src/app/(landing)/page.tsx
@@ -1,3 +1,9 @@
+import CommunitySection from '@/components/landing/CommunitySection';
+
 export default function LandingPage() {
-  return <div>Landing Page</div>;
+  return (
+    <section>
+      <CommunitySection />
+    </section>
+  );
 }

--- a/packages/nextjs/src/components/landing/CommunitySection.tsx
+++ b/packages/nextjs/src/components/landing/CommunitySection.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { MessageCircle, Github } from 'lucide-react';
+import TwitterIcon from '../ui/twitter-icon';
+
+export default function CommunitySection() {
+  const communityLinks = [
+    {
+      id: 'telegram',
+      title: 'Join our Telegram',
+      description: 'Connect with the community and get real-time updates',
+      icon: <MessageCircle className="w-8 h-8 text-primary" />,
+      link: 'https://t.me/Akkuea',
+    },
+    {
+      id: 'twitter',
+      title: 'Follow us on X',
+      description: 'Stay updated with our latest news and announcements',
+      icon: <TwitterIcon className="w-8 h-8 text-primary" />,
+      link: 'https://x.com/Akkuea_Official',
+    },
+    {
+      id: 'github',
+      title: 'Explore our GitHub',
+      description: 'Contribute to our open source development',
+      icon: <Github className="w-8 h-8 text-primary" />,
+      link: ' https://github.com/akkuea/akkuea',
+    },
+  ];
+
+  return (
+    <section className="py-16 px-4 bg-[#F5F7F8]">
+      <div className="max-w-6xl mx-auto text-center">
+        <div className="mb-12">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            Join the <span className="text-primary">Akkuea</span> Community
+          </h2>
+          <p className="text-gray-600 text-lg max-w-2xl mx-auto leading-relaxed">
+            Akkuea is more than a platform — {"it's"} a movement. Connect with us, share ideas, and
+            help us shape the future of decentralized education.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
+          {communityLinks.map((platform) => (
+            <a
+              key={platform.id}
+              href={platform.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-white rounded-2xl py-12 px-2 cursor-pointer transition-all duration-300  hover:shadow-lg hover:scale-105 group"
+            >
+              <div className="flex justify-center mb-6">
+                <div className="p-3 bg-[#F0FDFA] rounded-full shadow-sm group-hover:shadow-md transition-shadow">
+                  {platform.icon}
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <h3 className="text-xl font-semibold text-gray-900">{platform.title}</h3>
+                <p className="text-gray-600 text-sm leading-relaxed">{platform.description}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/nextjs/src/components/ui/twitter-icon.tsx
+++ b/packages/nextjs/src/components/ui/twitter-icon.tsx
@@ -1,0 +1,17 @@
+export default function TwitterIcon({ className }: { className: string }) {
+  return (
+    <svg
+      width="29"
+      height="27"
+      viewBox="0 0 29 27"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M22.6801 0.226562H27.0894L17.4564 11.2365L28.7888 26.2184H19.9156L12.9658 17.1319L5.01359 26.2184H0.601636L10.9051 14.4421L0.0338135 0.226562H9.1323L15.4143 8.53197L22.6801 0.226562ZM21.1326 23.5793H23.5758L7.80472 2.72711H5.18287L21.1326 23.5793Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Description
This pull request adds a new "CommunitySection" to the landing page, allowing users to easily connect with the Akkuea community on Telegram, X (Twitter), and GitHub. It introduces a new reusable `TwitterIcon` (this is because the lucide-react icon library doesn't have the current X icon) component and updates the landing page to display the community section.

## Changes Made

**Landing page improvements:**

* Added a new `CommunitySection` component to the landing page by updating `page.tsx`, providing users with quick access to Akkuea's community platforms.
* Implemented the `CommunitySection` component, which displays links to Telegram, X (Twitter), and GitHub with platform-specific icons, descriptions, and responsive styling.

**UI components:**

* Created a new `TwitterIcon` React component to render a scalable SVG icon for X (Twitter), used within the community section.

## Related Issue 
* This PR closes issue #243 

## Screenshots 
Desktop Screen 
[Screencast from 2025-09-09 21-05-28.webm](https://github.com/user-attachments/assets/d7382277-a30a-43fa-89fa-ce99455644b9)

Mobile Screen 
[Screencast from 2025-09-09 21-07-50.webm](https://github.com/user-attachments/assets/f4c4c94a-5540-437d-a0c3-1e25c5bc449f)


@xJeffx23 
Please review. Thanks 🙏.