### PR TITLE
docs: integrate documentation structure to readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,27 @@ Issue 294
 
 ---
 
-Issue 295
-<!-- Make the changes from issue number 295 here. Thank you for contributing to Akkuea! -->
+
+## 📚 Documentation Structure
+
+### Core Documentation
+
+#### [📋 Documentation Index](index.md)
+Complete navigation hub for all documentation sections with quick access links and overview information.
+
+#### [🏗️ Platform Features](features/README.md)
+Comprehensive overview of Akkuea's social networking capabilities, content interaction systems, and community features.
+
+#### [📖 Educational Resources](educational-resources/README.md)
+Detailed documentation of the content creation, sharing, and discovery systems that power educational collaboration.
+
+#### [🛒 Marketplace](marketplace/README.md)
+Complete guide to the designer-educator marketplace, including project workflows, payment systems, and quality assurance.
+
+#### [🤖 AI Agents](ai-agents/README.md)
+Documentation for native AI agent creation, training, and management systems that enable specialized educational assistance.
+
+
 
 ---
 


### PR DESCRIPTION
# Add documentation structure

## Description
This pull request is about the documentation structure into `docs` folder and explain the structure of the document in a file called `readme`

- Closes #295 