### PR TITLE
feat: add smooth scroll to 'Join the Community' button in Hero + link…

### DIFF
--- a/packages/nextjs/src/components/landing/Benefits.tsx
+++ b/packages/nextjs/src/components/landing/Benefits.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from "next/link";
 
 const Benefits = () => {
   const benefits = [
@@ -70,9 +71,12 @@ const Benefits = () => {
 
           {/* Buttons */}
           <div className="flex gap-4 items-center">
-            <button className="rounded-[10px] py-2.5 px-6 bg-[#5EEAD4] dark:bg-primary text-white dark:text-primary-foreground text-sm font-medium hover:bg-[#4DD4C1] dark:hover:bg-primary/90 transition-colors">
-              Get Started
-            </button>
+            <Link href="/home">
+              <button className="rounded-[10px] py-2.5 px-6 bg-[#5EEAD4] dark:bg-primary text-white dark:text-primary-foreground text-sm font-medium hover:bg-[#4DD4C1] dark:hover:bg-primary/90 transition-colors">
+                Get Started
+              </button>
+            </Link>
+
             <button className="rounded-[10px] py-2.5 px-6 text-[#5EEAD4] dark:text-primary border-[1px] border-[#5EEAD4] dark:border-primary bg-white dark:bg-background text-sm font-medium hover:bg-[#F0FDFA] dark:hover:bg-primary/10 transition-colors">
               Read More
             </button>


### PR DESCRIPTION
# 📝 PR: Smooth Scroll for "Join the Community" Button + Get Started Link  

## 📌 Description  
- Added smooth scroll functionality to the **“Join the Community”** button in the Hero section.  
- Updated the **“Get Started”** button in Benefits section to navigate users to Home (`/home`).  

---

## 🎯 Motivation and Context  
This update improves navigation and user experience:  
- **Join the Community** now smoothly scrolls to the Community section (CTA consistency).  
- **Get Started** button correctly routes users to the Home page.  

---

## 🛠️ Changes Made  
- Implemented `scrollIntoView({ behavior: "smooth" })` for Hero CTA.  
- Replaced `Get Started` button with `Link` to `/home`.  

---

## ✅ Notes  
- Tested on both desktop and mobile.  
- Only affects navigation/UI, no backend changes.  

Closes #490  
