### PR TITLE
fix: center main feed layout and improve mobile responsiveness

### DIFF
--- a/packages/nextjs/src/app/[locale]/(learning-hub)/layout.tsx
+++ b/packages/nextjs/src/app/[locale]/(learning-hub)/layout.tsx
@@ -7,9 +7,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <SidebarProvider defaultOpen={true} className="flex flex-col min-h-screen">
       <Navbar />
-      <div className="flex flex-1 bg-background text-foreground">
+      <div className="flex flex-1 bg-background text-foreground relative">
         <LearningHubSidebar />
-        <main className="flex-1 mt-14 px-4 py-8 overflow-x-hidden">
+        <main className="flex-1 mt-14 px-4 py-8 overflow-x-hidden md:mr-0">
           <div className="w-full max-w-5xl mx-auto">{children}</div>
         </main>
         <RightSidebar />

--- a/packages/nextjs/src/app/[locale]/(learning-hub)/layout.tsx
+++ b/packages/nextjs/src/app/[locale]/(learning-hub)/layout.tsx
@@ -5,12 +5,12 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SidebarProvider defaultOpen={true}>
+    <SidebarProvider defaultOpen={true} className="flex flex-col min-h-screen">
       <Navbar />
-      <div className="grid grid-cols-[320px_1fr_256px] min-h-screen bg-background text-foreground">
+      <div className="flex flex-1 bg-background text-foreground">
         <LearningHubSidebar />
-        <main className="flex justify-center mt-14 px-4 py-8 pl-[4em]">
-          <div className="w-full max-w-5xl">{children}</div>
+        <main className="flex-1 mt-14 px-4 py-8 overflow-x-hidden">
+          <div className="w-full max-w-5xl mx-auto">{children}</div>
         </main>
         <RightSidebar />
       </div>

