### PR TITLE
docs: add documentation structure for issue 311

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,44 @@ Issue 310
 ---
 
 Issue 311
-<!-- Make the changes from issue number 311 here. Thank you for contributing to Akkuea! -->
+### Core Vision
+**Empowering education through the strategic use of emerging technology**
+
+## Documentation Structure
+
+### 📚 Platform Overview
+- **[Platform Features](features/README.md)** - Core social networking and educational capabilities
+- **[Educational Resources](educational-resources/README.md)** - Content sharing and management system
+- **[Marketplace](marketplace/README.md)** - Designer-user connection platform
+- **[AI Agents](ai-agents/README.md)** - Native AI agent creation and management
+
+### 👥 User Guides
+- **[Getting Started](guides/getting-started.md)** - Quick start guide for new users
+- **[User Workflows](guides/user-workflows.md)** - Step-by-step processes
+- **[Content Creation](guides/content-creation.md)** - Publishing educational resources
+- **[Marketplace Guide](guides/marketplace-guide.md)** - Using the designer marketplace
+
+### 🔧 Technical Documentation
+- **[Architecture Overview](technical/architecture.md)** - System design and components
+- **[API Reference](technical/api-reference.md)** - Complete API documentation
+- **[Database Schema](technical/database-schema.md)** - Data models and relationships
+- **[Smart Contracts](technical/smart-contracts.md)** - Blockchain implementation
+
+### 🚀 Developer Resources
+- **[Setup Guide](development/setup.md)** - Development environment configuration
+- **[Contributing](development/contributing.md)** - Contribution guidelines
+- **[Code Standards](development/code-standards.md)** - Coding conventions
+- **[Testing](development/testing.md)** - Testing strategies and tools
+
+### 🎨 Design System
+- **[Visual Identity](design/visual-identity.md)** - Brand guidelines and color schemes
+- **[UI Components](design/ui-components.md)** - Component library documentation
+- **[Design Patterns](design/design-patterns.md)** - Common design patterns
+
+### 📊 Analytics & Insights
+- **[Reward System](analytics/reward-system.md)** - User incentive mechanisms
+- **[Engagement Metrics](analytics/engagement-metrics.md)** - Platform analytics
+- **[Performance Tracking](analytics/performance-tracking.md)** - System monitoring
 
 ---
 


### PR DESCRIPTION
### Summary
This PR adds the documentation structure requested in issue #311.  
The updates were made to `docs/index.md` in the section for issue 311.