### PR TITLE
feat(shared): add transaction status tracking types (C2-009)

### DIFF
--- a/akkuea-defi-rwa/apps/shared/src/schemas/index.ts
+++ b/akkuea-defi-rwa/apps/shared/src/schemas/index.ts
@@ -38,22 +38,38 @@ export {
   type BorrowPositionInput,
 } from "./lending.schema";
 
+// Transaction schemas and types
+export {
+  transactionTypeSchema,
+  transactionStatusSchema,
+  transactionSchema,
+  transactionFilterSchema,
+  transactionQueryParamsSchema,
+  paginatedTransactionResponseSchema,
+  type TransactionType,
+  type TransactionStatus,
+  type Transaction,
+  type TransactionFilter,
+  type TransactionQueryParams,
+  type PaginatedTransactionResponse,
+  type TransactionInput,
+  type TransactionFilterInput,
+  type TransactionQueryParamsInput,
+} from "./transaction.schema";
+
 // User schemas and types
 export {
   kycStatusSchema,
   kycTierSchema,
   kycDocumentSchema,
   userSchema,
-  transactionSchema,
   oraclePriceSchema,
   type KycStatus,
   type KycTier,
   type KycDocument,
   type User,
-  type Transaction,
   type OraclePrice,
   type UserInput,
   type KycDocumentInput,
-  type TransactionInput,
   type OraclePriceInput,
 } from "./user.schema";

--- a/akkuea-defi-rwa/apps/shared/src/schemas/transaction.schema.ts
+++ b/akkuea-defi-rwa/apps/shared/src/schemas/transaction.schema.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import {
+  stellarAddressSchema,
+  isoDateSchema,
+  positiveAmountSchema,
+  transactionHashSchema,
+} from "./common.schema";
+
+/**
+ * Transaction type enum
+ */
+export const transactionTypeSchema = z.enum([
+  "deposit",
+  "withdraw",
+  "borrow",
+  "repay",
+  "liquidation",
+  "buy_shares",
+  "sell_shares",
+  "dividend",
+]);
+
+/**
+ * Transaction status enum (includes submitting and not_found for state machine)
+ */
+export const transactionStatusSchema = z.enum([
+  "submitting",
+  "pending",
+  "confirmed",
+  "failed",
+  "not_found",
+]);
+
+/**
+ * Schema for Transaction
+ */
+export const transactionSchema = z.object({
+  id: z.string().uuid(),
+  type: transactionTypeSchema,
+  hash: transactionHashSchema.optional(),
+  from: stellarAddressSchema,
+  to: stellarAddressSchema.optional(),
+  amount: positiveAmountSchema,
+  asset: z.string(),
+  status: transactionStatusSchema,
+  timestamp: isoDateSchema,
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  // Stellar reconstruction fields
+  ledger: z.number().int().positive().optional(),
+  fee: z.string().regex(/^\d+(\.\d+)?$/).optional(),
+  memo: z.string().optional(),
+});
+
+/**
+ * Transaction filter for API queries
+ */
+export const transactionFilterSchema = z.object({
+  type: transactionTypeSchema.optional(),
+  status: transactionStatusSchema.optional(),
+  from: stellarAddressSchema.optional(),
+  to: stellarAddressSchema.optional(),
+  asset: z.string().optional(),
+  since: isoDateSchema.optional(),
+  until: isoDateSchema.optional(),
+});
+
+/**
+ * Query params with pagination for transaction list APIs
+ */
+export const transactionQueryParamsSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+}).merge(transactionFilterSchema);
+
+/**
+ * Paginated transaction list response
+ */
+export const paginatedTransactionResponseSchema = z.object({
+  items: z.array(transactionSchema),
+  nextCursor: z.string().optional(),
+  total: z.number().int().min(0).optional(),
+});
+
+// Type inference
+export type TransactionType = z.infer<typeof transactionTypeSchema>;
+export type TransactionStatus = z.infer<typeof transactionStatusSchema>;
+export type Transaction = z.infer<typeof transactionSchema>;
+export type TransactionFilter = z.infer<typeof transactionFilterSchema>;
+export type TransactionQueryParams = z.infer<typeof transactionQueryParamsSchema>;
+export type PaginatedTransactionResponse = z.infer<
+  typeof paginatedTransactionResponseSchema
+>;
+
+export type TransactionInput = z.input<typeof transactionSchema>;
+export type TransactionFilterInput = z.input<typeof transactionFilterSchema>;
+export type TransactionQueryParamsInput = z.input<
+  typeof transactionQueryParamsSchema
+>;

