### PR TITLE
Task #165: Add simple manual authentication tests

### DIFF
--- a/packages/gin/main.go
+++ b/packages/gin/main.go
@@ -41,6 +41,15 @@ func main() {
 
 		// Current user endpoint
 		protected.GET("/auth/me", api.GetCurrentUser)
+		
+		// Temporary protected route for testing (Task #165)
+		protected.GET("/protected", func(c *gin.Context) {
+			c.JSON(200, gin.H{
+				"message": "Protected route accessed successfully",
+				"user_id": c.GetString("user_id"),
+				"role":    c.GetString("user_role"),
+			})
+		})
 	}
 
 	// Get port from config (env), default to 8080

--- a/packages/gin/tests/README.md
+++ b/packages/gin/tests/README.md
@@ -1,0 +1,63 @@
+# Authentication Endpoint Tests
+
+This directory contains manual testing scripts for the authentication endpoints as requested in Task #165.
+
+## Test Script
+
+- `test_auth.sh` - Simple cURL script to test authentication endpoints
+
+## Test Coverage
+
+### ✅ POST /auth/register
+- Valid registration with all required fields
+- Invalid registration with missing fields
+
+### ✅ POST /auth/login  
+- Valid login with correct credentials
+- Invalid login with wrong credentials
+
+### ✅ Protected Routes
+- Access without token (401 Unauthorized)
+- Access with invalid token (401 Unauthorized)
+
+## Running Tests
+
+1. Start the Go server:
+   ```bash
+   cd packages/gin
+   go run main.go
+   ```
+
+2. Run the test script:
+   ```bash
+   ./tests/test_auth.sh
+   ```
+
+## Expected Results
+
+- Registration with valid data: 201 Created
+- Registration with invalid data: 400 Bad Request
+- Login with correct credentials: 200 OK (returns JWT token)
+- Login with incorrect credentials: 401 Unauthorized
+- Protected route without token: 401 Unauthorized
+- Protected route with invalid token: 401 Unauthorized
+
+## Manual Testing with Valid Token
+
+To test protected routes with a valid token:
+
+1. Run the login test and copy the JWT token from the response
+2. Use the token in Authorization header:
+   ```bash
+   curl -X GET "http://localhost:8080/protected" \
+     -H "Authorization: Bearer YOUR_JWT_TOKEN_HERE"
+   ```
+
+## Role-Based Access Testing
+
+To test different roles, modify the registration data in the script:
+- `"role": "Educator"`
+- `"role": "Student"`  
+- `"role": "Designer"`
+
+Each role should be able to access protected routes with a valid JWT token.

--- a/packages/gin/tests/test_auth.sh
+++ b/packages/gin/tests/test_auth.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Simple cURL tests for authentication endpoints
+# Task #165: Test Authentication Endpoints [Golang]
+
+BASE_URL="http://localhost:8080"
+
+echo "🧪 Testing Authentication Endpoints"
+echo "=================================="
+
+# Test 1: Register a user with valid data
+echo "1. Testing POST /auth/register with valid data..."
+curl -X POST "$BASE_URL/auth/register" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Test User",
+    "email": "test@example.com",
+    "password": "password123",
+    "role": "Student"
+  }' \
+  -w "\nStatus: %{http_code}\n\n"
+
+# Test 2: Register with invalid data (missing fields)
+echo "2. Testing POST /auth/register with invalid data..."
+curl -X POST "$BASE_URL/auth/register" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Test User"
+  }' \
+  -w "\nStatus: %{http_code}\n\n"
+
+# Test 3: Login with correct credentials
+echo "3. Testing POST /auth/login with correct credentials..."
+curl -X POST "$BASE_URL/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test@example.com",
+    "password": "password123"
+  }' \
+  -w "\nStatus: %{http_code}\n\n"
+
+# Test 4: Login with incorrect credentials
+echo "4. Testing POST /auth/login with incorrect credentials..."
+curl -X POST "$BASE_URL/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test@example.com",
+    "password": "wrongpassword"
+  }' \
+  -w "\nStatus: %{http_code}\n\n"
+
+# Test 5: Access protected route without token
+echo "5. Testing GET /protected without token..."
+curl -X GET "$BASE_URL/protected" \
+  -w "\nStatus: %{http_code}\n\n"
+
+# Test 6: Access protected route with invalid token
+echo "6. Testing GET /protected with invalid token..."
+curl -X GET "$BASE_URL/protected" \
+  -H "Authorization: Bearer invalid-token" \
+  -w "\nStatus: %{http_code}\n\n"
+
+echo "✅ Manual testing complete!"
+echo "Note: To test with valid token, first run the login test and copy the token from the response."


### PR DESCRIPTION
Task #165: Test Authentication Endpoints [Golang]


Description
Adds manual testing for authentication endpoints using cURL scripts, as requested by the moderator.


Changes
Add cURL script to test POST /auth/register with valid and invalid inputs
Add cURL script to test POST /auth/login with correct and incorrect credentials
Add temporary protected route GET /protected for testing
Document test cases in README.md for reproducibility
Use simple manual testing approach as requested by moderator

Fulfills Task #165 requirements without over-engineering


Files Added/Modified
packages/gin/tests/test_auth.sh - cURL script for manual testing
packages/gin/tests/README.md - Test documentation
packages/gin/main.go - Added temporary /protected route


Test Coverage
POST /auth/register - Valid and invalid inputs
POST /auth/login - Correct and incorrect credentials
GET /protected - Temporary protected route with JWT middleware
Role-based access - Educator, Student, Designer roles
Manual testing - cURL scripts (not unit tests)

Closes #165
