### PR TITLE
Fix: [docs] Document the Educational Design Principles

### DIFF
--- a/docs/design/visual-identity.md
+++ b/docs/design/visual-identity.md
@@ -34,7 +34,28 @@ Issue 535
 
 ---
 
-Issue 536
+### Educational Design Principles
+
+#### Cultural Sensitivity in Design
+```mermaid
+mindmap
+  root)Cultural Design Principles(
+    Respectful Representation
+      Authentic Colors
+      Traditional Patterns
+      Community Input
+    Inclusive Access
+      High Contrast
+      Clear Typography
+      Universal Symbols
+    Educational Context
+      Learning Hierarchy
+      Progressive Disclosure
+      Cognitive Load Management
+    Technology Integration
+      Modern Interface
+      Traditional Wisdom
+      Balanced Approach```
 
 ---
 


### PR DESCRIPTION
Added the Educational Design Principles documentation to the visual-identity.md file in the design/visual-design folder. Successfully followed Contributing guidelines and ensured no conflicts.

Closes #536