--- a/packages/nextjs/src/components/discovery/right-sidebar.tsx
+++ b/packages/nextjs/src/components/discovery/right-sidebar.tsx
@@ -125,8 +125,8 @@ export default function RightSidebar() {
 
   return (
     <aside
-      className={`fixed right-0 top-14 h-[calc(100vh-3.5rem)] bg-sidebar text-sidebar-foreground border-l border-sidebar-border shadow-lg transition-all duration-300 ease-in-out z-40 
-        ${isCollapsed ? 'w-16' : 'w-[280px] md:w-[280px] max-md:w-[90vw] max-md:max-w-[320px]'}
+      className={`sticky right-0 top-14 h-[calc(100vh-3.5rem)] bg-sidebar text-sidebar-foreground border-l border-sidebar-border shadow-lg transition-all duration-300 ease-in-out z-40 flex-shrink-0
+        ${isCollapsed ? 'w-16' : 'w-64'}
         transform md:translate-x-0
         ${isCollapsed ? 'translate-x-0 max-md:translate-x-full' : 'translate-x-0'}
       `}

--- a/packages/nextjs/src/components/discovery/right-sidebar.tsx
+++ b/packages/nextjs/src/components/discovery/right-sidebar.tsx
@@ -83,16 +83,23 @@ const mockTrending: TrendingItem[] = [
 ];
 
 export default function RightSidebar() {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(true);
   const [recommendations, setRecommendations] = useState<RecommendationItem[]>([]);
   const [trending, setTrending] = useState<TrendingItem[]>([]);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Load saved state from localStorage
-    const savedState = localStorage.getItem('rightSidebarState');
-    if (savedState) {
-      setIsCollapsed(JSON.parse(savedState));
+    // Check if desktop (>= 768px) and load saved state
+    const isDesktop = window.innerWidth >= 768;
+    if (isDesktop) {
+      const savedState = localStorage.getItem('rightSidebarState');
+      if (savedState) {
+        setIsCollapsed(JSON.parse(savedState));
+      } else {
+        setIsCollapsed(false); // Default expanded on desktop
+      }
+    } else {
+      setIsCollapsed(true); // Always collapsed on mobile
     }
 
     // Simulate API data fetch
@@ -101,12 +108,25 @@ export default function RightSidebar() {
       setTrending(mockTrending);
     };
     fetchData();
+
+    // Handle window resize
+    const handleResize = () => {
+      if (window.innerWidth < 768) {
+        setIsCollapsed(true);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   const toggleSidebar = () => {
     const newState = !isCollapsed;
     setIsCollapsed(newState);
-    localStorage.setItem('rightSidebarState', JSON.stringify(newState));
+    // Only save state on desktop
+    if (window.innerWidth >= 768) {
+      localStorage.setItem('rightSidebarState', JSON.stringify(newState));
+    }
   };
 
   const scrollToTab = (tab: 'recommendations' | 'trending') => {
@@ -124,31 +144,42 @@ export default function RightSidebar() {
   };
 
   return (
-    <aside
-      className={`sticky right-0 top-14 h-[calc(100vh-3.5rem)] bg-sidebar text-sidebar-foreground border-l border-sidebar-border shadow-lg transition-all duration-300 ease-in-out z-40 flex-shrink-0
-        ${isCollapsed ? 'w-16' : 'w-64'}
-        transform md:translate-x-0
-        ${isCollapsed ? 'translate-x-0 max-md:translate-x-full' : 'translate-x-0'}
-      `}
-    >
-      {/* Toggle Button */}
-      <Button
-        onClick={toggleSidebar}
-        variant="outline"
-        size="icon"
-        className="absolute -left-3 top-1/2 -translate-y-1/2 bg-sidebar rounded-full p-1.5 shadow-lg z-50 hover:bg-sidebar-accent transition-colors border-sidebar-border h-8 w-8"
-        aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+    <>
+      {/* Overlay for mobile */}
+      {!isCollapsed && (
+        <div
+          className="fixed inset-0 bg-black/50 z-30 md:hidden"
+          onClick={toggleSidebar}
+          aria-hidden="true"
+        />
+      )}
+
+      <aside
+        className={`fixed md:sticky right-0 top-14 h-[calc(100vh-3.5rem)] bg-sidebar text-sidebar-foreground border-l border-sidebar-border shadow-lg transition-all duration-300 ease-in-out z-40 flex-shrink-0
+          ${isCollapsed ? 'w-0 md:w-16' : 'w-full md:w-64'}
+          ${isCollapsed ? 'translate-x-full md:translate-x-0' : 'translate-x-0'}
+        `}
       >
-        {isCollapsed ? (
-          <ChevronLeft className="text-sidebar-foreground" size={16} />
-        ) : (
-          <ChevronRight className="text-sidebar-foreground" size={16} />
-        )}
-      </Button>
+        {/* Toggle Button - Fixed position on mobile */}
+        <Button
+          onClick={toggleSidebar}
+          variant="outline"
+          size="icon"
+          className={`absolute top-4 bg-sidebar rounded-full p-1.5 shadow-lg z-50 hover:bg-sidebar-accent transition-all border-sidebar-border h-10 w-10
+            ${isCollapsed ? 'fixed right-4 md:absolute md:-left-3 md:top-1/2 md:-translate-y-1/2' : 'right-4 md:-left-3 md:top-1/2 md:-translate-y-1/2'}
+          `}
+          aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          {isCollapsed ? (
+            <ChevronLeft className="text-sidebar-foreground" size={20} />
+          ) : (
+            <ChevronRight className="text-sidebar-foreground" size={20} />
+          )}
+        </Button>
 
       {isCollapsed ? (
-        // Collapsed State - Icon Navigation
-        <div className="h-full py-4">
+        // Collapsed State - Icon Navigation (hidden on mobile)
+        <div className="hidden md:block h-full py-4">
           <div className="flex justify-center mb-6">
             <div className="bg-primary rounded-[8px] h-8 w-8 flex items-center justify-center">
               <Compass className="w-5 h-5 text-white" />
@@ -185,9 +216,9 @@ export default function RightSidebar() {
         </div>
       ) : (
         // Expanded State - Full Content
-        <div className="h-full flex flex-col">
-          <div className="p-4 border-b border-sidebar-border">
-            <h2 className="text-lg font-semibold text-primary flex items-center gap-2">
+        <div className="h-full flex flex-col pt-16 md:pt-0">
+          <div className="p-4 md:p-4 border-b border-sidebar-border">
+            <h2 className="text-lg md:text-lg font-semibold text-primary flex items-center gap-2">
               <Compass className="w-5 h-5" />
               Discovery
             </h2>
@@ -195,16 +226,17 @@ export default function RightSidebar() {
 
           <div
             ref={contentRef}
-            className="flex-1 overflow-y-auto p-4 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+            className="flex-1 overflow-y-auto p-4 md:p-4 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
           >
             <Tabs defaultValue="recommendations" className="w-full">
               <TabsList className="grid w-full grid-cols-2 mb-4 bg-gray-200 dark:bg-gray-800 rounded-lg p-1">
-                <TabsTrigger value="recommendations" className="text-xs">
-                  <Sparkles className="w-4 h-4 mr-1" />
-                  For You
+                <TabsTrigger value="recommendations" className="text-xs md:text-xs">
+                  <Sparkles className="w-4 h-4 mr-1.5" />
+                  <span className="hidden sm:inline">For You</span>
+                  <span className="sm:hidden">You</span>
                 </TabsTrigger>
-                <TabsTrigger value="trending" className="text-xs">
-                  <Flame className="w-4 h-4 mr-1" />
+                <TabsTrigger value="trending" className="text-xs md:text-xs">
+                  <Flame className="w-4 h-4 mr-1.5" />
                   Trending
                 </TabsTrigger>
               </TabsList>
@@ -291,6 +323,7 @@ export default function RightSidebar() {
           </div>
         </div>
       )}
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/packages/nextjs/src/components/post/post.tsx
+++ b/packages/nextjs/src/components/post/post.tsx
@@ -153,28 +153,27 @@ export default function Post({ id, author, content, categories = [], modal }: Po
 
   return (
     <Card className="max-w-4xl w-full p-4">
-      <div className="flex flex-row justify-between items-center p-4">
-        <div className="flex gap-3">
-          <Avatar className="h-10 w-10">
+      <div className="flex flex-row justify-between items-center gap-3 p-4">
+        <div className="flex gap-3 min-w-0 flex-1">
+          <Avatar className="h-10 w-10 flex-shrink-0">
             <AvatarImage src={author.avatar} alt={author.name} />
             <AvatarFallback>{author.name[0]}</AvatarFallback>
           </Avatar>
-          <div className="flex flex-col">
-            <span className="font-semibold">{author.name}</span>
-            <span className="text-sm text-muted-foreground">@{author.username}</span>
+          <div className="flex flex-col min-w-0 flex-1">
+            <span className="font-semibold truncate">{author.name}</span>
+            <span className="text-sm text-muted-foreground truncate">@{author.username}</span>
           </div>
         </div>
 
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-shrink-0">
           {!isOpen && (
-            <Button variant="ghost" size="icon" className="ml-auto" onClick={modal}>
+            <Button variant="ghost" size="icon" onClick={modal}>
               <Eye className="h-4 w-4" />
             </Button>
           )}
           <Button
             variant="ghost"
             size="icon"
-            className="ml-auto"
             onClick={() => setReportDialogOpen(true)}
           >
             <Flag className="h-4 w-4" />


### PR DESCRIPTION
## 🛠️ Issue
Closes #501

## 📖 Description
This PR implements layout and responsiveness improvements for the learning hub main feed. The changes focus on fixing the layout centering issues and improving the mobile experience, particularly for the right sidebar (Discovery panel) and the main content area.

## ✅ Changes Made

### Layout Structure (`layout.tsx`)
- Changed from fixed `grid-cols-[320px_1fr_256px]` to flexible layout with `flex` and `flex-1`
- Added `min-h-screen` class to SidebarProvider for proper full-height layout
- Improved main content centering with `mx-auto` on the content wrapper
- Removed fixed left padding (`pl-[4em]`) for better responsive behavior
- Changed main content to use `flex-1` and added `overflow-x-hidden` for better mobile handling

### Right Sidebar (`right-sidebar.tsx`)
- Fixed initial state to be collapsed by default on mobile (`useState(true)`)
- Added desktop detection (>= 768px) to determine initial sidebar state
- Implemented window resize listener to auto-collapse sidebar on mobile viewports
- Changed from `fixed` positioning to `fixed md:sticky` for better mobile experience
- Added mobile overlay (backdrop) when sidebar is expanded on mobile devices
- Improved toggle button positioning: fixed on mobile, absolute on desktop
- Modified collapsed state to be hidden on mobile (`w-0 md:w-16`) instead of always visible
- Added proper translation classes for smooth slide-in/out animations
- Added responsive padding adjustments (`pt-16 md:pt-0`) for mobile header clearance
- Improved tab labels with responsive text ("For You" → "You" on small screens)
- Enhanced localStorage handling to only save state on desktop devices

### Post Component (`post.tsx`)
- Improved header layout with better flex properties and gap spacing
- Added `flex-shrink-0` to avatar to prevent compression
- Added `min-w-0` and `flex-1` to name/username container for proper text truncation
- Added `truncate` class to author name and username to prevent overflow
- Reorganized action buttons container with `flex-shrink-0` for consistent sizing
- Removed redundant `ml-auto` classes for cleaner code

## 🖼️ Media (screenshots/videos)

https://www.loom.com/share/b42acc9dc0d04df1a721ac5a4608bddc?sid=55aa53bf-8f34-4240-a992-eee110206a9a