### PR TITLE
Docs: Getting started docs added

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,9 @@ Issue 313
 
 ---
 
-Issue 314
+## Getting Started
 
-<!-- Make the changes from issue number 314 here. Thank you for contributing to Akkuea! -->
+1. **New Users**: Start with [Getting Started Guide](guides/getting-started.md)  
+2. **Developers**: Begin with [Setup Guide](development/setup.md)  
+3. **Content Creators**: Explore [Content Creation Guide](guides/content-creation.md)  
+4. **Marketplace Users**: Check [Marketplace Guide](guides/marketplace-guide.md)  


### PR DESCRIPTION
Added the `Getting Started` section on the docs section inside the `index.md` file

resolves #314 

Here is it how it looks after changes 
<img width="1297" height="266" alt="image" src="https://github.com/user-attachments/assets/da605a48-22d8-40e6-afb0-1fe187ee5c37" />
