### PR TITLE
feat/ Implement Batch Greeting Updates

### DIFF
--- a/packages/soroban/contracts/greeting-system/src/batch.rs
+++ b/packages/soroban/contracts/greeting-system/src/batch.rs
@@ -1,0 +1,167 @@
+use soroban_sdk::{Env, Vec, Address, String};
+use alloc::string::ToString;
+use crate::Error;
+use crate::utils;
+use crate::storage;
+use crate::datatype::{BatchUpdate, Greeting, OperationStatus};
+use crate::events::{emit_batch_update, BatchUpdateEvent};
+
+/// Maximum batch size to prevent gas exhaustion (tune based on testing).
+const MAX_BATCH_SIZE: u32 = 100;
+
+/// Perform a batch update on multiple greetings.
+/// Restricted to authorized users (e.g., creators or admins).
+/// Emits events and stores audit record.
+pub fn batch_update_greetings(
+    env: &Env,
+    user: Address,
+    greeting_ids: Vec<u64>,
+    updates: Vec<String>,
+) -> Result<u64, Error> {
+    // Authorization: Reuse your utils for admin/creator check.
+    utils::verify_user_authorization(env, &user)?;
+
+    // Validate inputs.
+    validate_batch_inputs(&greeting_ids, &updates)?;
+
+    let batch_id = storage::next_batch_id(env);
+    let num_greetings = greeting_ids.len() as u32;
+
+    // Create pending batch record.
+    let mut batch = BatchUpdate {
+        batch_id,
+        greeting_ids: greeting_ids.clone(),
+        updates: updates.clone(),
+        status: OperationStatus::Pending,
+        processed_by: user.clone(),
+        processed_at: utils::get_current_timestamp(env),
+    };
+    storage::write_batch(env, &batch)?;
+
+    // Emit pending event.
+    emit_batch_update(env, &BatchUpdateEvent {
+        batch_id,
+        num_greetings,
+        status: OperationStatus::Pending,
+        processed_by: user.clone(),
+    })?;
+
+    // Process updates.
+    let mut success_count = 0u32;
+    let len = greeting_ids.len();
+    for i in 0..len {
+        let gid = greeting_ids.get(i).unwrap();  
+        let update = updates.get(i).unwrap().clone();  // Clone String
+
+        if let Err(e) = process_single_update(env, &user, gid, update) {
+            // On first failure, mark batch failed and emit.
+            batch.status = OperationStatus::Failed(
+                String::from_str(env, &e.to_string())
+            );
+            batch.processed_at = utils::get_current_timestamp(env); // Update timestamp.
+            storage::write_batch(env, &batch)?;
+            emit_batch_update(env, &BatchUpdateEvent {
+                batch_id,
+                num_greetings,
+                status: batch.status.clone(),
+                processed_by: user.clone(),
+            })?;
+            return Err(e); // Fail the tx.
+        }
+        success_count += 1;
+    }
+
+    // All good: mark completed.
+    batch.status = OperationStatus::Completed;
+    batch.processed_at = utils::get_current_timestamp(env);
+    storage::write_batch(env, &batch)?;
+
+    emit_batch_update(env, &BatchUpdateEvent {
+        batch_id,
+        num_greetings,
+        status: OperationStatus::Completed,
+        processed_by: user,
+    })?;
+
+    Ok(batch_id)
+}
+
+/// Get the status of a batch update (for auditing).
+pub fn get_batch_status(env: &Env, batch_id: u64) -> Result<BatchUpdate, Error> {
+    storage::read_batch(env, batch_id)
+}
+
+/// Create a new greeting (helper function—added to fix "not found")
+pub fn create_greeting(
+    env: &Env,
+    greeting_id: u64,
+    text: String,
+    creator: Address,
+) -> Result<(), Error> {
+    // Quick check if exists (to avoid overwrite)
+    if storage::read_greeting(env, greeting_id).is_ok() {
+        return Err(Error::TierAlreadyExists); // Proxy error; add GreetingExists if you wan
+    }
+
+    let timestamp = utils::get_current_timestamp(env);
+    let greeting = Greeting {
+        id: greeting_id,
+        text,
+        creator,
+        updated_at: timestamp,
+    };
+
+    storage::write_greeting(env, &greeting)
+}
+
+/// Internal: Validate batch inputs for safety.
+fn validate_batch_inputs(greeting_ids: &Vec<u64>, updates: &Vec<String>) -> Result<(), Error> {
+    if greeting_ids.len() > MAX_BATCH_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+    if greeting_ids.len() != updates.len() {
+        return Err(Error::InvalidUpdateLength);
+    }
+
+    // Manual duplicate check (since we can't use BTreeSet).
+    let len = greeting_ids.len();
+    for i in 0..len {
+        let gid_i = greeting_ids.get(i).unwrap();  // Fix: * for u64
+        for j in (i + 1)..len {
+            let gid_j = greeting_ids.get(j).unwrap();  // Fix: *
+            if gid_i == gid_j {
+                return Err(Error::DuplicateGreetingIds);
+            }
+        }
+    }
+
+    // Check for empty updates
+    for i in 0..updates.len() {
+        if updates.get(i).unwrap().is_empty() {
+            return Err(Error::EmptyUpdate);
+        }
+    }
+
+    Ok(())
+}
+
+/// Internal: Update a single greeting (assumes it exists and user is authorized).
+fn process_single_update(
+    env: &Env,
+    user: &Address,
+    id: u64,
+    new_text: String,
+) -> Result<(), Error> {
+    let mut greeting = storage::read_greeting(env, id).map_err(|_| Error::UnauthorizedGreeting)?;
+    
+    // Auth check: User must be creator (extend for admin).
+    if greeting.creator != *user {
+        return Err(Error::UnauthorizedGreeting);
+    }
+
+    // Apply update.
+    greeting.text = new_text;
+    greeting.updated_at = utils::get_current_timestamp(env);
+    storage::write_greeting(env, &greeting)
+        .map_err(|_| Error::StorageError)
+}

