### PR TITLE
feat: implement GET /resources/:id endpoint

### DIFF
--- a/packages/gin/api/resources.go
+++ b/packages/gin/api/resources.go
@@ -88,6 +88,33 @@ func ListResources(c *gin.Context) {
     common.JSONSuccess(c, http.StatusOK, resources, "Resources retrieved successfully")
 }
 
+// GetResourceByID retrieves a single resource by its ID
+func GetResourceByID(c *gin.Context) {
+    // Parse resource ID from path
+    idParam := c.Param("id")
+    if idParam == "" {
+        common.JSONError(c, http.StatusBadRequest, "invalid_input", "Resource ID is required")
+        return
+    }
+    
+    rid, err := strconv.ParseUint(idParam, 10, 64)
+    if err != nil {
+        common.JSONError(c, http.StatusBadRequest, "invalid_input", "Invalid resource ID")
+        return
+    }
+
+    db := config.GetDB()
+
+    var resource models.Resource
+    // Preload Creator relationship to include creator details
+    if err := db.Preload("Creator").First(&resource, rid).Error; err != nil {
+        common.JSONError(c, http.StatusNotFound, "not_found", "Resource not found")
+        return
+    }
+
+    common.JSONSuccess(c, http.StatusOK, resource, "Resource retrieved successfully")
+}
+
 // ResourceUpdateRequest defines fields allowed for resource updates (all optional)
 type ResourceUpdateRequest struct {
     Title    *string `json:"title"`

--- a/packages/gin/main.go
+++ b/packages/gin/main.go
@@ -39,9 +39,10 @@ func main() {
 		protected.GET("/users/:id", api.GetUserByID)
 		protected.POST("/users", api.CreateUser)
 
-		// Resource endpoints (educator-only)
+		// Resource endpoints
 		protected.POST("/resources", middleware.RequireRole("Educator"), api.CreateResource)
 		protected.GET("/resources", api.ListResources)
+		protected.GET("/resources/:id", api.GetResourceByID)
 		protected.PUT("/resources/:id", middleware.RequireRole("Educator"), api.UpdateResource)
 
 		// Current user endpoint


### PR DESCRIPTION
- Added GetResourceByID handler to retrieve single resource by ID
- Returns HTTP 200 with resource JSON when found
- Returns HTTP 404 with error message when not found
- Preloads Creator relationship for complete resource data
- Validates ID parameter and handles invalid formats
- Follows existing error handling patterns using common.JSONError/JSONSuccess

closes #498