### PR TITLE
feat: implement share purchase function

### DIFF
--- a/akkuea-defi-rwa/apps/contracts/Cargo.lock
+++ b/akkuea-defi-rwa/apps/contracts/Cargo.lock
@@ -1074,6 +1074,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "rwa-defi-contract"
 version = "0.0.0"
 dependencies = [
+ "itoa",
  "soroban-sdk",
 ]
 

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/Cargo.toml
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+itoa = "1.0"
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -100,12 +100,6 @@ impl PropertyTokenContract {
 
         let mut buffer = itoa::Buffer::new();
         let property_id_str = String::from_str(&env, buffer.format(property_id));
-        PropertyEvents::share_purchase(
-            &env,
-            property_id_str,
-            buyer,
-            amount as i128,
-            total_cost,
-        );
+        PropertyEvents::share_purchase(&env, property_id_str, buyer, amount as i128, total_cost);
     }
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -15,7 +15,7 @@ pub use lending::*;
 pub use storage::*;
 
 // Import necessary types for the contract (always available, not just in tests)
-use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, token, vec, Address, Env, String, Vec};
 
 #[cfg(test)]
 mod test;
@@ -28,5 +28,84 @@ impl PropertyTokenContract {
     /// Placeholder function - will be replaced with actual contract logic
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
+    }
+
+    /// Purchase shares of a property
+    ///
+    /// This function allows users to purchase property token shares by transferring
+    /// payment tokens via SEP-41. The function validates the property exists, is verified,
+    /// has available shares, calculates the total cost, transfers payment, mints shares,
+    /// and emits a SharePurchase event.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `buyer` - Address of the buyer (must be authorized)
+    /// * `property_id` - ID of the property to purchase shares from
+    /// * `amount` - Number of shares to purchase (must be positive)
+    /// * `payment_token` - Address of the SEP-41 payment token contract
+    ///
+    /// # Panics
+    /// Panics if:
+    /// - Buyer is not authorized
+    /// - Contract is paused
+    /// - Property does not exist
+    /// - Property is not verified
+    /// - Property has no available shares
+    /// - Amount is zero or exceeds available shares
+    /// - Payment token transfer fails
+    pub fn purchase_shares(
+        env: Env,
+        buyer: Address,
+        property_id: u64,
+        amount: u64,
+        payment_token: Address,
+    ) {
+        buyer.require_auth();
+        PauseControl::require_not_paused(&env);
+
+        if amount == 0 {
+            panic!("Amount must be positive");
+        }
+
+        let property = storage::property::PropertyMetadata::load(&env, property_id)
+            .unwrap_or_else(|| panic!("Property not found"));
+
+        if !storage::property::is_verified(&env, property_id) {
+            panic!("Property is not verified");
+        }
+
+        let available_shares = storage::property::get_available_shares(&env, property_id);
+        if available_shares == 0 {
+            panic!("No shares available");
+        }
+
+        if amount > available_shares {
+            panic!("Insufficient shares available");
+        }
+
+        let price_per_share = storage::property::get_price_per_share(&env, property_id);
+        if price_per_share <= 0 {
+            panic!("Price per share not set");
+        }
+
+        let total_cost = (amount as i128)
+            .checked_mul(price_per_share)
+            .expect("Cost calculation overflow");
+
+        let token_client = token::Client::new(&env, &payment_token);
+        token_client.transfer(&buyer, &property.owner, &total_cost);
+
+        storage::shares::increase_balance(&env, property_id, &buyer, amount);
+        storage::property::decrease_available_shares(&env, property_id, amount);
+
+        let mut buffer = itoa::Buffer::new();
+        let property_id_str = String::from_str(&env, buffer.format(property_id));
+        PropertyEvents::share_purchase(
+            &env,
+            property_id_str,
+            buyer,
+            amount as i128,
+            total_cost,
+        );
     }
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/storage/keys.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/storage/keys.rs
@@ -56,7 +56,9 @@ impl StorageKey {
             StorageKey::TotalShares(_) => Symbol::new(&soroban_sdk::Env::default(), "TotShrs"),
             StorageKey::Admin => Symbol::new(&soroban_sdk::Env::default(), "Admin"),
             StorageKey::PropertyCounter => Symbol::new(&soroban_sdk::Env::default(), "PropCnt"),
-            StorageKey::AvailableShares(_) => Symbol::new(&soroban_sdk::Env::default(), "AvailShrs"),
+            StorageKey::AvailableShares(_) => {
+                Symbol::new(&soroban_sdk::Env::default(), "AvailShrs")
+            }
             StorageKey::PricePerShare(_) => Symbol::new(&soroban_sdk::Env::default(), "PriceShr"),
             StorageKey::PropertyVerified(_) => Symbol::new(&soroban_sdk::Env::default(), "PropVer"),
         }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/storage/keys.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/storage/keys.rs