--- a/packages/soroban/contracts/greeting-system/src/datatype.rs
+++ b/packages/soroban/contracts/greeting-system/src/datatype.rs
@@ -53,8 +53,39 @@ pub struct TierAssignmentEvent {
     pub timestamp: u64,
 }
 
+/// Represents a single greeting.
+#[contracttype]
+#[derive(Clone)]
+pub struct Greeting {
+    pub id: u64,
+    pub text: soroban_sdk::String,
+    pub creator: Address,
+    pub updated_at: u64,
+}
+
+/// Status of a batch operation.
+#[contracttype]
+#[derive(Clone)]
+pub enum OperationStatus {
+    Pending,
+    Completed,
+    Failed(soroban_sdk::String), // Reason for failure
+}
+
+/// Batch update record for auditing.
+#[contracttype]
+#[derive(Clone)]
+pub struct BatchUpdate {
+    pub batch_id: u64,
+    pub greeting_ids: soroban_sdk::Vec<u64>,
+    pub updates: soroban_sdk::Vec<soroban_sdk::String>,
+    pub status: OperationStatus,
+    pub processed_by: Address,
+    pub processed_at: u64,
+}
+
 impl TierLevel {
-    /// Convert tier level to string representation
+    /// Convert tier level to soroban_sdk::String representation
     pub fn to_str(&self) -> &str {
         match self {
             TierLevel::None => "None",

--- a/packages/soroban/contracts/greeting-system/src/error.rs
+++ b/packages/soroban/contracts/greeting-system/src/error.rs
@@ -27,4 +27,50 @@ pub enum Error {
     
     /// User already has a tier assigned
     TierAlreadyExists = 8,
+
+    /// Batch size exceeds the maximum allowed limit
+    BatchTooLarge = 9,
+
+    /// Mismatch between number of greeting IDs and updates
+    InvalidUpdateLength = 10,
+
+    /// Greeting not found or user not authorized to update it
+    UnauthorizedGreeting = 11,
+
+    /// Batch ID already exists
+    BatchIdExists = 12,
+
+    /// Duplicate greeting IDs in batch
+    DuplicateGreetingIds = 13,
+
+    /// Empty update text in batch
+    EmptyUpdate = 14,
+
+    /// Batch not found
+    BatchNotFound = 15,
+}
+
+// Add Display impl for to_string() to work (required for String::from_str(&e.to_string()))
+use core::fmt; 
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidContribution => f.write_str("Invalid contribution amount (must be positive)"),
+            Error::TierNotFound => f.write_str("Tier not found for the user"),
+            Error::Unauthorized => f.write_str("Unauthorized access (only verified Stellar accounts)"),
+            Error::DowngradeNotAllowed => f.write_str("Tier downgrade not allowed"),
+            Error::StorageError => f.write_str("Storage error"),
+            Error::InvalidTierLevel => f.write_str("Invalid tier level"),
+            Error::ZeroContribution => f.write_str("Zero contribution not allowed"),
+            Error::TierAlreadyExists => f.write_str("User already has a tier assigned"),
+            Error::BatchTooLarge => f.write_str("Batch size exceeds the maximum allowed limit"),
+            Error::InvalidUpdateLength => f.write_str("Mismatch between number of greeting IDs and updates"),
+            Error::UnauthorizedGreeting => f.write_str("Greeting not found or user not authorized to update it"),
+            Error::BatchIdExists => f.write_str("Batch ID already exists"),
+            Error::DuplicateGreetingIds => f.write_str("Duplicate greeting IDs in batch"),
+            Error::EmptyUpdate => f.write_str("Empty update text in batch"),
+            Error::BatchNotFound => f.write_str("Batch not found"),
+        }
+    }
 }

