### PR TITLE
Greeting system contract user registration

### DIFF
--- a/packages/soroban/contracts/greeting-system/src/datatype.rs
+++ b/packages/soroban/contracts/greeting-system/src/datatype.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String};
 
 /// Premium tier levels based on contribution amounts
 #[contracttype]
@@ -113,4 +113,14 @@ impl TierLevel {
             },
         }
     }
+}
+
+/// User profile data structure
+#[contracttype]
+#[derive(Debug, Clone)]
+pub struct UserProfile {
+    pub user: Address,          
+    pub name: String,      
+    pub preferences: String, 
+    pub registered_at: u64,    
 }

--- a/packages/soroban/contracts/greeting-system/src/error.rs
+++ b/packages/soroban/contracts/greeting-system/src/error.rs
@@ -27,4 +27,16 @@ pub enum Error {
     
     /// User already has a tier assigned
     TierAlreadyExists = 8,
+
+    /// User is already registered
+    UserAlreadyRegistered = 9,
+
+    /// User profile not found
+    UserNotFound = 10,
+
+    /// Invalid user name
+    InvalidName = 11,
+
+    /// Invalid user preferences
+    InvalidPreferences = 12,
 }

--- a/packages/soroban/contracts/greeting-system/src/events.rs
+++ b/packages/soroban/contracts/greeting-system/src/events.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
-use crate::{Error, TierAssignmentEvent, TierLevel, TierUpgradeEvent};
+use crate::{Error, TierAssignmentEvent, TierLevel, TierUpgradeEvent, UserProfile};
 
 /// Event symbol for tier assignment
 pub const TIER_ASSIGNED: Symbol = symbol_short!("TIER_ASGN");
@@ -10,6 +10,9 @@ pub const TIER_UPGRADED: Symbol = symbol_short!("TIER_UPG");
 
 /// Event symbol for tier downgrade (if allowed in future)
 pub const TIER_DOWNGRADED: Symbol = symbol_short!("TIER_DWN");
+
+/// Event symbol for user registration
+pub const USER_REGISTERED: Symbol = symbol_short!("USR_REG");
 
 /// Emit a tier assignment event
 pub fn emit_tier_assigned(env: &Env, event: &TierAssignmentEvent) -> Result<(), Error> {
@@ -68,5 +71,19 @@ pub fn emit_tier_downgraded(
         ),
     );
     
+    Ok(())
+}
+
+/// Emit a user registration event
+pub fn emit_user_registered(env: &Env, profile: &UserProfile) -> Result<(), Error> {
+    env.events().publish(
+        (USER_REGISTERED, symbol_short!("reg")),
+        (
+            profile.user.clone(),
+            profile.name.clone(),
+            profile.preferences.clone(),
+            profile.registered_at,
+        ),
+    );
     Ok(())
 }

--- a/packages/soroban/contracts/greeting-system/src/interface.rs
+++ b/packages/soroban/contracts/greeting-system/src/interface.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, String};
 
