### PR TITLE
feat: document limitation with adding roadmap item animations due to react-chrono

### DIFF
--- a/packages/nextjs/src/components/landing/Roadmap.tsx
+++ b/packages/nextjs/src/components/landing/Roadmap.tsx
@@ -2,6 +2,7 @@
 
 import { Bot, FlaskConical, Globe, Rocket, TestTube, Zap } from 'lucide-react';
 import dynamic from 'next/dynamic';
+import { useState, useEffect, useRef } from 'react';
 
 // The Chrono component relies on browser-specific APIs and does not support server-side rendering (SSR).
 // Therefore, we dynamically import it with SSR disabled to prevent rendering issues.
@@ -49,9 +50,43 @@ const roadmapTimeLineData = [
 ];
 
 export default function Roadmap() {
+  const [isVisible, setIsVisible] = useState(false);
+  const sectionRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect(); // Optional: stop observing after it's visible once
+        }
+      },
+      { threshold: 0.2 }, // Trigger when 20% of the section is visible
+    );
+
+    if (sectionRef.current) {
+      observer.observe(sectionRef.current);
+    }
+
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      if (sectionRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        observer.unobserve(sectionRef.current);
+      }
+    };
+  }, []);
+
   return (
-    <section className="bg-[#F3F4F6] dark:bg-muted/20 py-16 px-4">
-      <div className="max-w-4xl mx-auto text-center space-y-2">
+    <section
+      ref={sectionRef}
+      className="bg-[#F3F4F6] dark:bg-muted/20 py-16 px-4 overflow-hidden"
+    >
+      <div
+        className={`max-w-4xl mx-auto text-center space-y-2 transition-all duration-1000 ${
+          isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+        }`}
+      >
         <h2 className="text-3xl font-bold mb-4 text-black dark:text-foreground">
           <span className="text-[#5EEAD4] dark:text-primary">Akkuea</span> Roadmap
         </h2>
@@ -59,7 +94,11 @@ export default function Roadmap() {
           From development in 2025 to the official MVP launch in 2026.
         </p>
       </div>
-      <div className="mt-10 xl:max-w-6xl mx-auto">
+      <div
+        className={`mt-10 xl:max-w-6xl mx-auto transition-all duration-1000 delay-300 ${
+          isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+        }`}
+      >
         <Chrono
           theme={{
             primary: '#5EEAD4',
@@ -67,6 +106,9 @@ export default function Roadmap() {
           }}
           mode="VERTICAL_ALTERNATING"
           disableToolbar={true}
+  slideItemDuration={3000} 
+  slideshow
+  slideShowType='slide_from_sides'
         >
           {roadmapTimeLineData.map((item, index) => (
             <TimeLineCard

--- a/packages/nextjs/src/components/landing/TimeLineCard.tsx
+++ b/packages/nextjs/src/components/landing/TimeLineCard.tsx
@@ -17,14 +17,25 @@ export default function TimeLineCard({
   const [visible, setVisible] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => setVisible(entry.isIntersecting),
-      { threshold: 0.2 }
-    );
-    if (ref.current) observer.observe(ref.current);
-    return () => observer.disconnect();
-  }, []);
+ useEffect(() => {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        setVisible(true);
+        observer.disconnect(); 
+      }
+    },
+    {
+      root: null,
+      rootMargin: "-30% 0px -30% 0px", 
+      threshold: 0,
+    }
+  );
+
+  if (ref.current) observer.observe(ref.current);
+  return () => observer.disconnect();
+}, []);
+
 
   return (
     <div

--- a/packages/nextjs/src/components/landing/TimeLineCard.tsx
+++ b/packages/nextjs/src/components/landing/TimeLineCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { LucideIcon } from 'lucide-react';
 
 interface TimeLineCardProps {
@@ -13,15 +14,36 @@ export default function TimeLineCard({
   timelineTitle,
   description,
 }: TimeLineCardProps) {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => setVisible(entry.isIntersecting),
+      { threshold: 0.2 }
+    );
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className="flex flex-col pb-5 md:pb-1 h-full justify-between items-end gap-2 ">
-      <p className="flex text-sm font-medium md:font-bold md:text-xl items-center gap-2 text-right">
-        <span className="p-2 rounded-full bg-[#F0FDFA] text-primary hidden md:block">
-          <Icon />
-        </span>
-        <span>{timelineTitle}</span>
-      </p>
-      <p className="mt-2 text-gray-700 text-right text-sm md:text-base">{description}</p>
+    <div
+      ref={ref}
+      className={`transition-opacity duration-1000 ease-out delay-300 ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <div className="flex flex-col pb-5 md:pb-1 h-full justify-between items-end gap-2">
+        <p className="flex text-sm font-medium md:font-bold md:text-xl items-center gap-2 text-right">
+          <span className="p-2 rounded-full bg-[#F0FDFA] text-primary hidden md:block">
+            <Icon />
+          </span>
+          <span>{timelineTitle}</span>
+        </p>
+        <p className="mt-2 text-gray-700 text-right text-sm md:text-base">
+          {description}
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Context
This PR addresses the issue: *Add entrance animations for roadmap items (fade-in, slide-up, or zoom-in effects)*.

## Attempt
- Tried implementing animations (fade-in + slide-up) using `IntersectionObserver` on the timeline cards.
- Also explored staggered animations and hover interactions.

## Limitation
- The current dependency (`react-chrono`) renders its own card wrappers internally.
- This makes it difficult to:
  - Attach refs reliably for scroll-based animations.
  - Control the card lifecycle for staggered effects.
  - Apply hover/scale animations without conflicting with the package’s built-in styles.

## Why It Matters
Smooth entrance + staggered animations are part of the roadmap design goals. However, `react-chrono` prevents us from delivering them cleanly.

## Next Steps
- Option 1: Replace `react-chrono` with a custom timeline component for full control.
- Option 2: Contribute upstream to `react-chrono` to expose animation hooks or props.
- Option 3: Keep current setup, but accept limited animations (opacity-only with no staggering).

---

📌 This PR documents the limitation so the team and maintainers understand why animations could not be added as scoped in the issue.
[animation-akkuea.webm](https://github.com/user-attachments/assets/df9a1ec9-ae88-4fd1-a277-32c83535d686)