--- a/packages/soroban/contracts/greeting-system/src/events.rs
+++ b/packages/soroban/contracts/greeting-system/src/events.rs
@@ -1,6 +1,7 @@
-use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
 
-use crate::{Error, TierAssignmentEvent, TierLevel, TierUpgradeEvent};
+use crate::error::Error;
+use crate::datatype::{TierAssignmentEvent, TierUpgradeEvent, TierLevel, OperationStatus};
 
 /// Event symbol for tier assignment
 pub const TIER_ASSIGNED: Symbol = symbol_short!("TIER_ASGN");
@@ -68,5 +69,25 @@ pub fn emit_tier_downgraded(
         ),
     );
     
+    Ok(())
+}
+
+/// Event for batch update initiation/completion.
+#[contracttype]
+#[derive(Clone)]
+pub struct BatchUpdateEvent {
+    pub batch_id: u64,
+    pub num_greetings: u32,
+    pub status: OperationStatus,
+    pub processed_by: Address,
+}
+
+/// Emit batch update event.
+pub fn emit_batch_update(env: &Env, event: &BatchUpdateEvent) -> Result<(), crate::Error> {
+    // Fix: Use two symbols for topics (no b""—change to symbol_short!)
+    env.events().publish(
+        (symbol_short!("batch_upd"), symbol_short!("update")),
+        event.clone(),
+    );
     Ok(())
 }

--- a/packages/soroban/contracts/greeting-system/src/storage.rs
+++ b/packages/soroban/contracts/greeting-system/src/storage.rs
@@ -1,12 +1,16 @@
 use soroban_sdk::{contracttype, Address, Env};
 
 use crate::{Error, PremiumTier};
+use crate::datatype::{Greeting, BatchUpdate};
 
-/// Storage keys for the premium tier system
+/// Storage keys for the premium tier system and greetings/batches
 #[contracttype]
 #[derive(Clone)]
 pub enum StorageKey {
     PremiumTier(Address),
+    Greeting(u64),
+    Batch(u64),
+    BatchCounter,
 }
 
 /// Save a premium tier to storage
