### PR TITLE
feat: implement AdminControl module with transfer & tests

### DIFF
--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/admin.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/admin.rs
@@ -19,7 +19,7 @@ impl AdminControl {
         }
 
         env.storage().instance().set(&RoleKey::Admin, admin);
-        RoleStorage::grant_role(env, admin, &Role::ADMIN);
+        RoleStorage::grant_role(env, admin, &Role::Admin);
     }
 
     pub fn is_initialized(env: &Env) -> bool {
@@ -57,11 +57,11 @@ impl AdminControl {
             Some(pending_admin) => {
                 if pending_admin == new_admin.clone() {
                     if let Some(old_admin) = Self::get_admin(env) {
-                        RoleStorage::revoke_role(env, &old_admin, &Role::ADMIN);
+                        RoleStorage::revoke_role(env, &old_admin, &Role::Admin);
                     }
 
                     env.storage().instance().set(&RoleKey::Admin, new_admin);
-                    RoleStorage::grant_role(env, new_admin, &Role::ADMIN);
+                    RoleStorage::grant_role(env, new_admin, &Role::Admin);
                     env.storage().instance().remove(&RoleKey::PendingAdmin);
                 }
             }
@@ -91,7 +91,7 @@ impl PauseControl {
 
     pub fn can_pause(env: &Env, address: &Address) -> bool {
         let is_admin = AdminControl::is_admin(env, address);
-        let is_pauser = RoleStorage::has_role(env, address, &Role::PAUSER);
+        let is_pauser = RoleStorage::has_role(env, address, &Role::Pauser);
 
         is_admin || is_pauser
     }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/admin.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/admin.rs
@@ -1,0 +1,121 @@
+use soroban_sdk::{Address, Env};
+
+use crate::access::{roles::{RoleKey, RoleStorage, Role}};
+
+#[derive(Debug)]
+pub enum AdminError {
+    NotAdmin,
+    NotPendingAdmin,
+    AlreadyInitialized,
+    ZeroAddress
+}
+
+pub struct AdminControl;
+
+impl AdminControl {
+    pub fn initialize(env: &Env, admin: &Address) {
+        if Self::is_initialized(env) {
+            panic!("Admin already initialized")
+        }
+
+        env.storage().instance().set(&RoleKey::Admin, admin);
+        RoleStorage::grant_role(env, admin, &Role::ADMIN);
+    }
+
+    pub fn is_initialized(env: &Env) -> bool {
+        env.storage().instance().has(&RoleKey::Admin)
+    }
+
+    pub fn get_admin(env: &Env) -> Option<Address> {
+        env.storage().instance().get(&RoleKey::Admin)
+    }
+
+    pub fn is_admin(env: &Env, address: &Address) -> bool {
+        match Self::get_admin(env) {
+            Some(admin) => admin == address.clone(),
+            None => false
+        }
+    }
+
+    pub fn require_admin(env: &Env, caller: &Address) {
+        if !Self::is_admin(env, caller) {
+            panic!("Caller not admin")
+        }
+    }
+
+    pub fn transfer_admin_start(env: &Env, caller: &Address, new_admin: &Address) {
+        Self::require_admin(env, caller);
+        env.storage().instance().set(&RoleKey::PendingAdmin, new_admin);
+    }
+
+    pub fn transfer_admin_accept(env: &Env, new_admin: &Address) {
+        let pending: Option<Address> = env.storage().instance().get(&RoleKey::PendingAdmin);
+
+        match pending {
+            Some(pending_admin) => if pending_admin == new_admin.clone() {
+                if let Some(old_admin) = Self::get_admin(env) {
+                    RoleStorage::revoke_role(env, &old_admin, &Role::ADMIN);
+                }
+
+                env.storage().instance().set(&RoleKey::Admin, new_admin);
+                RoleStorage::grant_role(env, new_admin, &Role::ADMIN);
+                env.storage().instance().remove(&RoleKey::PendingAdmin);
+            },
+            _ => panic!("Caller is not pending admin"),
+        }
+    }
+
+    pub fn transfer_admin_cancel(env: &Env, caller: &Address) {
+        Self::require_admin(env, caller);
+        env.storage().instance().remove(&RoleKey::PendingAdmin);
+    }
+
+    pub fn get_pending_admin(env: &Env) -> Option<Address> {
+        env.storage().instance().get(&RoleKey::PendingAdmin)
+    }
+}
+
+pub struct PauseControl;
+
+impl PauseControl {
+    pub fn is_paused(env: &Env) -> bool {
+        env.storage().instance().get(&RoleKey::Paused).unwrap_or(false)
+    }
+
+    pub fn can_pause(env: &Env, address: &Address) -> bool {
+        let is_admin = AdminControl::is_admin(env, address);
+        let is_pauser = RoleStorage::has_role(env, address, &Role::PAUSER);
+
+        is_admin || is_pauser
+    }
+
+    pub fn require_can_pause(env: &Env, address: &Address) {
+        let can_pause = Self::can_pause(env, address);
+        if !can_pause {
+            panic!("Caller does not have permission to pause")
+        }
+    }
+
+    pub fn pause(env: &Env, caller: &Address) {
+        Self::require_can_pause(env, caller);
+        env.storage().instance().set(&RoleKey::Paused, &true);
+    }
+
+    pub fn unpause(env: &Env, caller: &Address) {
+        Self::require_can_pause(env, caller);
+        env.storage().instance().remove(&RoleKey::Paused);
+    }
+
+    pub fn require_paused(env: &Env) {
+        if !Self::is_paused(env) {
+            panic!("Contract not paused")
+        }
+    }
+
+    pub fn require_not_paused(env: &Env) {
+        if Self::is_paused(env) {
+            panic!("Contract paused")
+        }
+    }
+
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/mod.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/mod.rs
@@ -1,0 +1,31 @@
+pub mod roles;
+pub mod admin;
+
+pub use admin::{AdminControl, PauseControl};
+pub use roles::{RoleStorage, Role};
+
+use soroban_sdk::{Env, Address};
+
+pub fn require_role(env: &Env, caller: &Address, role: &Role) {
+    if !RoleStorage::has_role(env, caller, role) {
+        panic!("Caller does not have required role");
+    }
+}
+
+pub fn required_admin_or_role(env: &Env, caller: &Address, role: &Role) {
+    let is_admin = RoleStorage::has_role(env, caller, role);
+    let has_role = RoleStorage::has_role(env, caller, role);
+
+    if !is_admin || !has_role {
+        panic!("Caller is not authorized")
+    }
+}
+
+pub fn require_active_and_authorized(env: &Env, address: &Address, role: Option<&Role>) {
+    PauseControl::require_not_paused(env);
+
+    match role {
+        Some(r) => required_admin_or_role(env, address, r),
+        _ => AdminControl::require_admin(env, address),
+    }
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/mod.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/mod.rs
@@ -1,10 +1,10 @@
-pub mod roles;
 pub mod admin;
+pub mod roles;
 
 pub use admin::{AdminControl, PauseControl};
-pub use roles::{RoleStorage, Role};
+pub use roles::{Role, RoleStorage};
 
-use soroban_sdk::{Env, Address};
+use soroban_sdk::{Address, Env};
 
 pub fn require_role(env: &Env, caller: &Address, role: &Role) {
     if !RoleStorage::has_role(env, caller, role) {

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/roles.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/roles.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Env, Vec, Address, contracttype};
+use soroban_sdk::{contracttype, Address, Env, Vec};
 
 #[derive(Debug, PartialEq, Clone)]
 #[contracttype]
@@ -12,7 +12,7 @@ pub enum Role {
     // Right to verify property
     VERIFIER,
     // Right to execute liquidations
-    LIQUIDATOR
+    LIQUIDATOR,
 }
 
 #[derive(Clone)]
@@ -22,7 +22,7 @@ pub enum RoleKey {
     Paused,
     HasRole(Address, Role),
     RoleMembers(Role),
-    PendingAdmin
+    PendingAdmin,
 }
 
 pub struct RoleStorage;
@@ -38,7 +38,11 @@ impl RoleStorage {
         env.storage().instance().set(&key, &true);
 
         let members_key = RoleKey::RoleMembers(role.clone());
-        let mut members: Vec<Address> = env.storage().instance().get(&members_key).unwrap_or(Vec::new(env));
+        let mut members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&members_key)
+            .unwrap_or(Vec::new(env));
 
         let mut exists = false;
         for i in 0..members.len() {
@@ -78,5 +82,4 @@ impl RoleStorage {
         let key = RoleKey::RoleMembers(role.clone());
         env.storage().instance().get(&key).unwrap_or(Vec::new(env))
     }
-
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/roles.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/roles.rs
@@ -4,15 +4,15 @@ use soroban_sdk::{contracttype, Address, Env, Vec};
 #[contracttype]
 pub enum Role {
     // Full administrative privileges
-    ADMIN,
+    Admin,
     // Right to Pause/Resume Contracts
-    PAUSER,
+    Pauser,
     // Right to update oracle prices
-    ORACLE,
+    Oracle,
     // Right to verify property
-    VERIFIER,
+    Verifier,
     // Right to execute liquidations
-    LIQUIDATOR,
+    Liquidator,
 }
 
 #[derive(Clone)]

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/roles.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/access/roles.rs
@@ -1,0 +1,82 @@
+use soroban_sdk::{Env, Vec, Address, contracttype};
+
+#[derive(Debug, PartialEq, Clone)]
+#[contracttype]
+pub enum Role {
+    // Full administrative privileges
+    ADMIN,
+    // Right to Pause/Resume Contracts
+    PAUSER,
+    // Right to update oracle prices
+    ORACLE,
+    // Right to verify property
+    VERIFIER,
+    // Right to execute liquidations
+    LIQUIDATOR
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum RoleKey {
+    Admin,
+    Paused,
+    HasRole(Address, Role),
+    RoleMembers(Role),
+    PendingAdmin
+}
+
+pub struct RoleStorage;
+
+impl RoleStorage {
+    pub fn has_role(env: &Env, address: &Address, role: &Role) -> bool {
+        let key = RoleKey::HasRole(address.clone(), role.clone());
+        env.storage().instance().get(&key).unwrap_or(false)
+    }
+
+    pub fn grant_role(env: &Env, address: &Address, role: &Role) {
+        let key = RoleKey::HasRole(address.clone(), role.clone());
+        env.storage().instance().set(&key, &true);
+
+        let members_key = RoleKey::RoleMembers(role.clone());
+        let mut members: Vec<Address> = env.storage().instance().get(&members_key).unwrap_or(Vec::new(env));
+
+        let mut exists = false;
+        for i in 0..members.len() {
+            if members.get(i).unwrap() == address.clone() {
+                exists = true;
+                break;
+            }
+        }
+        if !exists {
+            members.push_back(address.clone());
+            env.storage().instance().set(&members_key, &members);
+        }
+    }
+
+    pub fn revoke_role(env: &Env, address: &Address, role: &Role) {
+        let key = RoleKey::HasRole(address.clone(), role.clone());
+        env.storage().instance().remove(&key);
+
+        let members_key = RoleKey::RoleMembers(role.clone());
+        if let Some(members) = env
+            .storage()
+            .instance()
+            .get::<RoleKey, Vec<Address>>(&members_key)
+        {
+            let mut new_members: Vec<Address> = Vec::new(env);
+            for i in 0..members.len() {
+                let member = members.get(i).unwrap();
+                if member != address.clone() {
+                    new_members.push_back(member);
+                }
+            }
+            env.storage().instance().set(&members_key, &new_members);
+        }
+    }
+
+    pub fn get_role_members(env: &Env, role: &Role) -> Vec<Address> {
+        let key = RoleKey::RoleMembers(role.clone());
+        env.storage().instance().get(&key).unwrap_or(Vec::new(env))
+    }
+
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -4,6 +4,7 @@ mod access;
 mod lending;
 
 pub use lending::*;
+pub use access::*;
 
 #[cfg(test)]
 mod test;

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -4,10 +4,13 @@
 //! This contract enables tokenization of real-world properties on the Stellar/Soroban blockchain.
 //! It provides functionality for property registration, share management, and ownership tracking.
 
-use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+use soroban_sdk::{Address, Env, String, Vec, contract, contractimpl, vec};
 
 mod storage;
 mod test;
+mod access;
+
+pub use access::*;
 
 #[contract]
 pub struct PropertyTokenContract;
@@ -17,5 +20,29 @@ impl PropertyTokenContract {
     /// Placeholder function - will be replaced with actual contract logic
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
+    }
+
+    pub fn initialize(env: Env, admin: Address) {
+        AdminControl::initialize(&env, &admin);
+    }
+
+    pub fn verify_property(env: Env, caller: Address, property_id: String) {
+        caller.require_auth();
+        PauseControl::require_not_paused(&env);
+        require_role(&env, &caller, &Role::VERIFIER);
+
+        // Verification logic
+        // Verify property by the property id
+    }
+
+    pub fn pause(env: Env, caller: Address) {
+        caller.require_auth();
+        PauseControl::pause(&env, &caller);
+    }
+
+    pub fn grant_role(env: Env, caller: Address, account: Address, role: Role) {
+        caller.require_auth();
+        AdminControl::require_admin(&env, &caller);
+        RoleStorage::grant_role(&env, &account, &role);
     }
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -3,8 +3,8 @@
 mod access;
 mod lending;
 
-pub use lending::*;
 pub use access::*;
+pub use lending::*;
 
 #[cfg(test)]
 mod test;

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-mod lending;
 mod access;
+mod lending;
 
 pub use lending::*;
 

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod lending;
+mod access;
 
 pub use lending::*;
 

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -1,8 +1,14 @@
 #![cfg(test)]
 
-use soroban_sdk::{vec, Env, String};
+use soroban_sdk::{Address, Env, String, vec};
+use soroban_sdk::testutils::Address as AddressTrait;
 
-use super::{PropertyTokenContract, PropertyTokenContractClient};
+use super::{PropertyTokenContract, PropertyTokenContractClient, PauseControl, AdminControl};
+
+fn setup() -> (Address, Env) {
+    let env = Env::default();
+    (env.register(PropertyTokenContract, ()), env)
+}
 
 #[test]
 fn test() {
@@ -19,4 +25,62 @@ fn test() {
             String::from_str(&env, "Dev"),
         ]
     );
+}
+
+#[test]
+fn test_admin_initialization() {
+
+}
+
+#[test]
+#[should_panic(expected = "Caller not admin")]
+fn test_require_admin_fails() {
+    let (contract_id, env) = setup();
+    // let client = PropertyTokenContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    // AdminControl::initialize(&env.as_contract(&contract_id, f), &admin);
+    env.as_contract(&contract_id, || {
+        AdminControl::require_admin(&env, &admin);
+        AdminControl::require_admin(&env, &other);
+    });
+}
+
+#[test]
+fn test_admin_transfer() {
+    let (contract_id, env) = setup();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AdminControl::initialize(&env, &admin);
+        // Start transfer
+        AdminControl::transfer_admin_start(&env, &admin, &new_admin);
+        assert_eq!(AdminControl::get_pending_admin(&env), Some(new_admin.clone()));
+        
+        // Accept transfer
+        AdminControl::transfer_admin_accept(&env, &new_admin);
+        assert!(AdminControl::is_admin(&env, &new_admin));
+        assert!(!AdminControl::is_admin(&env, &admin));
+    });
+
+
+}
+
+#[test]
+fn test_pause_unpause() {
+    let (contract_id, env) = setup();
+    let admin = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AdminControl::initialize(&env, &admin);
+        assert!(!PauseControl::is_paused(&env));
+
+        PauseControl::pause(&env, &admin);
+        assert!(PauseControl::is_paused(&env));
+    
+        PauseControl::unpause(&env, &admin);
+        assert!(!PauseControl::is_paused(&env));
+    });
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -1,6 +1,6 @@
+use super::access::{AdminControl, PauseControl};
 use super::*;
 use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env, String};
-use super::access::{AdminControl, PauseControl};
 
 // Created this contract just for testing storage
 #[contract]
@@ -17,7 +17,6 @@ fn setup() -> (Address, Env) {
     let env = Env::default();
     (env.register(TestContract, ()), env)
 }
-
 
 // Store and retrieve LendingPool
 
@@ -412,8 +411,8 @@ fn test_multiple_pools_storage() {
     assert!(user_deposits.contains(&pool_id_2));
 }
 
-#[test] 
-fn test_admin_initialization() { 
+#[test]
+fn test_admin_initialization() {
     let (contract_id, env) = setup();
     let admin = Address::generate(&env);
     env.as_contract(&contract_id, || {
@@ -423,48 +422,51 @@ fn test_admin_initialization() {
     })
 }
 
-#[test] 
-#[should_panic(expected = "Caller not admin")] 
-fn test_require_admin_fails() { 
-    let (contract_id, env) = setup();  
-    let admin = Address::generate(&env); 
-    let other = Address::generate(&env); 
-    // AdminControl::initialize(&env.as_contract(&contract_id, f), &admin); 
-    env.as_contract(&contract_id, || { 
-        AdminControl::require_admin(&env, &admin); 
-        AdminControl::require_admin(&env, &other); 
-    }); 
-}
-
-#[test] 
-fn test_admin_transfer() { 
-    let (contract_id, env) = setup(); 
-    let admin = Address::generate(&env); 
-    let new_admin = Address::generate(&env); 
-    env.as_contract(&contract_id, || { 
-        AdminControl::initialize(&env, &admin); 
-        
-        // Start transfer 
-        AdminControl::transfer_admin_start(&env, &admin, &new_admin); 
-        assert_eq!(AdminControl::get_pending_admin(&env), Some(new_admin.clone())); 
-        
-        // Accept transfer 
-        AdminControl::transfer_admin_accept(&env, &new_admin); 
-        assert!(AdminControl::is_admin(&env, &new_admin)); 
-        assert!(!AdminControl::is_admin(&env, &admin)); 
-    }); 
-}
-
-#[test] 
-fn test_pause_unpause() { 
-    let (contract_id, env) = setup(); 
-    let admin = Address::generate(&env); 
+#[test]
+#[should_panic(expected = "Caller not admin")]
+fn test_require_admin_fails() {
+    let (contract_id, env) = setup();
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+    // AdminControl::initialize(&env.as_contract(&contract_id, f), &admin);
     env.as_contract(&contract_id, || {
-        AdminControl::initialize(&env, &admin); 
-        assert!(!PauseControl::is_paused(&env)); 
-        PauseControl::pause(&env, &admin); 
-        assert!(PauseControl::is_paused(&env)); 
-        PauseControl::unpause(&env, &admin); 
-        assert!(!PauseControl::is_paused(&env)); 
-    }); 
+        AdminControl::require_admin(&env, &admin);
+        AdminControl::require_admin(&env, &other);
+    });
+}
+
+#[test]
+fn test_admin_transfer() {
+    let (contract_id, env) = setup();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        AdminControl::initialize(&env, &admin);
+
+        // Start transfer
+        AdminControl::transfer_admin_start(&env, &admin, &new_admin);
+        assert_eq!(
+            AdminControl::get_pending_admin(&env),
+            Some(new_admin.clone())
+        );
+
+        // Accept transfer
+        AdminControl::transfer_admin_accept(&env, &new_admin);
+        assert!(AdminControl::is_admin(&env, &new_admin));
+        assert!(!AdminControl::is_admin(&env, &admin));
+    });
+}
+
+#[test]
+fn test_pause_unpause() {
+    let (contract_id, env) = setup();
+    let admin = Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        AdminControl::initialize(&env, &admin);
+        assert!(!PauseControl::is_paused(&env));
+        PauseControl::pause(&env, &admin);
+        assert!(PauseControl::is_paused(&env));
+        PauseControl::unpause(&env, &admin);
+        assert!(!PauseControl::is_paused(&env));
+    });
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_initialization.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_initialization.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "HasRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "ADMIN"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "ADMIN"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_initialization.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_initialization.1.json
@@ -65,7 +65,7 @@
                             {
                               "vec": [
                                 {
-                                  "symbol": "ADMIN"
+                                  "symbol": "Admin"
                                 }
                               ]
                             }
@@ -84,7 +84,7 @@
                             {
                               "vec": [
                                 {
-                                  "symbol": "ADMIN"
+                                  "symbol": "Admin"
                                 }
                               ]
                             }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_transfer.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_transfer.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "HasRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "ADMIN"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "ADMIN"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_transfer.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_admin_transfer.1.json
@@ -65,7 +65,7 @@
                             {
                               "vec": [
                                 {
-                                  "symbol": "ADMIN"
+                                  "symbol": "Admin"
                                 }
                               ]
                             }
@@ -84,7 +84,7 @@
                             {
                               "vec": [
                                 {
-                                  "symbol": "ADMIN"
+                                  "symbol": "Admin"
                                 }
                               ]
                             }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_pause_unpause.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_pause_unpause.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "HasRole"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "ADMIN"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "symbol": "ADMIN"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_pause_unpause.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_pause_unpause.1.json
@@ -65,7 +65,7 @@
                             {
                               "vec": [
                                 {
-                                  "symbol": "ADMIN"
+                                  "symbol": "Admin"
                                 }
                               ]
                             }
@@ -84,7 +84,7 @@
                             {
                               "vec": [
                                 {
-                                  "symbol": "ADMIN"
+                                  "symbol": "Admin"
                                 }
                               ]
                             }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_pause_unpause.2.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_pause_unpause.2.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_require_admin_fails.1.json
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/test_snapshots/test/test_require_admin_fails.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
This PR implements an Admin Access Control module for the Soroban contract set. It provides:
- Admin initialization (initialize)
- Admin assertion helper (require_admin)
- Admin query (is_admin)
- Admin transfer flow (transfer_admin_start, get_pending_admin, transfer_admin_accept)
- Pause and Unpause module flows
- Role and Role storage module flows including access-based granting and revoking
- Unit tests covering initialization, require_admin panic, admin transfer start & accept, and pause/unpause integration.

This resolves issue #656 (Implement admin access control module).

Implementation notes:
- Uses Soroban `Env` and storage singletons to persist `admin` and `pending_admin`.
- All stateful interactions in tests are executed inside `env.as_contract(&contract_id, || {...})`.
- Tests use `Address::generate(&env)` for deterministic mock addresses.
- Panic messages intentionally use "Caller not admin" to allow `#[should_panic(expected = "Caller not admin")]` tests to match.
