### PR TITLE
doc: Document the Key Highlights

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,9 +76,19 @@ Issue 312
 
 ---
 
-Issue 313
+## Key Highlights
 
-<!-- Make the changes from issue number 313 here. Thank you for contributing to Akkuea! -->
+### 🎯 Reward-Based Learning
+Users who contribute high-quality educational resources and engage meaningfully with the community are rewarded through our comprehensive incentive system.
+
+### 🛒 Educational Marketplace
+Connect with specialized designers to create custom educational content, from local cultural traditions to specialized academic topics.
+
+### 🤖 AI-Powered Education
+Create intelligent agents specialized in specific domains, enabling automated content generation and personalized learning experiences.
+
+### 🌍 Cultural Heritage Focus
+Celebrating Costa Rica's indigenous communities while building global educational connections.
 
 ---
 


### PR DESCRIPTION
closes #313 

I added the Key Highlights section to the `docs/index.md` file.
The new content is now available where the "Issue 313" placeholder was located, replacing the comment with the requested markdown content.
The Key Highlights section now includes:
- Reward-Based Learning - Highlighting the incentive system for quality contributions
- Educational Marketplace - Describing the designer connection platform
- AI-Powered Education - Explaining the AI agent capabilities
- Cultural Heritage Focus - Emphasizing Costa Rica's indigenous heritage