### PR TITLE
fix: improve dark mode contrast and hover effects in community section

### DIFF
--- a/packages/nextjs/src/components/landing/CommunitySection.tsx
+++ b/packages/nextjs/src/components/landing/CommunitySection.tsx
@@ -53,10 +53,10 @@ export default function CommunitySection() {
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
-          
+
           communityLinks.forEach((link, index) => {
             setTimeout(() => {
-              setAnimatedItems(prev => new Set([...prev, link.id]));
+              setAnimatedItems((prev) => new Set([...prev, link.id]));
             }, link.delay + 600);
           });
         }
@@ -72,29 +72,32 @@ export default function CommunitySection() {
   }, []);
 
   return (
-    <section ref={sectionRef} className="py-16 px-4 bg-[#F5F7F8] overflow-hidden">
+    <section
+      ref={sectionRef}
+      className="py-16 px-4 bg-[#F5F7F8] overflow-hidden dark:bg-background"
+    >
       <div className="max-w-6xl mx-auto text-center">
-        <div className={`mb-12 transition-all duration-1000 ${
-          isVisible 
-            ? 'opacity-100 translate-y-0' 
-            : 'opacity-0 translate-y-8'
-        }`}>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+        <div
+          className={`mb-12 transition-all duration-1000 ${
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+          }`}
+        >
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4 dark:text-foreground">
             Join the{' '}
-            <span className={`text-primary inline-block transition-all duration-700 delay-300 ${
-              isVisible 
-                ? 'opacity-100 scale-100' 
-                : 'opacity-0 scale-95'
-            }`}>
+            <span
+              className={`text-primary inline-block transition-all duration-700 delay-300 ${
+                isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+              }`}
+            >
               Akkuea
             </span>{' '}
             Community
           </h2>
-          <p className={`text-gray-600 text-lg max-w-2xl mx-auto leading-relaxed transition-all duration-800 delay-500 ${
-            isVisible 
-              ? 'opacity-100 translate-y-0' 
-              : 'opacity-0 translate-y-4'
-          }`}>
+          <p
+            className={`text-gray-600 text-lg max-w-2xl dark:text-muted mx-auto leading-relaxed transition-all duration-800 delay-500 ${
+              isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+            }`}
+          >
             Akkuea is more than a platform — {"it's"} a movement. Connect with us, share ideas, and
             help us shape the future of decentralized education.
           </p>
@@ -109,28 +112,28 @@ export default function CommunitySection() {
               rel="noopener noreferrer"
               className={`
                 bg-white rounded-2xl py-12 px-2 cursor-pointer group
-                transition-all duration-700 ease-out
+                transition-all duration-700 ease-out dark:bg-card
                 hover:shadow-2xl hover:scale-105 hover:-translate-y-2
-                ${animatedItems.has(platform.id) 
-                  ? 'opacity-100 translate-y-0 scale-100' 
-                  : 'opacity-0 translate-y-12 scale-95'
+                ${
+                  animatedItems.has(platform.id)
+                    ? 'opacity-100 translate-y-0 scale-100'
+                    : 'opacity-0 translate-y-12 scale-95'
                 }
               `}
-              style={{ 
-                transitionDelay: animatedItems.has(platform.id) ? '0ms' : `${platform.delay}ms` 
+              style={{
+                transitionDelay: animatedItems.has(platform.id) ? '0ms' : `${platform.delay}ms`,
               }}
             >
               <div className="flex justify-center mb-6">
-                <div className={`
+                <div
+                  className={`
                   p-3 bg-[#F0FDFA] rounded-full shadow-sm 
                   transition-all duration-500 ease-out
                   group-hover:shadow-xl group-hover:bg-primary/5 
                   group-hover:scale-110 group-hover:rotate-6
-                  ${animatedItems.has(platform.id) 
-                    ? 'animate-bounce-subtle' 
-                    : ''
-                  }
-                `}>
+                  ${animatedItems.has(platform.id) ? 'animate-bounce-subtle' : ''}
+                `}
+                >
                   <div className="transition-transform duration-300 group-hover:scale-110">
                     {platform.icon}
                   </div>
@@ -138,32 +141,41 @@ export default function CommunitySection() {
               </div>
 
               <div className="space-y-3">
-                <h3 className={`
+                <h3
+                  className={`
                   text-xl font-semibold text-gray-900 
                   transition-all duration-500 delay-100
                   group-hover:text-primary group-hover:scale-105
-                  ${animatedItems.has(platform.id) 
-                    ? 'opacity-100 translate-y-0' 
-                    : 'opacity-0 translate-y-4'
+                  dark:text-foreground
+                  ${
+                    animatedItems.has(platform.id)
+                      ? 'opacity-100 translate-y-0'
+                      : 'opacity-0 translate-y-4'
                   }
-                `}>
+                `}
+                >
                   {platform.title}
                 </h3>
-                <p className={`
+                <p
+                  className={`
                   text-gray-600 text-sm leading-relaxed
                   transition-all duration-500 delay-200
                   group-hover:text-gray-700
-                  ${animatedItems.has(platform.id) 
-                    ? 'opacity-100 translate-y-0' 
-                    : 'opacity-0 translate-y-4'
+                  dark:group-hover:text-muted
+                  dark:text-muted
+                  ${
+                    animatedItems.has(platform.id)
+                      ? 'opacity-100 translate-y-0'
+                      : 'opacity-0 translate-y-4'
                   }
-                `}>
+                `}
+                >
                   {platform.description}
                 </p>
               </div>
 
               <div className="absolute inset-0 bg-gradient-to-br from-primary/0 to-primary/0 rounded-2xl transition-all duration-500 group-hover:from-primary/5 group-hover:to-transparent opacity-0 group-hover:opacity-100" />
-              
+
               <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-primary/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-sm" />
             </a>
           ))}
@@ -174,28 +186,43 @@ export default function CommunitySection() {
 
       <style jsx>{`
         @keyframes bounce-subtle {
-          0%, 100% { transform: translateY(0); }
-          50% { transform: translateY(-2px); }
+          0%,
+          100% {
+            transform: translateY(0);
+          }
+          50% {
+            transform: translateY(-2px);
+          }
         }
-        
+
         @keyframes float-slow {
-          0%, 100% { transform: translateY(0px) rotate(0deg); }
-          50% { transform: translateY(-10px) rotate(5deg); }
+          0%,
+          100% {
+            transform: translateY(0px) rotate(0deg);
+          }
+          50% {
+            transform: translateY(-10px) rotate(5deg);
+          }
         }
-        
+
         @keyframes float-slow-reverse {
-          0%, 100% { transform: translateY(0px) rotate(0deg); }
-          50% { transform: translateY(10px) rotate(-5deg); }
+          0%,
+          100% {
+            transform: translateY(0px) rotate(0deg);
+          }
+          50% {
+            transform: translateY(10px) rotate(-5deg);
+          }
         }
-        
+
         .animate-bounce-subtle {
           animation: bounce-subtle 2s infinite;
         }
-        
+
         .animate-float-slow {
           animation: float-slow 6s ease-in-out infinite;
         }
-        
+
         .animate-float-slow-reverse {
           animation: float-slow-reverse 8s ease-in-out infinite;
         }


### PR DESCRIPTION
This PR fixes Issue #485 (Improve Contrast in Landing Page Community Section – Dark Theme).

✨ What’s Changed

- Added dark mode tokens (dark:bg-card, dark:text-foreground, dark:text-muted)

- Improved contrast and readability for card text and icons including animated cards

- Kept the colors and styling consistent with existing sections (“We Are Akkuea”, “Benefits of Akkuea”)

✅ Tested

- Dark mode readability improved

- Light mode unchanged

- Animations and transitions working smoothly

- Matches Akkuea’s design system

---

<img width="1099" height="548" alt="Screenshot 2025-10-05 at 1 39 58 PM" src="https://github.com/user-attachments/assets/523bc884-3387-4477-90c3-5caacbb68ecb" />

Let me know if any changes are needed!
 
 