-use crate::{Error, PremiumFeatures, PremiumTier, TierLevel};
+use crate::{Error, PremiumFeatures, PremiumTier, TierLevel, UserProfile};
 
 /// Interface for premium tier management
 pub trait PremiumTierTrait {
@@ -69,4 +69,21 @@ pub trait PremiumTierTrait {
     /// # Returns
     /// * `Result<i128, Error>` - The total contribution in Stroops
     fn get_total_contribution(env: Env, user: Address) -> Result<i128, Error>;
+}
+
+/// Interface for user registration and profiles
+pub trait UserRegistryTrait {
+    /// Register a specific user address with name and preferences
+    fn register_user(env: Env, user: Address, name: String, preferences: String) -> Result<(), Error>;
+
+    /// Get a user profile by address
+    fn get_user_profile(env: Env, user: Address) -> Result<UserProfile, Error>;
+}
+
+/// Interface for admin/config actions
+pub trait ConfigTrait {
+    /// Set the reputation contract address for integration
+    fn set_reputation_contract(env: Env, contract: Address) -> Result<(), Error>;
+
+    fn get_reputation_contract(env: Env) -> Option<Address>;
 }

--- a/packages/soroban/contracts/greeting-system/src/lib.rs
+++ b/packages/soroban/contracts/greeting-system/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
 mod datatype;
 mod error;
@@ -7,6 +7,7 @@ mod events;
 mod interface;
 mod storage;
 mod utils;
+mod user;
 
 pub use datatype::*;
 pub use error::*;
@@ -116,6 +117,32 @@ impl GreetingSystem {
     pub fn get_total_contribution(env: Env, user: Address) -> Result<i128, Error> {
         let tier = load_premium_tier(&env, &user)?;
         Ok(tier.contribution)
+    }
+}
+
+#[contractimpl]
+impl crate::UserRegistryTrait for GreetingSystem {
+    /// Registers a user with profile details
+    fn register_user(env: Env, user: Address, name: String, preferences: String) -> Result<(), Error> {
+        user::register(&env, &user, &name, &preferences)
+    }
+
+    /// Retrieves a user profile by address
+    fn get_user_profile(env: Env, user: Address) -> Result<UserProfile, Error> {
+        user::get_profile(&env, &user)
+    }
+}
+
+#[contractimpl]
+impl crate::ConfigTrait for GreetingSystem {
+    fn set_reputation_contract(env: Env, contract: Address) -> Result<(), Error> {
+        // Require admin auth: here we keep it simple and require the contract address itself to auth.
+        contract.require_auth();
+        crate::storage::set_reputation_contract(&env, &contract)
+    }
+
+    fn get_reputation_contract(env: Env) -> Option<Address> {
+        crate::storage::get_reputation_contract(&env)
     }
 }
 

--- a/packages/soroban/contracts/greeting-system/src/storage.rs
+++ b/packages/soroban/contracts/greeting-system/src/storage.rs
@@ -1,12 +1,14 @@
 use soroban_sdk::{contracttype, Address, Env};
 
-use crate::{Error, PremiumTier};
+use crate::{Error, PremiumTier, UserProfile};
 
 /// Storage keys for the premium tier system
 #[contracttype]
 #[derive(Clone)]
 pub enum StorageKey {
     PremiumTier(Address),
+    UserProfile(Address),
+    ReputationContract,
 }
 
 /// Save a premium tier to storage
@@ -36,4 +38,39 @@ pub fn remove_premium_tier(env: &Env, user: &Address) -> Result<(), Error> {
     let key = StorageKey::PremiumTier(user.clone());
     env.storage().persistent().remove(&key);
     Ok(())
+}
+
+/// Save user profile to storage
+pub fn save_user_profile(env: &Env, profile: &UserProfile) -> Result<(), Error> {
+    let key = StorageKey::UserProfile(profile.user.clone());
+    env.storage().persistent().set(&key, profile);
+    Ok(())
+}
+
+/// Load a user profile from storage
+pub fn load_user_profile(env: &Env, user: &Address) -> Result<UserProfile, Error> {
+    let key = StorageKey::UserProfile(user.clone());
+    env.storage()
+        .persistent()
+        .get(&key)
+        .ok_or(Error::UserNotFound)
+}
+
+/// Check if a user is registered
+pub fn has_user_profile(env: &Env, user: &Address) -> bool {
+    let key = StorageKey::UserProfile(user.clone());
+    env.storage().persistent().has(&key)
+}
+
+/// Set the external reputation contract address
+pub fn set_reputation_contract(env: &Env, contract: &Address) -> Result<(), Error> {
+    let key = StorageKey::ReputationContract;
+    env.storage().persistent().set(&key, contract);
+    Ok(())
+}
+
+/// Get the external reputation contract address, if set
+pub fn get_reputation_contract(env: &Env) -> Option<Address> {
+    let key = StorageKey::ReputationContract;
+    env.storage().persistent().get(&key)
 }

--- a/packages/soroban/contracts/greeting-system/src/test.rs
+++ b/packages/soroban/contracts/greeting-system/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 use crate::{
     xlm_to_stroops, GreetingSystem, GreetingSystemClient, TierLevel,
@@ -202,6 +202,7 @@ fn test_get_total_contribution() {
     assert_eq!(total, xlm_to_stroops(500));
 }
 
+
 #[test]
 fn test_get_premium_status_not_found() {
     let (_env, client, user) = create_test_env();
@@ -250,4 +251,54 @@ fn test_tier_features_elite() {
     assert!(features.priority_support);
     assert!(features.analytics_access);
     assert_eq!(features.api_rate_limit, 500);
+}
+
+#[test]
+fn test_register_user_and_get_profile() {
+    let (env, client, user) = create_test_env();
+    env.mock_all_auths();
+
+    let name = String::from_str(&env, "Alice");
+    let prefs = String::from_str(&env, "friend");
+
+    client.register_user(&user, &name, &prefs);
+
+    let profile = client.get_user_profile(&user);
+    assert_eq!(profile.user, user);
+    assert_eq!(profile.name, name);
+    assert_eq!(profile.preferences, prefs);
+}
+
+#[test]
+fn test_register_user_duplicate_fails() {
+    let (env, client, user) = create_test_env();
+    env.mock_all_auths();
+
+    let name = String::from_str(&env, "Bob");
+    let prefs = String::from_str(&env, "casual");
+
+    client.register_user(&user, &name, &prefs);
+    let err = client.try_register_user(&user, &name, &prefs);
+    assert!(err.is_err());
+}
+
+#[test]
+fn test_stress_register_many_users() {
+    let (env, client, _user) = create_test_env();
+    env.mock_all_auths();
+
+    let total = 1000u32;
+    for i in 0..total {
+        let u = Address::generate(&env);
+        let name = String::from_str(&env, "User");
+        
+        let prefs = String::from_str(&env, "p");
+        client.register_user(&u, &name, &prefs);
+
+       
+        if i % 200 == 0 {
+            let profile = client.get_user_profile(&u);
+            assert_eq!(profile.user, u);
+        }
+    }
 }

--- a/packages/soroban/contracts/greeting-system/src/user.rs
+++ b/packages/soroban/contracts/greeting-system/src/user.rs
@@ -1,0 +1,44 @@
+use soroban_sdk::{symbol_short, Address, Env, IntoVal, String, Symbol, Vec};
+
+use crate::{
+    emit_user_registered, get_current_timestamp, get_reputation_contract, has_user_profile,
+    save_user_profile, validate_name, validate_preferences, verify_user_authorization, Error,
+    UserProfile,
+};
+
+pub fn register(env: &Env, user: &Address, name: &String, preferences: &String) -> Result<(), Error> {
+    verify_user_authorization(env, user)?;
+    validate_name(name)?;
+    validate_preferences(preferences)?;
+
+    if has_user_profile(env, user) {
+        return Err(Error::UserAlreadyRegistered);
+    }
+
+    let timestamp = get_current_timestamp(env);
+    let profile = UserProfile {
+        user: user.clone(),
+        name: name.clone(),
+        preferences: preferences.clone(),
+        registered_at: timestamp,
+    };
+
+    save_user_profile(env, &profile)?;
+
+   
+    if let Some(rep_contract) = get_reputation_contract(env) { //  platform-user-reputation-contract.register(env, user, expertise)
+        let expertise: Vec<Symbol> = Vec::new(env);
+        let args = (user.clone(), expertise).into_val(env);
+        let _res: () = env.invoke_contract(&rep_contract, &symbol_short!("register"), args);
+    }
+
+    emit_user_registered(env, &profile)?;
+    Ok(())
+}
+
+
+pub fn get_profile(env: &Env, user: &Address) -> Result<UserProfile, Error> {
+    crate::load_user_profile(env, user)
+}
+
+

--- a/packages/soroban/contracts/greeting-system/src/utils.rs
+++ b/packages/soroban/contracts/greeting-system/src/utils.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, String};
 
 use crate::Error;
 
@@ -44,6 +44,24 @@ pub fn xlm_to_stroops(xlm: i128) -> i128 {
 /// Convert Stroops to XLM (1 XLM = 10,000,000 Stroops)
 pub fn stroops_to_xlm(stroops: i128) -> i128 {
     stroops / 10_000_000
+}
+
+/// Validate user name input
+pub fn validate_name(name: &String) -> Result<(), Error> {
+    let len = name.len() as u32;
+    if len == 0 || len > 64 {
+        return Err(Error::InvalidName);
+    }
+    Ok(())
+}
+
+/// Validate user preferences input
+pub fn validate_preferences(preferences: &String) -> Result<(), Error> {
+    let len = preferences.len() as u32;
+    if len > 256 {
+        return Err(Error::InvalidPreferences);
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements user registration with persistent profiles for the greeting system.
- Contract structure matches spec: lib.rs, user.rs, utils.rs.
- Enforces verified accounts, and also validates input sizes.
- Integrates with platform-user-reputation-contract to initialize reputation on registration (no profile duplication).
- Exposes register_user(user, name, preferences) and get_user_profile(user).
- Includes scalability test, all tests pass.