@@ -36,4 +40,48 @@ pub fn remove_premium_tier(env: &Env, user: &Address) -> Result<(), Error> {
     let key = StorageKey::PremiumTier(user.clone());
     env.storage().persistent().remove(&key);
     Ok(())
+}
+
+/// Read a greeting from storage
+pub fn read_greeting(env: &Env, id: u64) -> Result<Greeting, Error> {
+    let key = StorageKey::Greeting(id);
+    env.storage()
+        .persistent()
+        .get(&key)
+        .ok_or(Error::UnauthorizedGreeting) // Map to a custom Error if needed, e.g., add NotFound variant
+}
+
+/// Write a greeting to storage
+pub fn write_greeting(env: &Env, greeting: &Greeting) -> Result<(), Error> {
+    let key = StorageKey::Greeting(greeting.id);
+    env.storage().persistent().set(&key, greeting);
+    Ok(())
+}
+
+/// Read a batch update record from storage
+pub fn read_batch(env: &Env, batch_id: u64) -> Result<BatchUpdate, Error> {
+    let key = StorageKey::Batch(batch_id);
+    env.storage()
+        .persistent()
+        .get(&key)
+        .ok_or(Error::BatchNotFound)
+}
+
+/// Write a batch update record to storage
+pub fn write_batch(env: &Env, batch: &BatchUpdate) -> Result<(), Error> {
+    let key = StorageKey::Batch(batch.batch_id);
+    env.storage().persistent().set(&key, batch);
+    Ok(())
+}
+
+/// Get the next available batch ID (auto-increments)
+pub fn next_batch_id(env: &Env) -> u64 {
+    let counter_key = StorageKey::BatchCounter;
+    let mut counter: u64 = env.storage()
+        .persistent()
+        .get(&counter_key)
+        .unwrap_or(0);
+    counter += 1;
+    env.storage().persistent().set(&counter_key, &counter);
+    counter
 }


### PR DESCRIPTION
Summary

This PR implements batch update functionality for the greeting-system contract. It enables updating multiple greetings in a single transaction, including auditing, events, and authorization checks to ensure security on the Stellar network. This eliminates the need for individual updates, significantly improving efficiency.
Closes #474

Key Changes

Core Batch Logic (batch.rs):

Added batch_update_greetings(env: Env, user: Address, greeting_ids: Vec<u64>, updates: Vec<String>) -> Result<u64, Error>: Processes updates for multiple greetings, emits events for pending/completed/failed states, and stores batch records. Restricted to authorized users (via utils::verify_user_authorization).
Added get_batch_status(env: Env, batch_id: u64) -> Result<BatchUpdate, Error>: Fetches full batch details for auditing.
Internal helpers: validate_batch_inputs (checks size, duplicates, empty updates), process_single_update (single greeting update with auth), and create_greeting (bonus helper for new greetings).
Gas-safe: Max batch size 100, auto-increment batch IDs via storage::next_batch_id.


Data Structures (datatype.rs – assumed additions):

BatchUpdate { batch_id, greeting_ids, updates, status: OperationStatus, processed_by, processed_at } – Full audit trail.
OperationStatus enum: Pending, Completed, Failed(String) for error details.


Events (events.rs):

New BatchUpdateEvent struct with #[contracttype].
emit_batch_update fn: Publishes on "batch_upd" topic with status updates.


Storage (storage.rs):

Added keys for Batch(u64) and BatchCounter.
Fns: read_batch, write_batch, next_batch_id – Optimized persistent storage.


Main Contract (lib.rs):

Exposed batch fns via #[contractimpl]: batch_update_greetings, get_batch_status, create_greeting.
Integrated premium tier checks (from existing) for future auth extensions.


Error Handling (error.rs):

New variants: BatchTooLarge, InvalidUpdateLength, DuplicateGreetingIds, EmptyUpdate, BatchNotFound.
Added Display impl for to_string() in failed events.


Utils (utils.rs – assumed):

Relies on existing verify_user_authorization, get_current_timestamp for auth/timestamps.