@@ -31,6 +31,18 @@ pub enum StorageKey {
     /// Property counter to generate unique property IDs
     /// Single instance per contract
     PropertyCounter,
+
+    /// Available shares for a property (total - sold)
+    /// Key: AvailableShares(property_id)
+    AvailableShares(u64),
+
+    /// Price per share for a property
+    /// Key: PricePerShare(property_id)
+    PricePerShare(u64),
+
+    /// Verified status for a property
+    /// Key: PropertyVerified(property_id)
+    PropertyVerified(u64),
 }
 
 impl StorageKey {
@@ -44,6 +56,9 @@ impl StorageKey {
             StorageKey::TotalShares(_) => Symbol::new(&soroban_sdk::Env::default(), "TotShrs"),
             StorageKey::Admin => Symbol::new(&soroban_sdk::Env::default(), "Admin"),
             StorageKey::PropertyCounter => Symbol::new(&soroban_sdk::Env::default(), "PropCnt"),
+            StorageKey::AvailableShares(_) => Symbol::new(&soroban_sdk::Env::default(), "AvailShrs"),
+            StorageKey::PricePerShare(_) => Symbol::new(&soroban_sdk::Env::default(), "PriceShr"),
+            StorageKey::PropertyVerified(_) => Symbol::new(&soroban_sdk::Env::default(), "PropVer"),
         }
     }
 }

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/storage/property.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/storage/property.rs
@@ -162,3 +162,95 @@ impl PropertyMetadata {
         env.storage().persistent().remove(&key);
     }
 }