--- a/akkuea-defi-rwa/apps/shared/src/schemas/user.schema.ts
+++ b/akkuea-defi-rwa/apps/shared/src/schemas/user.schema.ts
@@ -65,31 +65,6 @@ export const userSchema = z.object({
 });
 
 /**
- * Schema for Transaction
- */
-export const transactionSchema = z.object({
-  id: z.string().uuid(),
-  type: z.enum([
-    "deposit",
-    "withdraw",
-    "borrow",
-    "repay",
-    "liquidation",
-    "buy_shares",
-    "sell_shares",
-    "dividend",
-  ]),
-  hash: z.string().length(64).optional(),
-  from: stellarAddressSchema,
-  to: stellarAddressSchema.optional(),
-  amount: positiveAmountSchema,
-  asset: z.string(),
-  status: z.enum(["pending", "confirmed", "failed"]),
-  timestamp: isoDateSchema,
-  metadata: z.record(z.string(), z.unknown()).optional(),
-});
-
-/**
  * Schema for OraclePrice
  */
 export const oraclePriceSchema = z.object({
@@ -108,11 +83,9 @@ export type KycStatus = z.infer<typeof kycStatusSchema>;
 export type KycTier = z.infer<typeof kycTierSchema>;
 export type KycDocument = z.infer<typeof kycDocumentSchema>;
 export type User = z.infer<typeof userSchema>;
-export type Transaction = z.infer<typeof transactionSchema>;
 export type OraclePrice = z.infer<typeof oraclePriceSchema>;
 
 // Keep input types for advanced use cases
 export type UserInput = z.input<typeof userSchema>;
 export type KycDocumentInput = z.input<typeof kycDocumentSchema>;
-export type TransactionInput = z.input<typeof transactionSchema>;
 export type OraclePriceInput = z.input<typeof oraclePriceSchema>;

--- a/akkuea-defi-rwa/apps/shared/src/types/index.ts
+++ b/akkuea-defi-rwa/apps/shared/src/types/index.ts
@@ -13,11 +13,19 @@ export type {
 } from "../schemas/lending.schema";
 
 export type {
+  TransactionType,
+  TransactionStatus,
+  Transaction,
+  TransactionFilter,
+  TransactionQueryParams,
+  PaginatedTransactionResponse,
+} from "../schemas/transaction.schema";
+
+export type {
   KycStatus,
   KycTier,
   KycDocument,
   User,
-  Transaction,
   OraclePrice,
 } from "../schemas/user.schema";
 

--- a/akkuea-defi-rwa/apps/shared/tests/schemas/transaction.schema.test.ts
+++ b/akkuea-defi-rwa/apps/shared/tests/schemas/transaction.schema.test.ts
@@ -1,0 +1,132 @@
+/// <reference types="bun-types" />
+import { describe, it, expect } from "bun:test";
+import {
+  transactionSchema,
+  transactionFilterSchema,
+  transactionQueryParamsSchema,
+  type TransactionFilter,
+} from "../../src/schemas";
+
+const validStellarAddress = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+
+const validTransaction = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  type: "deposit",
+  hash: "a".repeat(64),
+  from: validStellarAddress,
+  to: validStellarAddress,
+  amount: "100.50",
+  asset: "USDC",
+  status: "confirmed",
+  timestamp: "2024-01-15T10:30:00Z",
+  metadata: { source: "web" },
+};
+
+describe("transactionSchema", () => {
+  it("valid transaction parses", () => {
+    const result = transactionSchema.safeParse(validTransaction);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-hex hash", () => {
+    const invalid = {
+      ...validTransaction,
+      hash: "G".repeat(64),
+    };
+    const result = transactionSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const hashIssue = result.error.issues.find((i) =>
+        i.path.includes("hash")
+      );
+      expect(hashIssue).toBeDefined();
+    }
+  });
+
+  it("accepts status submitting", () => {
+    const withSubmitting = { ...validTransaction, status: "submitting" };
+    const result = transactionSchema.safeParse(withSubmitting);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts status not_found", () => {
+    const withNotFound = { ...validTransaction, status: "not_found" };
+    const result = transactionSchema.safeParse(withNotFound);
+    expect(result.success).toBe(true);
+  });
+
+  it("parses Stellar fields ledger, fee, memo correctly", () => {
+    const withStellar = {
+      ...validTransaction,
+      ledger: 12345,
+      fee: "0.00001",
+      memo: "payment-id-001",
+    };
+    const result = transactionSchema.safeParse(withStellar);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ledger).toBe(12345);
+      expect(result.data.fee).toBe("0.00001");
+      expect(result.data.memo).toBe("payment-id-001");
+    }
+  });
+
+  it("accepts valid hex hash (lowercase)", () => {
+    const withHexHash = {
+      ...validTransaction,
+      hash: "abcdef0123456789".repeat(4),
+    };
+    const result = transactionSchema.safeParse(withHexHash);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid hex hash (uppercase)", () => {
+    const withHexHash = {
+      ...validTransaction,
+      hash: "ABCDEF0123456789".repeat(4),
+    };
+    const result = transactionSchema.safeParse(withHexHash);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("transactionFilterSchema", () => {
+  it("filter type compiles and parses valid filter", () => {
+    const filter: TransactionFilter = {
+      type: "deposit",
+      status: "pending",
+      asset: "USDC",
+    };
+    const result = transactionFilterSchema.safeParse(filter);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty filter", () => {
+    const result = transactionFilterSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("transactionQueryParamsSchema", () => {
+  it("parses query params with pagination", () => {
+    const params = {
+      cursor: "cursor-123",
+      limit: 10,
+      status: "confirmed",
+    };
+    const result = transactionQueryParamsSchema.safeParse(params);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(10);
+      expect(result.data.cursor).toBe("cursor-123");
+    }
+  });
+
+  it("defaults limit to 20", () => {
+    const result = transactionQueryParamsSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+});

--- a/akkuea-defi-rwa/apps/shared/tsconfig.test.json
+++ b/akkuea-defi-rwa/apps/shared/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Add transaction status tracking types (C2-009)

### Summary
Moves the Transaction schema into its own module, tightens validation, adds Stellar-related fields and statuses, and introduces filter/query/pagination types for transaction APIs.

### Changes
- **Transaction schema** — New `apps/shared/src/schemas/transaction.schema.ts` with the full Transaction schema (no longer in `user.schema.ts`).
- **Validation** — `hash` uses existing `transactionHashSchema` (64-char hex). Status enum extended with `submitting` and `not_found`.
- **Stellar** — Optional `ledger` (int), `fee` (decimal string), `memo` (string).
- **API types** — `TransactionFilter` for query filters (type, status, from, to, asset, since, until). `TransactionQueryParams` with `cursor`, `limit` (1–100, default 20) plus filter fields. `PaginatedTransactionResponse` with `items`, `nextCursor`, `total`.
- **Exports** — Transaction schemas and types re-exported from `schemas/index.ts` and `types/index.ts` so existing `Transaction` imports keep working.
- **Tests** — New `tests/schemas/transaction.schema.test.ts` for valid/invalid parsing, statuses, Stellar fields, filter, and query params. `tsconfig.test.json` and `/// <reference types="bun-types" />` so test files type-check with `bun:test`.

### Verification
- `bun test` and `bun run build` pass.
- Acceptance: transaction in own file, non-hex hash rejected, new statuses and Stellar fields validated, old imports resolve.

### Closes #690  