### PR TITLE
feat(shared): add test factories, staging fixtures, migrate tests to …

### DIFF
--- a/akkuea-defi-rwa/apps/api/src/__tests__/kyc.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/__tests__/kyc.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from 'bun:test';
 import { Elysia } from 'elysia';
 import { kycRoutes } from '../routes/kyc';
 import { errorHandler } from '../middleware/errorHandler';
+import { VALID_UUID, NON_EXISTENT_UUID } from '@real-estate-defi/shared';
 
 const skipIfNoDatabase = !process.env.DATABASE_URL;
-const VALID_USER_ID = '550e8400-e29b-41d4-a716-446655440000';
-const NON_EXISTENT_USER_ID = '550e8400-e29b-41d4-a716-446655440099';
-const NON_EXISTENT_DOC_ID = '550e8400-e29b-41d4-a716-446655440099';
+const VALID_USER_ID = VALID_UUID;
+const NON_EXISTENT_USER_ID = NON_EXISTENT_UUID;
+const NON_EXISTENT_DOC_ID = NON_EXISTENT_UUID;
 
 function createApp() {
   return new Elysia().use(errorHandler).use(kycRoutes);

--- a/akkuea-defi-rwa/apps/api/src/__tests__/lending.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/__tests__/lending.test.ts
@@ -3,10 +3,7 @@ import { Elysia } from 'elysia';
 import { lendingRoutes } from '../routes/lending';
 import { errorHandler } from '../middleware/errorHandler';
 import { CreatePoolDto, DepositDto, WithdrawDto, BorrowDto, RepayDto } from '../dto/lending.dto';
-
-// Valid Stellar address for testing
-const VALID_STELLAR_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7';
-const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+import { VALID_STELLAR_ADDRESS, VALID_UUID } from '@real-estate-defi/shared';
 
 describe('Lending DTO Validation', () => {
   describe('CreatePoolDto', () => {

--- a/akkuea-defi-rwa/apps/api/src/__tests__/positions.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/__tests__/positions.test.ts
@@ -4,9 +4,12 @@ import type { BorrowPosition, DepositPosition, LendingPool, User } from '../db/s
 import { errorHandler } from '../middleware/errorHandler';
 import { lendingRoutes } from '../routes/lending';
 import { PositionService } from '../services/PositionService';
+import {
+  VALID_STELLAR_ADDRESS,
+  VALID_STELLAR_ADDRESS_2,
+  VALID_UUID as VALID_POOL_ID,
+} from '@real-estate-defi/shared';
 
-const VALID_POOL_ID = '550e8400-e29b-41d4-a716-446655440000';
-const VALID_STELLAR_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7';
 const INVALID_STELLAR_ADDRESS = 'NOT_A_VALID_STELLAR_ADDRESS';
 const FIXED_NOW = new Date('2026-03-22T12:00:00.000Z');
 
@@ -119,15 +122,15 @@ describe('PositionService', () => {
   it('returns an empty snapshot when the wallet has no local user record', async () => {
     const deposits = await service.getUserDeposits(
       VALID_POOL_ID,
-      'GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON',
+      VALID_STELLAR_ADDRESS_2,
     );
     const borrows = await service.getUserBorrows(
       VALID_POOL_ID,
-      'GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON',
+      VALID_STELLAR_ADDRESS_2,
     );
     const summary = await service.getPositionSummary(
       VALID_POOL_ID,
-      'GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON',
+      VALID_STELLAR_ADDRESS_2,
     );
 
     expect(deposits).toEqual([]);

--- a/akkuea-defi-rwa/apps/api/src/__tests__/properties.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/__tests__/properties.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
 import { Elysia } from 'elysia';
 import { propertyRoutes } from '../routes/properties';
+import { VALID_UUID, NON_EXISTENT_UUID } from '@real-estate-defi/shared';
 
 // Skip tests if DATABASE_URL is not set (required for integration tests)
 const skipIfNoDatabase = !process.env.DATABASE_URL;
-
-// Valid UUIDs for testing
-const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
-const NON_EXISTENT_UUID = '550e8400-e29b-41d4-a716-446655440999';
 
 describe.skipIf(skipIfNoDatabase)('Property Routes Integration Tests', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/akkuea-defi-rwa/apps/api/src/__tests__/tokenization.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/__tests__/tokenization.test.ts
@@ -3,8 +3,7 @@ import { Elysia } from 'elysia';
 import { propertyRoutes } from '../routes/properties';
 import { TokenizationService } from '../services/TokenizationService';
 import { logger } from '../services/logger';
-
-const PROPERTY_ID = '550e8400-e29b-41d4-a716-446655440000';
+import { VALID_UUID as PROPERTY_ID } from '@real-estate-defi/shared';
 const OWNER_WALLET = 'GBQ6M5OBU64ATKSRH4OKW2IFQCB5R6Q73F4VMK6KQ37C5G6GQ6FJTYA3';
 const ADMIN_WALLET = 'GC3C4X5R7N2X7CII7SPRD4U6ZLKZKAJZDW6N4Q4QAV3FJ7Q3N7GJ5P6L';
 const CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';

--- a/akkuea-defi-rwa/apps/shared/src/index.ts
+++ b/akkuea-defi-rwa/apps/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./schemas";
 export * from "./utils";
 export * from "./constants";
 export * from "./errors";
+export * from "./testing";
 export * from "./utils/stellar";
 export * from "./utils/validation";
 export * from "./utils/format";

--- a/akkuea-defi-rwa/apps/shared/src/testing/constants.ts
+++ b/akkuea-defi-rwa/apps/shared/src/testing/constants.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared test constants — canonical values to eliminate duplication across test suites.
+ */
+
+/** Valid Stellar public key (ed25519, G-prefix, base32) */
+export const VALID_STELLAR_ADDRESS =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
+
+/** Secondary Stellar address for two-party tests */
+export const VALID_STELLAR_ADDRESS_2 =
+  "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON";
+
+/** USDC issuer on Stellar testnet */
+export const USDC_ISSUER_ADDRESS =
+  "GA5ZSEJYBEOJ58MWPSPMXSVPZJVHIHAIPSZI7ZS2UXUJRZ4MZEGERUAU";
+
+/** Deterministic UUID for primary test entities */
+export const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+/** UUID that should never exist in any store */
+export const NON_EXISTENT_UUID = "00000000-0000-4000-a000-000000000000";
+
+/** ISO-8601 timestamps for consistent date testing */
+export const BASE_DATE = "2025-01-15T10:00:00.000Z";
+export const UPDATED_DATE = "2025-06-20T14:30:00.000Z";
+
+/** 64-char hex transaction hash */
+export const VALID_TX_HASH =
+  "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";

--- a/akkuea-defi-rwa/apps/shared/src/testing/factories.ts
+++ b/akkuea-defi-rwa/apps/shared/src/testing/factories.ts
@@ -1,0 +1,198 @@
+/**
+ * Test factories — `create<Type>(overrides?)` functions that return
+ * schema-compliant objects with realistic defaults.
+ */
+import type {
+  User,
+  KycDocument,
+  PropertyLocation,
+  PropertyInfo,
+  LendingPool,
+  DepositPosition,
+  BorrowPosition,
+  Transaction,
+  OraclePrice,
+} from "../schemas";
+import {
+  VALID_STELLAR_ADDRESS,
+  VALID_STELLAR_ADDRESS_2,
+  USDC_ISSUER_ADDRESS,
+  VALID_UUID,
+  VALID_TX_HASH,
+  BASE_DATE,
+  UPDATED_DATE,
+} from "./constants";
+
+let _seq = 0;
+/** Returns a deterministic UUID with an incrementing suffix to avoid collisions. */
+function nextUUID(): string {
+  _seq += 1;
+  const suffix = String(_seq).padStart(12, "0");
+  return `550e8400-e29b-41d4-a716-${suffix}`;
+}
+
+/** Reset the internal sequence counter (useful between test suites). */
+export function resetFactorySequence(): void {
+  _seq = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Domain factories
+// ---------------------------------------------------------------------------
+
+export function createUser(overrides?: Partial<User>): User {
+  return {
+    id: nextUUID(),
+    walletAddress: VALID_STELLAR_ADDRESS,
+    email: "investor@example.com",
+    displayName: "Test Investor",
+    kycStatus: "approved",
+    kycTier: "verified",
+    kycDocuments: [],
+    createdAt: BASE_DATE,
+    updatedAt: UPDATED_DATE,
+    ...overrides,
+  };
+}
+
+export function createKycDocument(
+  overrides?: Partial<KycDocument>,
+): KycDocument {
+  return {
+    id: nextUUID(),
+    userId: VALID_UUID,
+    type: "passport",
+    fileName: "passport_scan.pdf",
+    fileUrl: "https://storage.example.com/docs/passport_scan.pdf",
+    status: "approved",
+    uploadedAt: BASE_DATE,
+    reviewedAt: UPDATED_DATE,
+    ...overrides,
+  };
+}
+
+export function createPropertyLocation(
+  overrides?: Partial<PropertyLocation>,
+): PropertyLocation {
+  return {
+    address: "1200 Brickell Ave",
+    city: "Miami",
+    country: "US",
+    postalCode: "33131",
+    coordinates: { latitude: 25.7617, longitude: -80.1918 },
+    ...overrides,
+  };
+}
+
+export function createProperty(
+  overrides?: Partial<PropertyInfo>,
+): PropertyInfo {
+  return {
+    id: nextUUID(),
+    name: "Brickell Luxury Condo",
+    description:
+      "Premium residential unit in Miami's Brickell financial district",
+    propertyType: "residential",
+    location: createPropertyLocation(),
+    totalValue: "2000000",
+    totalShares: 2000,
+    availableShares: 500,
+    pricePerShare: "1000",
+    images: ["https://images.example.com/brickell-condo-1.jpg"],
+    documents: [],
+    verified: true,
+    listedAt: BASE_DATE,
+    owner: VALID_STELLAR_ADDRESS,
+    ...overrides,
+  };
+}
+
+export function createLendingPool(
+  overrides?: Partial<LendingPool>,
+): LendingPool {
+  return {
+    id: nextUUID(),
+    name: "USDC Lending Pool",
+    asset: "USDC",
+    assetAddress: USDC_ISSUER_ADDRESS,
+    totalDeposits: "500000",
+    totalBorrows: "200000",
+    availableLiquidity: "300000",
+    utilizationRate: 40,
+    supplyAPY: 8,
+    borrowAPY: 10,
+    collateralFactor: 75,
+    liquidationThreshold: 80,
+    liquidationPenalty: 5,
+    reserveFactor: 1000,
+    isActive: true,
+    isPaused: false,
+    createdAt: BASE_DATE,
+    ...overrides,
+  };
+}
+
+export function createDepositPosition(
+  overrides?: Partial<DepositPosition>,
+): DepositPosition {
+  return {
+    id: nextUUID(),
+    poolId: VALID_UUID,
+    depositor: VALID_STELLAR_ADDRESS,
+    amount: "1000",
+    shares: "1000",
+    depositedAt: BASE_DATE,
+    lastAccrualAt: UPDATED_DATE,
+    accruedInterest: "12.50",
+    ...overrides,
+  };
+}
+
+export function createBorrowPosition(
+  overrides?: Partial<BorrowPosition>,
+): BorrowPosition {
+  return {
+    id: nextUUID(),
+    poolId: VALID_UUID,
+    borrower: VALID_STELLAR_ADDRESS_2,
+    principal: "500",
+    accruedInterest: "8.25",
+    collateralAmount: "750",
+    collateralAsset: USDC_ISSUER_ADDRESS,
+    healthFactor: 1.8,
+    borrowedAt: BASE_DATE,
+    lastAccrualAt: UPDATED_DATE,
+    ...overrides,
+  };
+}
+
+export function createTransaction(
+  overrides?: Partial<Transaction>,
+): Transaction {
+  return {
+    id: nextUUID(),
+    type: "deposit",
+    hash: VALID_TX_HASH,
+    from: VALID_STELLAR_ADDRESS,
+    to: USDC_ISSUER_ADDRESS,
+    amount: "1000",
+    asset: "USDC",
+    status: "confirmed",
+    timestamp: BASE_DATE,
+    ...overrides,
+  };
+}
+
+export function createOraclePrice(
+  overrides?: Partial<OraclePrice>,
+): OraclePrice {
+  return {
+    asset: "USDC",
+    assetAddress: USDC_ISSUER_ADDRESS,
+    priceUSD: "1.00",
+    timestamp: UPDATED_DATE,
+    source: "stellarx-oracle",
+    confidence: 99,
+    ...overrides,
+  };
+}

--- a/akkuea-defi-rwa/apps/shared/src/testing/index.ts
+++ b/akkuea-defi-rwa/apps/shared/src/testing/index.ts
@@ -1,0 +1,3 @@
+export * from "./constants";
+export * from "./factories";
+export * from "./scenarios";

--- a/akkuea-defi-rwa/apps/shared/src/testing/scenarios.ts
+++ b/akkuea-defi-rwa/apps/shared/src/testing/scenarios.ts
@@ -1,0 +1,181 @@
+/**
+ * Staging scenarios — pre-built fixtures that represent realistic
+ * launch-grade data flows for smoke testing and integration tests.
+ */
+import {
+  createUser,
+  createProperty,
+  createLendingPool,
+  createDepositPosition,
+  createBorrowPosition,
+  createTransaction,
+  createKycDocument,
+} from "./factories";
+import { VALID_STELLAR_ADDRESS, VALID_STELLAR_ADDRESS_2 } from "./constants";
+
+// ---------------------------------------------------------------------------
+// Miami property tokenisation scenario
+// ---------------------------------------------------------------------------
+
+const miamiOwner = createUser({ displayName: "Miami Owner" });
+const miamiProperty = createProperty({
+  owner: miamiOwner.walletAddress,
+  totalShares: 2000,
+  availableShares: 1870,
+  pricePerShare: "1000",
+  totalValue: "2000000",
+});
+
+const investor1 = createUser({
+  displayName: "Investor A",
+  email: "investorA@example.com",
+});
+const investor2 = createUser({
+  displayName: "Investor B",
+  email: "investorB@example.com",
+});
+const investor3 = createUser({
+  displayName: "Investor C",
+  email: "investorC@example.com",
+});
+
+export const MIAMI_PROPERTY_SCENARIO = {
+  owner: miamiOwner,
+  property: miamiProperty,
+  investors: [
+    { user: investor1, shares: 50 },
+    { user: investor2, shares: 30 },
+    { user: investor3, shares: 50 },
+  ],
+  transactions: [
+    createTransaction({
+      type: "buy_shares",
+      from: investor1.walletAddress,
+      amount: "50000",
+    }),
+    createTransaction({
+      type: "buy_shares",
+      from: investor2.walletAddress,
+      amount: "30000",
+    }),
+    createTransaction({
+      type: "buy_shares",
+      from: investor3.walletAddress,
+      amount: "50000",
+    }),
+  ],
+} as const;
+
+// ---------------------------------------------------------------------------
+// USDC lending pool scenario
+// ---------------------------------------------------------------------------
+
+const usdcPool = createLendingPool({
+  name: "USDC Main Pool",
+  totalDeposits: "110000",
+  totalBorrows: "35000",
+  availableLiquidity: "75000",
+  utilizationRate: 31.8,
+  supplyAPY: 6.5,
+  borrowAPY: 9.2,
+});
+
+export const USDC_LENDING_SCENARIO = {
+  pool: usdcPool,
+  depositors: [
+    {
+      user: createUser({ displayName: "Depositor A" }),
+      position: createDepositPosition({
+        poolId: usdcPool.id,
+        amount: "50000",
+        shares: "50000",
+        accruedInterest: "325.00",
+      }),
+    },
+    {
+      user: createUser({ displayName: "Depositor B" }),
+      position: createDepositPosition({
+        poolId: usdcPool.id,
+        amount: "35000",
+        shares: "35000",
+        accruedInterest: "210.00",
+      }),
+    },
+    {
+      user: createUser({ displayName: "Depositor C" }),
+      position: createDepositPosition({
+        poolId: usdcPool.id,
+        amount: "25000",
+        shares: "25000",
+        accruedInterest: "150.00",
+      }),
+    },
+  ],
+  borrowers: [
+    {
+      user: createUser({
+        displayName: "Borrower A",
+        walletAddress: VALID_STELLAR_ADDRESS,
+      }),
+      position: createBorrowPosition({
+        poolId: usdcPool.id,
+        principal: "20000",
+        collateralAmount: "30000",
+        healthFactor: 1.8,
+        accruedInterest: "184.00",
+      }),
+    },
+    {
+      user: createUser({
+        displayName: "Borrower B",
+        walletAddress: VALID_STELLAR_ADDRESS_2,
+      }),
+      position: createBorrowPosition({
+        poolId: usdcPool.id,
+        principal: "15000",
+        collateralAmount: "18000",
+        healthFactor: 1.2,
+        accruedInterest: "138.00",
+      }),
+    },
+  ],
+} as const;
+
+// ---------------------------------------------------------------------------
+// User onboarding progression scenario
+// ---------------------------------------------------------------------------
+
+export const USER_ONBOARDING_SCENARIO = {
+  newUser: createUser({
+    displayName: "New User",
+    kycStatus: "not_started",
+    kycTier: "none",
+    kycDocuments: [],
+    email: undefined,
+  }),
+  pendingUser: createUser({
+    displayName: "Pending User",
+    kycStatus: "pending",
+    kycTier: "basic",
+    kycDocuments: [
+      createKycDocument({ status: "pending", reviewedAt: undefined }),
+    ],
+  }),
+  verifiedUser: createUser({
+    displayName: "Verified User",
+    kycStatus: "approved",
+    kycTier: "verified",
+    kycDocuments: [createKycDocument({ status: "approved" })],
+  }),
+  rejectedUser: createUser({
+    displayName: "Rejected User",
+    kycStatus: "rejected",
+    kycTier: "none",
+    kycDocuments: [
+      createKycDocument({
+        status: "rejected",
+        rejectionReason: "Document expired",
+      }),
+    ],
+  }),
+} as const;

--- a/akkuea-defi-rwa/apps/webapp/src/components/transactions/__tests__/TransactionHistory.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/components/transactions/__tests__/TransactionHistory.test.ts
@@ -1,33 +1,10 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type {
-  Transaction,
-  PaginatedTransactionResponse,
+import type { PaginatedTransactionResponse } from "@real-estate-defi/shared";
+import {
+  VALID_TX_HASH,
+  createTransaction,
 } from "@real-estate-defi/shared";
 import { transactionsApi } from "@/services/api";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const VALID_STELLAR_ADDRESS =
-  "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU";
-
-const VALID_TX_HASH =
-  "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-
-function makeTx(overrides: Partial<Transaction> = {}): Transaction {
-  return {
-    id: "550e8400-e29b-41d4-a716-446655440001",
-    type: "deposit",
-    hash: VALID_TX_HASH,
-    from: VALID_STELLAR_ADDRESS,
-    amount: "10000",
-    asset: "USDC",
-    status: "confirmed",
-    timestamp: "2024-01-15T10:00:00Z",
-    ...overrides,
-  };
-}
 
 const STELLAR_EXPERT_BASE = "https://stellar.expert/explorer/testnet/tx";
 
@@ -38,8 +15,8 @@ const STELLAR_EXPERT_BASE = "https://stellar.expert/explorer/testnet/tx";
 const mockGetTransactions = mock(
   async (): Promise<PaginatedTransactionResponse> => ({
     items: [
-      makeTx(),
-      makeTx({ id: "550e8400-e29b-41d4-a716-446655440002", type: "borrow" }),
+      createTransaction(),
+      createTransaction({ id: "550e8400-e29b-41d4-a716-446655440002", type: "borrow" }),
     ],
     nextCursor: undefined,
     total: 2,
@@ -80,7 +57,7 @@ describe("TransactionHistory — service integration", () => {
     // Simulate slow API
     mockGetTransactions.mockImplementationOnce(async () => {
       await new Promise((r) => setTimeout(r, 50));
-      return { items: [makeTx()], nextCursor: undefined, total: 1 };
+      return { items: [createTransaction()], nextCursor: undefined, total: 1 };
     });
 
     const result = await transactionsApi.getTransactions({});
@@ -122,7 +99,7 @@ describe("TransactionHistory — service integration", () => {
   it("load more fetches next page with cursor", async () => {
     // Page 1 — has nextCursor
     mockGetTransactions.mockImplementationOnce(async () => ({
-      items: [makeTx({ id: "page1-001" })],
+      items: [createTransaction({ id: "page1-001" })],
       nextCursor: "cursor_after_page1",
       total: 3,
     }));
@@ -133,7 +110,7 @@ describe("TransactionHistory — service integration", () => {
 
     // Page 2 — uses cursor from page 1
     mockGetTransactions.mockImplementationOnce(async () => ({
-      items: [makeTx({ id: "page2-001" }), makeTx({ id: "page2-002" })],
+      items: [createTransaction({ id: "page2-001" }), createTransaction({ id: "page2-002" })],
       nextCursor: undefined,
       total: 3,
     }));
@@ -162,7 +139,7 @@ describe("TransactionHistory — service integration", () => {
       "dividend",
     ] as const;
     for (const type of types) {
-      const tx = makeTx({ type });
+      const tx = createTransaction({ type });
       expect(tx.type).toBe(type);
     }
   });
@@ -176,7 +153,7 @@ describe("TransactionHistory — service integration", () => {
       "not_found",
     ] as const;
     for (const status of statuses) {
-      const tx = makeTx({ status });
+      const tx = createTransaction({ status });
       expect(tx.status).toBe(status);
     }
   });

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/__tests__/useHealthFactor.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/__tests__/useHealthFactor.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { useHealthFactor } from "../useHealthFactor";
 import type { BorrowPosition } from "@real-estate-defi/shared";
-
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-const VALID_STELLAR_ADDRESS =
-  "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU";
+import { createBorrowPosition } from "@real-estate-defi/shared";
 
 /**
  * useHealthFactor is a pure useMemo hook — calling it with a React ref is
@@ -55,19 +49,7 @@ function computeHealthFactor(borrows: BorrowPosition[]) {
 }
 
 function makeBorrow(overrides: Partial<BorrowPosition> = {}): BorrowPosition {
-  return {
-    id: "borrow-001",
-    poolId: "550e8400-e29b-41d4-a716-446655440001",
-    borrower: VALID_STELLAR_ADDRESS,
-    principal: "10000",
-    accruedInterest: "0",
-    collateralAmount: "20000",
-    collateralAsset: VALID_STELLAR_ADDRESS,
-    healthFactor: 2.0,
-    borrowedAt: "2024-01-15T10:00:00Z",
-    lastAccrualAt: "2024-01-15T10:00:00Z",
-    ...overrides,
-  };
+  return createBorrowPosition({ principal: "10000", accruedInterest: "0", healthFactor: 2.0, ...overrides });
 }
 
 // ---------------------------------------------------------------------------

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/__tests__/useLendingPools.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/__tests__/useLendingPools.test.ts
@@ -1,39 +1,30 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { LendingPool, DepositPosition } from "@real-estate-defi/shared";
+import {
+  VALID_STELLAR_ADDRESS,
+  createLendingPool,
+  createDepositPosition,
+} from "@real-estate-defi/shared";
 import { lendingApi } from "@/services/api";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const VALID_STELLAR_ADDRESS =
-  "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU";
-
-const mockPool: LendingPool = {
-  id: "550e8400-e29b-41d4-a716-446655440001",
+const mockPool = createLendingPool({
   name: "USDC Stable Pool",
   asset: "USDC",
-  assetAddress: VALID_STELLAR_ADDRESS,
   totalDeposits: "5000000",
   totalBorrows: "3600000",
   availableLiquidity: "1400000",
   utilizationRate: 72,
   supplyAPY: 5.2,
   borrowAPY: 7.8,
-  collateralFactor: 75,
-  liquidationThreshold: 80,
-  liquidationPenalty: 5,
-  reserveFactor: 1000,
-  isActive: true,
-  isPaused: false,
-  createdAt: "2024-01-01T00:00:00Z",
-};
+});
 
-const mockPool2: LendingPool = {
-  id: "550e8400-e29b-41d4-a716-446655440002",
+const mockPool2 = createLendingPool({
   name: "XLM Native Pool",
   asset: "XLM",
-  assetAddress: VALID_STELLAR_ADDRESS,
   totalDeposits: "2000000",
   totalBorrows: "1300000",
   availableLiquidity: "700000",
@@ -41,13 +32,7 @@ const mockPool2: LendingPool = {
   supplyAPY: 4.5,
   borrowAPY: 6.5,
   collateralFactor: 70,
-  liquidationThreshold: 80,
-  liquidationPenalty: 5,
-  reserveFactor: 1000,
-  isActive: true,
-  isPaused: false,
-  createdAt: "2024-01-02T00:00:00Z",
-};
+});
 
 // ---------------------------------------------------------------------------
 // Direct tests of lendingApi — mirrors the unit-test approach used by the
@@ -113,16 +98,12 @@ describe("useLendingPools — service integration", () => {
   });
 
   it("fetches user deposit positions per pool when address is provided", async () => {
-    const mockDeposit: DepositPosition = {
-      id: "dep-001",
+    const mockDeposit = createDepositPosition({
       poolId: mockPool.id,
-      depositor: VALID_STELLAR_ADDRESS,
       amount: "25000",
       shares: "25000",
-      depositedAt: "2024-01-15T10:00:00Z",
-      lastAccrualAt: "2024-01-15T10:00:00Z",
       accruedInterest: "12.5",
-    };
+    });
 
     mockGetUserDeposits.mockImplementationOnce(
       async (): Promise<DepositPosition[]> => [mockDeposit],

--- a/akkuea-defi-rwa/apps/webapp/src/services/api/__tests__/lending.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/services/api/__tests__/lending.test.ts
@@ -6,10 +6,13 @@ import type {
   DepositPosition,
   LendingPool,
 } from "@real-estate-defi/shared";
-
-// Valid Stellar address for tests
-const VALID_STELLAR_ADDRESS =
-  "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU";
+import {
+  VALID_STELLAR_ADDRESS,
+  VALID_UUID,
+  createLendingPool,
+  createDepositPosition,
+  createBorrowPosition,
+} from "@real-estate-defi/shared";
 
 describe("Lending API", () => {
   beforeEach(() => {
@@ -23,11 +26,9 @@ describe("Lending API", () => {
   describe("getPools", () => {
     it("fetches all lending pools", async () => {
       const mockPools: LendingPool[] = [
-        {
-          id: "550e8400-e29b-41d4-a716-446655440001",
+        createLendingPool({
           name: "USD Pool",
           asset: "USD",
-          assetAddress: VALID_STELLAR_ADDRESS,
           totalDeposits: "1000000",
           totalBorrows: "500000",
           availableLiquidity: "500000",
@@ -35,18 +36,10 @@ describe("Lending API", () => {
           supplyAPY: 2.5,
           borrowAPY: 5.0,
           collateralFactor: 60,
-          liquidationThreshold: 80,
-          liquidationPenalty: 5,
-          reserveFactor: 1000,
-          isActive: true,
-          isPaused: false,
-          createdAt: "2024-01-01T00:00:00Z",
-        },
-        {
-          id: "550e8400-e29b-41d4-a716-446655440002",
+        }),
+        createLendingPool({
           name: "EUR Pool",
           asset: "EUR",
-          assetAddress: VALID_STELLAR_ADDRESS,
           totalDeposits: "2000000",
           totalBorrows: "1200000",
           availableLiquidity: "800000",
@@ -55,12 +48,7 @@ describe("Lending API", () => {
           borrowAPY: 6.5,
           collateralFactor: 65,
           liquidationThreshold: 85,
-          liquidationPenalty: 5,
-          reserveFactor: 1000,
-          isActive: true,
-          isPaused: false,
-          createdAt: "2024-01-02T00:00:00Z",
-        },
+        }),
       ];
 
       const { fetchMock, calls } = setupMockFetch({
@@ -79,11 +67,9 @@ describe("Lending API", () => {
 
   describe("getPool", () => {
     it("fetches pool by ID", async () => {
-      const mockPool: LendingPool = {
-        id: "550e8400-e29b-41d4-a716-446655440001",
+      const mockPool = createLendingPool({
         name: "USD Pool",
         asset: "USD",
-        assetAddress: VALID_STELLAR_ADDRESS,
         totalDeposits: "1000000",
         totalBorrows: "500000",
         availableLiquidity: "500000",
@@ -91,13 +77,7 @@ describe("Lending API", () => {
         supplyAPY: 2.5,
         borrowAPY: 5.0,
         collateralFactor: 60,
-        liquidationThreshold: 80,
-        liquidationPenalty: 5,
-        reserveFactor: 1000,
-        isActive: true,
-        isPaused: false,
-        createdAt: "2024-01-01T00:00:00Z",
-      };
+      });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -106,7 +86,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.getPool(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
       );
 
       expect(result).toEqual(mockPool);
@@ -124,16 +104,7 @@ describe("Lending API", () => {
         amount: 1000,
       };
 
-      const mockResponse: DepositPosition = {
-        id: "550e8400-e29b-41d4-a716-446655440010",
-        poolId: "550e8400-e29b-41d4-a716-446655440001",
-        depositor: VALID_STELLAR_ADDRESS,
-        amount: "1000",
-        shares: "1000",
-        depositedAt: "2024-01-15T10:00:00Z",
-        lastAccrualAt: "2024-01-15T10:00:00Z",
-        accruedInterest: "12.5",
-      };
+      const mockResponse = createDepositPosition({ accruedInterest: "12.5" });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -142,7 +113,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.deposit(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         depositPayload,
       );
 
@@ -169,18 +140,11 @@ describe("Lending API", () => {
         borrowAmount: 5000,
       };
 
-      const mockResponse: BorrowPosition = {
-        id: "550e8400-e29b-41d4-a716-446655440020",
-        poolId: "550e8400-e29b-41d4-a716-446655440001",
-        borrower: VALID_STELLAR_ADDRESS,
+      const mockResponse = createBorrowPosition({
         principal: "5000",
         accruedInterest: "0",
         collateralAmount: "10000",
-        collateralAsset: VALID_STELLAR_ADDRESS,
-        healthFactor: 1.8,
-        borrowedAt: "2024-01-15T12:00:00Z",
-        lastAccrualAt: "2024-01-15T12:00:00Z",
-      };
+      });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -189,7 +153,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.borrow(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         borrowPayload,
       );
 
@@ -211,16 +175,7 @@ describe("Lending API", () => {
 
   describe("withdraw", () => {
     it("withdraws from pool", async () => {
-      const mockResponse: DepositPosition = {
-        id: "550e8400-e29b-41d4-a716-446655440010",
-        poolId: "550e8400-e29b-41d4-a716-446655440001",
-        depositor: VALID_STELLAR_ADDRESS,
-        amount: "500",
-        shares: "500",
-        depositedAt: "2024-01-15T10:00:00Z",
-        lastAccrualAt: "2024-01-15T10:00:00Z",
-        accruedInterest: "12.5",
-      };
+      const mockResponse = createDepositPosition({ amount: "500", shares: "500", accruedInterest: "12.5" });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -229,7 +184,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.withdraw(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         {
           userAddress: VALID_STELLAR_ADDRESS,
           amount: 500,
@@ -251,18 +206,12 @@ describe("Lending API", () => {
 
   describe("repay", () => {
     it("repays a borrow position", async () => {
-      const mockResponse: BorrowPosition = {
-        id: "550e8400-e29b-41d4-a716-446655440020",
-        poolId: "550e8400-e29b-41d4-a716-446655440001",
-        borrower: VALID_STELLAR_ADDRESS,
+      const mockResponse = createBorrowPosition({
         principal: "4500",
         accruedInterest: "10",
         collateralAmount: "9000",
-        collateralAsset: VALID_STELLAR_ADDRESS,
         healthFactor: 1.9,
-        borrowedAt: "2024-01-15T12:00:00Z",
-        lastAccrualAt: "2024-01-15T12:00:00Z",
-      };
+      });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -271,7 +220,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.repay(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         {
           userAddress: VALID_STELLAR_ADDRESS,
           amount: 500,
@@ -294,26 +243,8 @@ describe("Lending API", () => {
   describe("getUserDeposits", () => {
     it("gets user deposit positions", async () => {
       const mockDeposits: DepositPosition[] = [
-        {
-          id: "550e8400-e29b-41d4-a716-446655440030",
-          poolId: "550e8400-e29b-41d4-a716-446655440001",
-          depositor: VALID_STELLAR_ADDRESS,
-          amount: "1000",
-          shares: "1000",
-          depositedAt: "2024-01-10T08:00:00Z",
-          lastAccrualAt: "2024-01-15T08:00:00Z",
-          accruedInterest: "5.2",
-        },
-        {
-          id: "550e8400-e29b-41d4-a716-446655440031",
-          poolId: "550e8400-e29b-41d4-a716-446655440001",
-          depositor: VALID_STELLAR_ADDRESS,
-          amount: "2000",
-          shares: "2000",
-          depositedAt: "2024-01-12T10:00:00Z",
-          lastAccrualAt: "2024-01-15T10:00:00Z",
-          accruedInterest: "8.1",
-        },
+        createDepositPosition({ accruedInterest: "5.2" }),
+        createDepositPosition({ amount: "2000", shares: "2000", accruedInterest: "8.1" }),
       ];
 
       const { fetchMock, calls } = setupMockFetch({
@@ -323,7 +254,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.getUserDeposits(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         VALID_STELLAR_ADDRESS,
       );
 
@@ -338,18 +269,12 @@ describe("Lending API", () => {
   describe("getUserBorrows", () => {
     it("gets user borrow positions", async () => {
       const mockBorrows: BorrowPosition[] = [
-        {
-          id: "550e8400-e29b-41d4-a716-446655440040",
-          poolId: "550e8400-e29b-41d4-a716-446655440001",
-          borrower: VALID_STELLAR_ADDRESS,
+        createBorrowPosition({
           principal: "5000",
           accruedInterest: "21",
           collateralAmount: "10000",
-          collateralAsset: VALID_STELLAR_ADDRESS,
           healthFactor: 1.75,
-          borrowedAt: "2024-01-08T14:00:00Z",
-          lastAccrualAt: "2024-01-15T14:00:00Z",
-        },
+        }),
       ];
 
       const { fetchMock, calls } = setupMockFetch({
@@ -359,7 +284,7 @@ describe("Lending API", () => {
       global.fetch = fetchMock;
 
       const result = await lendingApi.getUserBorrows(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         VALID_STELLAR_ADDRESS,
       );
 

--- a/akkuea-defi-rwa/apps/webapp/src/services/api/__tests__/properties.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/services/api/__tests__/properties.test.ts
@@ -2,10 +2,7 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { propertyApi } from "../properties";
 import { setupMockFetch, wrapFetchMock } from "./helpers";
 import type { PropertyInfo, ShareOwnership } from "@real-estate-defi/shared";
-
-// Valid Stellar address for tests
-const VALID_STELLAR_ADDRESS =
-  "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU";
+import { VALID_STELLAR_ADDRESS, VALID_UUID, createProperty } from "@real-estate-defi/shared";
 
 describe("Property API", () => {
   beforeEach(() => {
@@ -18,58 +15,16 @@ describe("Property API", () => {
 
   describe("getAll", () => {
     it("fetches all properties with pagination", async () => {
-      const mockResponse: {
-        data: PropertyInfo[];
-        pagination: {
-          page: number;
-          limit: number;
-          total: number;
-          totalPages: number;
-        };
-      } = {
+      const mockResponse = {
         data: [
-          {
-            id: "550e8400-e29b-41d4-a716-446655440001",
-            name: "Property 1",
-            description: "A beautiful residential property in downtown",
-            propertyType: "residential",
-            location: {
-              address: "123 Main St",
-              city: "New York",
-              country: "USA",
-              postalCode: "10001",
-            },
-            totalValue: "1000000",
-            totalShares: 1000,
-            availableShares: 500,
-            pricePerShare: "1000",
-            images: ["https://example.com/image1.jpg"],
-            documents: [],
-            verified: true,
-            listedAt: "2024-01-01T00:00:00Z",
-            owner: VALID_STELLAR_ADDRESS,
-          },
-          {
-            id: "550e8400-e29b-41d4-a716-446655440002",
+          createProperty({ name: "Property 1" }),
+          createProperty({
             name: "Property 2",
-            description: "A commercial property in the business district",
             propertyType: "commercial",
-            location: {
-              address: "456 Business Ave",
-              city: "Los Angeles",
-              country: "USA",
-              postalCode: "90001",
-            },
             totalValue: "2000000",
             totalShares: 2000,
             availableShares: 1500,
-            pricePerShare: "1000",
-            images: ["https://example.com/image2.jpg"],
-            documents: [],
-            verified: true,
-            listedAt: "2024-01-02T00:00:00Z",
-            owner: VALID_STELLAR_ADDRESS,
-          },
+          }),
         ],
         pagination: {
           page: 1,
@@ -138,26 +93,7 @@ describe("Property API", () => {
 
   describe("getById", () => {
     it("fetches property by ID", async () => {
-      const mockProperty: PropertyInfo = {
-        id: "550e8400-e29b-41d4-a716-446655440001",
-        name: "Test Property",
-        description: "A test property for unit testing purposes",
-        propertyType: "residential",
-        location: {
-          address: "123 Test St",
-          city: "Test City",
-          country: "USA",
-        },
-        totalValue: "1000000",
-        totalShares: 1000,
-        availableShares: 800,
-        pricePerShare: "1000",
-        images: ["https://example.com/test.jpg"],
-        documents: [],
-        verified: true,
-        listedAt: "2024-01-01T00:00:00Z",
-        owner: VALID_STELLAR_ADDRESS,
-      };
+      const mockProperty = createProperty({ name: "Test Property", availableShares: 800 });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -165,13 +101,11 @@ describe("Property API", () => {
       });
       global.fetch = fetchMock;
 
-      const result = await propertyApi.getById(
-        "550e8400-e29b-41d4-a716-446655440001",
-      );
+      const result = await propertyApi.getById(mockProperty.id);
 
       expect(result).toEqual(mockProperty);
       expect(calls[0].url).toBe(
-        "http://localhost:3001/properties/550e8400-e29b-41d4-a716-446655440001",
+        `http://localhost:3001/properties/${mockProperty.id}`,
       );
       expect(calls[0].options.method).toBe("GET");
     });
@@ -195,22 +129,17 @@ describe("Property API", () => {
         images: ["https://example.com/image1.jpg"],
       };
 
-      const mockResponse: PropertyInfo = {
-        id: "550e8400-e29b-41d4-a716-446655440001",
+      const mockResponse = createProperty({
         name: createPayload.name,
         description: createPayload.description,
-        propertyType: "residential",
         location: createPayload.location,
         totalValue: createPayload.totalValue,
         totalShares: createPayload.totalShares,
         availableShares: createPayload.totalShares,
         pricePerShare: createPayload.pricePerShare,
         images: createPayload.images,
-        documents: [],
         verified: false,
-        listedAt: "2024-01-15T10:00:00Z",
-        owner: VALID_STELLAR_ADDRESS,
-      };
+      });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 201,
@@ -243,7 +172,7 @@ describe("Property API", () => {
       global.fetch = fetchMock;
 
       const result = await propertyApi.tokenize(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
       );
 
       expect(result).toEqual(mockResponse);
@@ -268,7 +197,7 @@ describe("Property API", () => {
       global.fetch = fetchMock;
 
       const result = await propertyApi.buyShares(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         VALID_STELLAR_ADDRESS,
         50,
       );
@@ -291,7 +220,7 @@ describe("Property API", () => {
   describe("getShares", () => {
     it("gets user share holdings for a property", async () => {
       const mockShareOwnership: ShareOwnership = {
-        propertyId: "550e8400-e29b-41d4-a716-446655440001",
+        propertyId: VALID_UUID,
         owner: VALID_STELLAR_ADDRESS,
         shares: 100,
         purchasePrice: "10000",
@@ -305,7 +234,7 @@ describe("Property API", () => {
       global.fetch = fetchMock;
 
       const result = await propertyApi.getShares(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         VALID_STELLAR_ADDRESS,
       );
 
@@ -325,7 +254,7 @@ describe("Property API", () => {
       global.fetch = fetchMock;
 
       const result = await propertyApi.getShares(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
         VALID_STELLAR_ADDRESS,
       );
 

--- a/akkuea-defi-rwa/apps/webapp/src/services/api/__tests__/users.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/services/api/__tests__/users.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { userApi } from "../users";
 import { setupMockFetch, wrapFetchMock } from "./helpers";
 import type { KycDocument, Transaction, User } from "@real-estate-defi/shared";
-
-// Valid Stellar address for tests
-const VALID_STELLAR_ADDRESS =
-  "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU";
+import {
+  VALID_STELLAR_ADDRESS,
+  VALID_UUID,
+  createUser,
+  createTransaction,
+  createKycDocument,
+} from "@real-estate-defi/shared";
 
 describe("User API", () => {
   beforeEach(() => {
@@ -18,17 +21,7 @@ describe("User API", () => {
 
   describe("getByWallet", () => {
     it("fetches user by wallet address", async () => {
-      const mockUser: User = {
-        id: "550e8400-e29b-41d4-a716-446655440001",
-        walletAddress: VALID_STELLAR_ADDRESS,
-        email: "user@example.com",
-        displayName: "Test User",
-        kycStatus: "pending",
-        kycTier: "none",
-        kycDocuments: [],
-        createdAt: "2024-01-01T00:00:00Z",
-        updatedAt: "2024-01-01T00:00:00Z",
-      };
+      const mockUser = createUser({ kycStatus: "pending", kycTier: "none" });
 
       const { fetchMock, calls } = setupMockFetch({
         status: 200,
@@ -55,17 +48,7 @@ describe("User API", () => {
 
       const mockResponse: { token: string; user: User } = {
         token: "auth-token-123",
-        user: {
-          id: "550e8400-e29b-41d4-a716-446655440001",
-          walletAddress: VALID_STELLAR_ADDRESS,
-          email: "user@example.com",
-          displayName: "Test User",
-          kycStatus: "pending",
-          kycTier: "none",
-          kycDocuments: [],
-          createdAt: "2024-01-01T00:00:00Z",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
+        user: createUser({ kycStatus: "pending", kycTier: "none" }),
       };
 
       const { fetchMock, calls } = setupMockFetch({
@@ -93,28 +76,8 @@ describe("User API", () => {
   describe("getTransactions", () => {
     it("fetches user transactions", async () => {
       const mockTransactions: Transaction[] = [
-        {
-          id: "550e8400-e29b-41d4-a716-446655440010",
-          type: "deposit",
-          hash: "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
-          from: VALID_STELLAR_ADDRESS,
-          to: VALID_STELLAR_ADDRESS,
-          amount: "1000",
-          asset: "USDC",
-          status: "confirmed",
-          timestamp: "2024-01-15T10:00:00Z",
-        },
-        {
-          id: "550e8400-e29b-41d4-a716-446655440011",
-          type: "borrow",
-          hash: "def456abc123def456abc123def456abc123def456abc123def456abc123defg",
-          from: VALID_STELLAR_ADDRESS,
-          to: VALID_STELLAR_ADDRESS,
-          amount: "500",
-          asset: "USDC",
-          status: "pending",
-          timestamp: "2024-01-15T12:00:00Z",
-        },
+        createTransaction({ type: "deposit", amount: "1000" }),
+        createTransaction({ type: "borrow", amount: "500", status: "pending" }),
       ];
 
       const { fetchMock, calls } = setupMockFetch({
@@ -137,7 +100,7 @@ describe("User API", () => {
     it("fetches user portfolio", async () => {
       const mockPortfolio = {
         properties: [
-          { propertyId: "550e8400-e29b-41d4-a716-446655440001", shares: 10 },
+          { propertyId: VALID_UUID, shares: 10 },
           { propertyId: "550e8400-e29b-41d4-a716-446655440002", shares: 5 },
         ],
         deposits: [
@@ -178,7 +141,7 @@ describe("User API", () => {
       global.fetch = fetchMock;
 
       const result = await userApi.getKycStatus(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
       );
 
       expect(result).toEqual(mockKycStatus);
@@ -192,7 +155,7 @@ describe("User API", () => {
   describe("submitKyc", () => {
     it("submits KYC for verification", async () => {
       const submitPayload = {
-        userId: "550e8400-e29b-41d4-a716-446655440001",
+        userId: VALID_UUID,
         documents: [
           {
             type: "passport" as const,
@@ -226,16 +189,7 @@ describe("User API", () => {
   describe("getKycDocuments", () => {
     it("fetches user KYC documents", async () => {
       const mockDocuments: KycDocument[] = [
-        {
-          id: "550e8400-e29b-41d4-a716-446655440020",
-          userId: "550e8400-e29b-41d4-a716-446655440001",
-          type: "passport",
-          fileName: "passport.pdf",
-          fileUrl: "https://example.com/doc.pdf",
-          status: "approved",
-          uploadedAt: "2024-01-10T08:00:00Z",
-          reviewedAt: "2024-01-12T10:00:00Z",
-        },
+        createKycDocument(),
       ];
 
       const { fetchMock, calls } = setupMockFetch({
@@ -245,7 +199,7 @@ describe("User API", () => {
       global.fetch = fetchMock;
 
       const result = await userApi.getKycDocuments(
-        "550e8400-e29b-41d4-a716-446655440001",
+        VALID_UUID,
       );
 
       expect(result).toEqual(mockDocuments);

--- a/akkuea-defi-rwa/docs/testing/smoke-tests.md
+++ b/akkuea-defi-rwa/docs/testing/smoke-tests.md
@@ -1,0 +1,120 @@
+# Smoke Tests & Test Fixtures
+
+## What are smoke tests?
+
+Smoke tests verify that the most critical user flows work end-to-end after a deployment. They are **not** exhaustive — they confirm the app boots, connects to dependencies, and can handle a "happy path" request.
+
+Run smoke tests:
+- After every deploy to staging/production
+- Before a release candidate is tagged
+- When infrastructure changes (DB migrations, env vars, new services)
+
+## Running tests
+
+```bash
+# All workspaces
+bun test --workspaces
+
+# Shared package only
+cd apps/shared && bun test
+
+# API only
+cd apps/api && bun test
+```
+
+## Shared test utilities
+
+All testing helpers live in `apps/shared/src/testing/` and are re-exported from the package root.
+
+### Constants
+
+```ts
+import {
+  VALID_STELLAR_ADDRESS,
+  VALID_UUID,
+  NON_EXISTENT_UUID,
+  BASE_DATE,
+  VALID_TX_HASH,
+} from "@real-estate-defi/shared";
+```
+
+These replace locally-duplicated values like `const VALID_STELLAR_ADDRESS = "G..."` that appear across test files.
+
+### Factories
+
+Each factory returns a schema-compliant object with realistic defaults and accepts `Partial<T>` overrides:
+
+```ts
+import { createUser, createProperty, createLendingPool } from "@real-estate-defi/shared";
+
+// Defaults — approved KYC user with Miami address
+const user = createUser();
+
+// Override specific fields
+const pendingUser = createUser({
+  kycStatus: "pending",
+  kycTier: "basic",
+});
+
+// Property with custom valuation
+const property = createProperty({ totalValue: "5000000" });
+```
+
+Available factories:
+- `createUser(overrides?)`
+- `createKycDocument(overrides?)`
+- `createPropertyLocation(overrides?)`
+- `createProperty(overrides?)`
+- `createLendingPool(overrides?)`
+- `createDepositPosition(overrides?)`
+- `createBorrowPosition(overrides?)`
+- `createTransaction(overrides?)`
+- `createOraclePrice(overrides?)`
+
+Call `resetFactorySequence()` between test suites if you need deterministic IDs.
+
+### Staging scenarios
+
+Pre-composed fixtures that represent realistic product states:
+
+```ts
+import {
+  MIAMI_PROPERTY_SCENARIO,
+  USDC_LENDING_SCENARIO,
+  USER_ONBOARDING_SCENARIO,
+} from "@real-estate-defi/shared";
+
+// Miami property with owner, 3 investors, and purchase transactions
+const { owner, property, investors, transactions } = MIAMI_PROPERTY_SCENARIO;
+
+// USDC pool with 3 depositors and 2 borrowers at different health factors
+const { pool, depositors, borrowers } = USDC_LENDING_SCENARIO;
+
+// User progression: new -> pending -> verified -> rejected
+const { newUser, pendingUser, verifiedUser, rejectedUser } = USER_ONBOARDING_SCENARIO;
+```
+
+## Example: API route test
+
+```ts
+import { describe, it, expect } from "bun:test";
+import { createUser, VALID_UUID } from "@real-estate-defi/shared";
+
+describe("GET /users/:id", () => {
+  it("should return user data", async () => {
+    const expected = createUser({ id: VALID_UUID });
+    // ... seed DB, make request, assert shape matches expected
+  });
+});
+```
+
+## Example: Webapp component test
+
+```ts
+import { createProperty, MIAMI_PROPERTY_SCENARIO } from "@real-estate-defi/shared";
+
+test("PropertyCard renders price", () => {
+  const property = createProperty({ totalValue: "3500000" });
+  // ... render component with property, assert "$3,500,000" visible
+});
+```


### PR DESCRIPTION
# feat(shared): Launch-grade test harnesses and staging fixtures (C3-004)     
 Closes: #720                                                                                
 
  ## Summary                                                                    
  - Add shared test constants, factories (`create<Type>(overrides?)`), and
  staging scenarios to `apps/shared/src/testing/`
  - Migrate 11 test files across API and webapp to use shared utilities,
  eliminating duplicated inline test data
  - Add smoke test documentation at `docs/testing/smoke-tests.md`

  ## Changes
  - **4 new files:** `constants.ts`, `factories.ts`, `scenarios.ts`, `index.ts`
  in `apps/shared/src/testing/`
  - **1 new doc:** `docs/testing/smoke-tests.md`
  - **5 API tests modified:** `lending`, `kyc`, `positions`, `properties`,
  `tokenization` — replaced inline constants with shared imports
  - **6 webapp tests modified:** `TransactionHistory`, `useHealthFactor`,
  `useLendingPools`, `lending`, `properties`, `users` — replaced inline
  constants, mock objects, and local factories (`makeTx`, `makeBorrow`) with
  shared factories
  - **Net diff:** +633 / −356 lines

  ## Test plan
  - [ ] `cd apps/shared && bun test` — existing tests still pass
  - [ ] `cd apps/api && bun test` — API tests pass with shared imports
  - [ ] `cd apps/webapp && bun test` — webapp tests pass with shared factories
  - [ ] Verify `import { createUser, MIAMI_PROPERTY_SCENARIO } from
  "@real-estate-defi/shared"` resolves correctly