+
+/// Gets the available shares for a property
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+///
+/// # Returns
+/// * `u64` - Number of available shares (0 if not set)
+pub fn get_available_shares(env: &Env, property_id: u64) -> u64 {
+    let key = StorageKey::AvailableShares(property_id);
+    env.storage().instance().get(&key).unwrap_or(0)
+}
+
+/// Sets the available shares for a property
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+/// * `available` - Number of available shares
+pub fn set_available_shares(env: &Env, property_id: u64, available: u64) {
+    let key = StorageKey::AvailableShares(property_id);
+    env.storage().instance().set(&key, &available);
+}
+
+/// Decreases available shares for a property
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+/// * `amount` - Number of shares to decrease
+///
+/// # Panics
+/// Panics if the subtraction would underflow (insufficient available shares)
+pub fn decrease_available_shares(env: &Env, property_id: u64, amount: u64) {
+    let current = get_available_shares(env, property_id);
+    let new_available = current
+        .checked_sub(amount)
+        .expect("Insufficient available shares");
+    set_available_shares(env, property_id, new_available);
+}
+
+/// Gets the price per share for a property
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+///
+/// # Returns
+/// * `i128` - Price per share (0 if not set)
+pub fn get_price_per_share(env: &Env, property_id: u64) -> i128 {
+    let key = StorageKey::PricePerShare(property_id);
+    env.storage().instance().get(&key).unwrap_or(0)
+}
+
+/// Sets the price per share for a property
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+/// * `price` - Price per share (must be positive)
+pub fn set_price_per_share(env: &Env, property_id: u64, price: i128) {
+    if price <= 0 {
+        panic!("Price per share must be positive");
+    }
+    let key = StorageKey::PricePerShare(property_id);
+    env.storage().instance().set(&key, &price);
+}
+
+/// Checks if a property is verified
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+///
+/// # Returns
+/// * `bool` - True if verified, false otherwise
+pub fn is_verified(env: &Env, property_id: u64) -> bool {
+    let key = StorageKey::PropertyVerified(property_id);
+    env.storage().instance().get(&key).unwrap_or(false)
+}
+
+/// Sets the verified status for a property
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `property_id` - ID of the property
+/// * `verified` - Verified status
+pub fn set_verified(env: &Env, property_id: u64, verified: bool) {
+    let key = StorageKey::PropertyVerified(property_id);
+    env.storage().instance().set(&key, &verified);
+}

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -590,7 +590,7 @@ fn setup_purchase_test() -> (Address, Env, Address, Address, Address, u64) {
     let token_admin_client = StellarAssetClient::new(&env, &payment_token);
 
     // Mint tokens to buyer for testing
-    token_admin_client.mint(&buyer, &10_000_000_000_0000i128); // $10M with 7 decimals
+    token_admin_client.mint(&buyer, &100_000_000_000_000_i128); // $10M with 7 decimals
 
     let property_id = 1u64;
 
@@ -606,7 +606,7 @@ fn setup_purchase_test() -> (Address, Env, Address, Address, Address, u64) {
         String::from_str(&env, "Test Property"),
         String::from_str(&env, "A test property"),
         String::from_str(&env, "123 Test St"),
-        1_000_000_000_0000, // $1M with 7 decimals
+        10_000_000_000_000, // $1M with 7 decimals
         100_000u64,         // 100k total shares
         env.ledger().timestamp(),
     );
@@ -796,7 +796,7 @@ fn test_purchase_nonexistent_property() {
         let payment_token = stellar_asset.address();
 
         let token_admin_client = StellarAssetClient::new(&env, &payment_token);
-        token_admin_client.mint(&buyer, &10_000_000_000_0000i128);
+        token_admin_client.mint(&buyer, &100_000_000_000_000_i128);
 
         env.as_contract(&contract_id, || {
             AdminControl::initialize(&env, &admin);

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -1,6 +1,6 @@
 use super::access::{AdminControl, PauseControl};
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String, token};
+use soroban_sdk::{testutils::Address as _, testutils::Events, token, Address, Env, String};
 use token::StellarAssetClient;
 
 // Created this contract just for testing storage
@@ -575,24 +575,23 @@ fn setup_purchase_test() -> (Address, Env, Address, Address, Address, u64) {
     let env = Env::default();
     // Mock all auths for testing
     env.mock_all_auths();
-    
+
     let contract_id = env.register(PropertyTokenContract, ());
     let admin = Address::generate(&env);
     let property_owner = Address::generate(&env);
     let buyer = Address::generate(&env);
-    
+
     // Create a test token using register_stellar_asset_contract_v2
     let token_admin = Address::generate(&env);
     let stellar_asset = env.register_stellar_asset_contract_v2(token_admin.clone());
     let payment_token = stellar_asset.address();
-    
-    // Create token client and admin client for minting
-    let token_client = token::Client::new(&env, &payment_token);
+
+    // Create token admin client for minting
     let token_admin_client = StellarAssetClient::new(&env, &payment_token);
-    
+
     // Mint tokens to buyer for testing
     token_admin_client.mint(&buyer, &10_000_000_000_0000i128); // $10M with 7 decimals
-    
+
     let property_id = 1u64;
 
     // Initialize admin
@@ -622,7 +621,14 @@ fn setup_purchase_test() -> (Address, Env, Address, Address, Address, u64) {
         storage::property::set_verified(&env, property_id, true);
     });
 
-    (contract_id, env, property_owner, buyer, payment_token, property_id)
+    (
+        contract_id,
+        env,
+        property_owner,
+        buyer,
+        payment_token,
+        property_id,
+    )
 }
 
 #[test]
@@ -660,10 +666,7 @@ fn test_purchase_shares_happy_path() {
     let final_buyer_shares = env.as_contract(&contract_id, || {
         storage::shares::get_balance(&env, property_id, &buyer)
     });
-    assert_eq!(
-        final_buyer_shares,
-        initial_buyer_shares + purchase_amount
-    );
+    assert_eq!(final_buyer_shares, initial_buyer_shares + purchase_amount);
 
     // Verify available shares decreased
     let final_available_shares = env.as_contract(&contract_id, || {
@@ -782,16 +785,16 @@ fn test_purchase_nonexistent_property() {
     let (contract_id, env, _property_owner, buyer, payment_token) = {
         let env = Env::default();
         env.mock_all_auths();
-        
+
         let contract_id = env.register(PropertyTokenContract, ());
         let admin = Address::generate(&env);
         let property_owner = Address::generate(&env);
         let buyer = Address::generate(&env);
         let token_admin = Address::generate(&env);
-        
+
         let stellar_asset = env.register_stellar_asset_contract_v2(token_admin.clone());
         let payment_token = stellar_asset.address();
-        
+
         let token_admin_client = StellarAssetClient::new(&env, &payment_token);
         token_admin_client.mint(&buyer, &10_000_000_000_0000i128);
 
@@ -843,9 +846,7 @@ fn test_purchase_when_contract_paused() {
     let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
         setup_purchase_test();
 
-    let admin = env.as_contract(&contract_id, || {
-        AdminControl::get_admin(&env).unwrap()
-    });
+    let admin = env.as_contract(&contract_id, || AdminControl::get_admin(&env).unwrap());
 
     // Pause contract
     env.as_contract(&contract_id, || {

--- a/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/akkuea-defi-rwa/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -1,6 +1,7 @@
 use super::access::{AdminControl, PauseControl};
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String, token};
+use token::StellarAssetClient;
 
 // Created this contract just for testing storage
 #[contract]
@@ -564,4 +565,301 @@ fn test_borrow_event() {
 
     let events = env.events().all();
     assert_eq!(events.events().len(), 1);
+}
+
+// =========================================================================
+// Purchase Shares Tests
+// =========================================================================
+
+fn setup_purchase_test() -> (Address, Env, Address, Address, Address, u64) {
+    let env = Env::default();
+    // Mock all auths for testing
+    env.mock_all_auths();
+    
+    let contract_id = env.register(PropertyTokenContract, ());
+    let admin = Address::generate(&env);
+    let property_owner = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    
+    // Create a test token using register_stellar_asset_contract_v2
+    let token_admin = Address::generate(&env);
+    let stellar_asset = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let payment_token = stellar_asset.address();
+    
+    // Create token client and admin client for minting
+    let token_client = token::Client::new(&env, &payment_token);
+    let token_admin_client = StellarAssetClient::new(&env, &payment_token);
+    
+    // Mint tokens to buyer for testing
+    token_admin_client.mint(&buyer, &10_000_000_000_0000i128); // $10M with 7 decimals
+    
+    let property_id = 1u64;
+
+    // Initialize admin
+    env.as_contract(&contract_id, || {
+        AdminControl::initialize(&env, &admin);
+    });
+
+    // Create property metadata
+    let property = storage::property::PropertyMetadata::new(
+        property_id,
+        property_owner.clone(),
+        String::from_str(&env, "Test Property"),
+        String::from_str(&env, "A test property"),
+        String::from_str(&env, "123 Test St"),
+        1_000_000_000_0000, // $1M with 7 decimals
+        100_000u64,         // 100k total shares
+        env.ledger().timestamp(),
+    );
+
+    env.as_contract(&contract_id, || {
+        property.save(&env);
+        // Set available shares
+        storage::property::set_available_shares(&env, property_id, 100_000u64);
+        // Set price per share (1_000_000 = $0.10 with 7 decimals)
+        storage::property::set_price_per_share(&env, property_id, 1_000_000i128);
+        // Set verified status
+        storage::property::set_verified(&env, property_id, true);
+    });
+
+    (contract_id, env, property_owner, buyer, payment_token, property_id)
+}
+
+#[test]
+fn test_purchase_shares_happy_path() {
+    let (contract_id, env, property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    let purchase_amount = 1_000u64;
+    let price_per_share = 1_000_000i128; // $0.10
+    let expected_cost = (purchase_amount as i128) * price_per_share;
+
+    // Get initial balances
+    let token_client = token::Client::new(&env, &payment_token);
+    let initial_buyer_balance = token_client.balance(&buyer);
+    let initial_owner_balance = token_client.balance(&property_owner);
+    let initial_buyer_shares = env.as_contract(&contract_id, || {
+        storage::shares::get_balance(&env, property_id, &buyer)
+    });
+    let initial_available_shares = env.as_contract(&contract_id, || {
+        storage::property::get_available_shares(&env, property_id)
+    });
+
+    // Purchase shares (auth is mocked via env.mock_all_auths() in setup)
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            purchase_amount,
+            payment_token.clone(),
+        );
+    });
+
+    // Verify buyer balance increased
+    let final_buyer_shares = env.as_contract(&contract_id, || {
+        storage::shares::get_balance(&env, property_id, &buyer)
+    });
+    assert_eq!(
+        final_buyer_shares,
+        initial_buyer_shares + purchase_amount
+    );
+
+    // Verify available shares decreased
+    let final_available_shares = env.as_contract(&contract_id, || {
+        storage::property::get_available_shares(&env, property_id)
+    });
+    assert_eq!(
+        final_available_shares,
+        initial_available_shares - purchase_amount
+    );
+
+    // Verify payment transferred
+    let final_buyer_balance = token_client.balance(&buyer);
+    let final_owner_balance = token_client.balance(&property_owner);
+    assert_eq!(final_buyer_balance, initial_buyer_balance - expected_cost);
+    assert_eq!(final_owner_balance, initial_owner_balance + expected_cost);
+
+    // Verify SharePurchase event emitted
+    // Events are emitted during contract execution
+    // The event verification is done implicitly through state changes above
+    // (shares increased, available decreased, token balances updated)
+}
+
+#[test]
+fn test_purchase_all_remaining_shares() {
+    let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    let available_shares = env.as_contract(&contract_id, || {
+        storage::property::get_available_shares(&env, property_id)
+    });
+
+    // Purchase all remaining shares
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            available_shares,
+            payment_token.clone(),
+        );
+    });
+
+    // Verify available shares is now 0
+    let final_available_shares = env.as_contract(&contract_id, || {
+        storage::property::get_available_shares(&env, property_id)
+    });
+    assert_eq!(final_available_shares, 0);
+}
+
+#[test]
+#[should_panic(expected = "No shares available")]
+fn test_purchase_when_sold_out() {
+    let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    // Set available shares to 0
+    env.as_contract(&contract_id, || {
+        storage::property::set_available_shares(&env, property_id, 0);
+    });
+
+    // Attempt purchase
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            1u64,
+            payment_token.clone(),
+        );
+    });
+}
+
+#[test]
+#[should_panic(expected = "Insufficient shares available")]
+fn test_purchase_exceeding_available() {
+    let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    let available_shares = env.as_contract(&contract_id, || {
+        storage::property::get_available_shares(&env, property_id)
+    });
+
+    // Attempt to purchase more than available
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            available_shares + 1,
+            payment_token.clone(),
+        );
+    });
+}
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_purchase_zero_amount() {
+    let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    // Attempt purchase with zero amount
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            0u64,
+            payment_token.clone(),
+        );
+    });
+}
+
+#[test]
+#[should_panic(expected = "Property not found")]
+fn test_purchase_nonexistent_property() {
+    let (contract_id, env, _property_owner, buyer, payment_token) = {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(PropertyTokenContract, ());
+        let admin = Address::generate(&env);
+        let property_owner = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        
+        let stellar_asset = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let payment_token = stellar_asset.address();
+        
+        let token_admin_client = StellarAssetClient::new(&env, &payment_token);
+        token_admin_client.mint(&buyer, &10_000_000_000_0000i128);
+
+        env.as_contract(&contract_id, || {
+            AdminControl::initialize(&env, &admin);
+        });
+
+        (contract_id, env, property_owner, buyer, payment_token)
+    };
+
+    // Attempt purchase of non-existent property
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            999u64, // Non-existent property ID
+            1u64,
+            payment_token.clone(),
+        );
+    });
+}
+
+#[test]
+#[should_panic(expected = "Property is not verified")]
+fn test_purchase_unverified_property() {
+    let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    // Set property as unverified
+    env.as_contract(&contract_id, || {
+        storage::property::set_verified(&env, property_id, false);
+    });
+
+    // Attempt purchase
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            1u64,
+            payment_token.clone(),
+        );
+    });
+}
+
+#[test]
+#[should_panic(expected = "Contract paused")]
+fn test_purchase_when_contract_paused() {
+    let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
+        setup_purchase_test();
+
+    let admin = env.as_contract(&contract_id, || {
+        AdminControl::get_admin(&env).unwrap()
+    });
+
+    // Pause contract
+    env.as_contract(&contract_id, || {
+        PauseControl::pause(&env, &admin);
+    });
+
+    // Attempt purchase
+    env.as_contract(&contract_id, || {
+        PropertyTokenContract::purchase_shares(
+            env.clone(),
+            buyer.clone(),
+            property_id,
+            1u64,
+            payment_token.clone(),
+        );
+    });
 }


### PR DESCRIPTION
Closes #691

---

Add purchase_shares entry point that allows users to buy property token shares. The function handles payment via SEP-41 token transfer, validates property state, updates share balances, and emits purchase events.

- Add purchase_shares function with buyer authorization
- Add storage helpers for available shares, price per share, and verification status
- Implement validation for property existence, verification, and share availability
- Handle edge cases: sold out, zero amount, contract paused
- Add comprehensive test coverage for all purchase scenarios