### PR TITLE
Feat/c3 005 rate limiting

### DIFF
--- a/akkuea-defi-rwa/apps/api/src/middleware/index.ts
+++ b/akkuea-defi-rwa/apps/api/src/middleware/index.ts
@@ -1,5 +1,6 @@
 export * from './errorHandler';
 export * from './requestLogger';
+export { rateLimit } from './rateLimit';
 export {
   validate,
   validateBody,

--- a/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { rateLimit } from './rateLimit';
+
+function createMockRequest(options: {
+  headers?: Record<string, string>;
+} = {}) {
+  const headers = new Headers(options.headers ?? {});
+  return {
+    headers,
+  } as unknown as Request;
+}
+
+function createMockSet() {
+  const set = {
+    status: undefined as number | string | undefined,
+    headers: undefined as Record<string, string> | undefined,
+  };
+  return set;
+}
+
+describe('rateLimit middleware', () => {
+  describe('basic rate limiting', () => {
+    it('should allow requests under the limit', () => {
+      const middleware = rateLimit({ max: 10, windowMs: 60000 });
+      const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.2.1' } });
+      const set = createMockSet();
+
+      const result = middleware({ request, set });
+
+      expect(result).toBeUndefined();
+      expect(set.status).toBeUndefined();
+    });
+
+    it('should block requests over the limit', () => {
+      const middleware = rateLimit({ max: 3, windowMs: 60000 });
+      const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.2.2' } });
+      const set = createMockSet();
+
+      middleware({ request, set }); // 1st request
+      middleware({ request, set }); // 2nd request
+      middleware({ request, set }); // 3rd request
+      const result = middleware({ request, set }); // 4th request - should be blocked
+
+      expect(result).toEqual({
+        success: false,
+        error: 'RATE_LIMITED',
+        message: 'Too many requests. Please try again later.',
+      });
+      expect(set.status).toBe(429);
+    });
+
+    it('should set rate limit headers', () => {
+      const middleware = rateLimit({ max: 10, windowMs: 60000 });
+      const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.3.1' } });
+      const set = createMockSet();
+
+      middleware({ request, set });
+
+      expect(set.headers).toBeDefined();
+      expect(set.headers!['X-RateLimit-Limit']).toBe('10');
+      expect(set.headers!['X-RateLimit-Remaining']).toBe('9');
+      expect(set.headers!['X-RateLimit-Reset']).toBeDefined();
+    });
+  });
+
+  describe('identifier differentiation', () => {
+    it('should track anonymous users by IP', () => {
+      const middleware = rateLimit({ max: 2, windowMs: 60000 });
+
+      const request1 = createMockRequest({ headers: { 'x-forwarded-for': '198.51.100.1' } });
+      const request2 = createMockRequest({ headers: { 'x-forwarded-for': '198.51.100.2' } });
+      const set1 = createMockSet();
+      const set2 = createMockSet();
+
+      middleware({ request: request1, set: set1 }); // 1st for IP1
+      middleware({ request: request1, set: set1 }); // 2nd for IP1 - blocked
+      const result2 = middleware({ request: request2, set: set2 }); // 1st for IP2 - should be allowed
+
+      expect(result2).toBeUndefined();
+    });
+
+    it('should track authenticated users by x-user-address header', () => {
+      const middleware = rateLimit({ max: 2, windowMs: 60000 });
+
+      const request1 = createMockRequest({
+        headers: { 'x-user-address': 'GAAAAAAA123456789', 'x-forwarded-for': '192.0.2.1' },
+      });
+      const request2 = createMockRequest({
+        headers: { 'x-user-address': 'GBBBBBB987654321', 'x-forwarded-for': '192.0.2.1' },
+      });
+      const set1 = createMockSet();
+      const set2 = createMockSet();
+
+      middleware({ request: request1, set: set1 }); // 1st for user A
+      middleware({ request: request1, set: set1 }); // 2nd for user A - blocked
+      const result2 = middleware({ request: request2, set: set2 }); // 1st for user B - should be allowed
+
+      expect(result2).toBeUndefined();
+    });
+
+    it('should prioritize user address over IP for authenticated requests', () => {
+      const middleware = rateLimit({ max: 1, windowMs: 60000 });
+
+      const request = createMockRequest({
+        headers: {
+          'x-user-address': 'GCCCCCC555555555',
+          'x-forwarded-for': '192.0.2.100',
+        },
+      });
+      const set1 = createMockSet();
+      const set2 = createMockSet();
+
+      middleware({ request, set: set1 }); // 1st request
+      const result = middleware({ request, set: set2 }); // 2nd request - should be blocked since same user
+
+      expect(result).toEqual({
+        success: false,
+        error: 'RATE_LIMITED',
+        message: 'Too many requests. Please try again later.',
+      });
+    });
+  });
+
+  describe('Retry-After header', () => {
+    it('should set Retry-After header when rate limited', () => {
+      const middleware = rateLimit({ max: 1, windowMs: 60000 });
+      const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.5.1' } });
+      const set = createMockSet();
+
+      middleware({ request, set }); // 1st request
+      middleware({ request, set }); // 2nd request - blocked
+
+      expect(set.headers!['Retry-After']).toBeDefined();
+      expect(Number(set.headers!['Retry-After'])).toBeGreaterThan(0);
+    });
+  });
+
+  describe('custom keyGenerator', () => {
+    it('should use custom key generator when provided', () => {
+      const middleware = rateLimit({
+        max: 1,
+        windowMs: 60000,
+        keyGenerator: (req) => `custom:${req.headers.get('x-api-key') ?? 'unknown'}`,
+      });
+
+      const request1 = createMockRequest({ headers: { 'x-api-key': 'key1', 'x-forwarded-for': '192.0.2.1' } });
+      const request2 = createMockRequest({ headers: { 'x-api-key': 'key2', 'x-forwarded-for': '192.0.2.1' } });
+      const set1 = createMockSet();
+      const set2 = createMockSet();
+
+      middleware({ request: request1, set: set1 }); // 1st with key1
+      const result2 = middleware({ request: request2, set: set2 }); // 1st with key2 - should be allowed
+
+      expect(result2).toBeUndefined();
+    });
+  });
+
+  describe('default values', () => {
+    it('should use default max of 10 and window of 60000ms', () => {
+      const middleware = rateLimit();
+      const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.7.1' } });
+      const set = createMockSet();
+
+      middleware({ request, set });
+
+      expect(set.headers!['X-RateLimit-Limit']).toBe('10');
+      expect(set.headers!['X-RateLimit-Remaining']).toBe('9');
+    });
+  });
+});

--- a/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { rateLimit } from './rateLimit';
 
 function createMockRequest(options: {

--- a/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.ts
+++ b/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.ts
@@ -1,0 +1,103 @@
+interface RateLimitOptions {
+  windowMs?: number;
+  max?: number;
+  keyGenerator?: (request: Request) => string;
+}
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const DEFAULT_WINDOW_MS = 60000;
+const DEFAULT_MAX = 10;
+
+function getClientIP(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    return forwarded.split(',')[0].trim();
+  }
+  return request.headers.get('x-real-ip') ?? 'unknown';
+}
+
+function getIdentifier(request: Request, keyGenerator?: (request: Request) => string): string {
+  if (keyGenerator) {
+    return keyGenerator(request);
+  }
+  const userAddress = request.headers.get('x-user-address');
+  if (userAddress) {
+    return `user:${userAddress}`;
+  }
+  return `ip:${getClientIP(request)}`;
+}
+
+function createRateLimitStore() {
+  const store = new Map<string, RateLimitEntry>();
+
+  function cleanup() {
+    const now = Date.now();
+    for (const [key, entry] of store.entries()) {
+      if (now >= entry.resetAt) {
+        store.delete(key);
+      }
+    }
+  }
+
+  function checkLimit(identifier: string, windowMs: number, max: number): {
+    allowed: boolean;
+    remaining: number;
+    resetAt: number;
+    retryAfter?: number;
+  } {
+    cleanup();
+    const now = Date.now();
+    const entry = store.get(identifier);
+
+    if (!entry || now >= entry.resetAt) {
+      const resetAt = now + windowMs;
+      store.set(identifier, { count: 1, resetAt });
+      return { allowed: true, remaining: max - 1, resetAt };
+    }
+
+    entry.count += 1;
+    const remaining = Math.max(0, max - entry.count);
+
+    if (entry.count > max) {
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      return { allowed: false, remaining: 0, resetAt: entry.resetAt, retryAfter };
+    }
+
+    return { allowed: true, remaining, resetAt: entry.resetAt };
+  }
+
+  return { checkLimit };
+}
+
+export function rateLimit(options: RateLimitOptions = {}) {
+  const { windowMs = DEFAULT_WINDOW_MS, max = DEFAULT_MAX, keyGenerator } = options;
+  const store = createRateLimitStore();
+
+  return function rateLimitMiddleware({ request, set }: { request: Request; set: { status?: number | string; headers?: Record<string, string> } }) {
+    const identifier = getIdentifier(request, keyGenerator);
+    const result = store.checkLimit(identifier, windowMs, max);
+
+    set.headers = {
+      ...(set.headers ?? {}),
+      'X-RateLimit-Limit': String(max),
+      'X-RateLimit-Remaining': String(result.remaining),
+      'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
+    };
+
+    if (!result.allowed) {
+      set.status = 429;
+      if (result.retryAfter) {
+        set.headers['Retry-After'] = String(result.retryAfter);
+      }
+      return {
+        success: false,
+        error: 'RATE_LIMITED',
+        message: 'Too many requests. Please try again later.',
+      };
+    }
+  };
+}

--- a/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.ts
+++ b/akkuea-defi-rwa/apps/api/src/middleware/rateLimit.ts
@@ -15,7 +15,7 @@ const DEFAULT_MAX = 10;
 function getClientIP(request: Request): string {
   const forwarded = request.headers.get('x-forwarded-for');
   if (forwarded) {
-    return forwarded.split(',')[0].trim();
+    return forwarded.split(',')[0]?.trim() ?? 'unknown';
   }
   return request.headers.get('x-real-ip') ?? 'unknown';
 }
@@ -77,7 +77,8 @@ export function rateLimit(options: RateLimitOptions = {}) {
   const { windowMs = DEFAULT_WINDOW_MS, max = DEFAULT_MAX, keyGenerator } = options;
   const store = createRateLimitStore();
 
-  return function rateLimitMiddleware({ request, set }: { request: Request; set: { status?: number | string; headers?: Record<string, string> } }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function rateLimitMiddleware({ request, set }: any) {
     const identifier = getIdentifier(request, keyGenerator);
     const result = store.checkLimit(identifier, windowMs, max);
 

--- a/akkuea-defi-rwa/apps/api/src/routes/kyc.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/kyc.ts
@@ -1,6 +1,7 @@
 import { Elysia } from 'elysia';
 import { KYCController } from '../controllers/KYCController';
 import { ApiError } from '../errors/ApiError';
+import { rateLimit } from '../middleware';
 
 const DOCUMENT_TYPES = [
   'passport',
@@ -105,43 +106,7 @@ export const kycRoutes = new Elysia({ prefix: '/kyc' })
         return handleKycError(error, set);
       }
     },
-    {
-      beforeHandle: [
-        async ({ request, set }) => {
-          const forwarded = request.headers.get('x-forwarded-for');
-          const key = forwarded?.split(',')[0]?.trim() ?? 'unknown';
-          const windowMs = 60 * 1000;
-          const max = 10;
-          type RateLimitEntry = { count: number; resetAt: number };
-          const globalStore = globalThis as typeof globalThis & {
-            __kycUploadRateLimit?: Map<string, RateLimitEntry>;
-          };
-          const store: Map<string, RateLimitEntry> =
-            globalStore.__kycUploadRateLimit ?? new Map<string, RateLimitEntry>();
-          globalStore.__kycUploadRateLimit = store;
-          const now = Date.now();
-          const entry = store.get(key);
-          if (!entry) {
-            store.set(key, { count: 1, resetAt: now + windowMs });
-            return;
-          }
-          if (now >= entry.resetAt) {
-            entry.count = 1;
-            entry.resetAt = now + windowMs;
-            return;
-          }
-          entry.count += 1;
-          if (entry.count > max) {
-            set.status = 429;
-            return {
-              success: false,
-              error: 'TOO_MANY_REQUESTS',
-              message: 'Too many upload requests. Please try again later.',
-            };
-          }
-        },
-      ],
-    },
+    { beforeHandle: [rateLimit()] },
   )
   .post('/submit', async ({ body, set }) => {
     try {
@@ -157,7 +122,7 @@ export const kycRoutes = new Elysia({ prefix: '/kyc' })
     } catch (error) {
       return handleKycError(error, set);
     }
-  })
+  }, { beforeHandle: [rateLimit()] })
   .post('/verify/:documentId', async ({ params: { documentId }, body, set }) => {
     try {
       return await KYCController.verifyDocument(

--- a/akkuea-defi-rwa/apps/api/src/routes/kyc.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/kyc.ts
@@ -145,7 +145,7 @@ export const kycRoutes = new Elysia({ prefix: '/kyc' })
       const { buffer, contentType, fileName } = await KYCController.getDocumentFile(documentId);
       set.headers['Content-Type'] = contentType;
       set.headers['Content-Disposition'] = `inline; filename="${fileName}"`;
-      return new Response(buffer, {
+      return new Response(new Uint8Array(buffer), {
         status: 200,
         headers: {
           'Content-Type': contentType,

--- a/akkuea-defi-rwa/apps/api/src/routes/lending.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/lending.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 import { z } from 'zod';
-import { validate, uuidParamSchema, paginationQuerySchema } from '../middleware';
+import { validate, uuidParamSchema, paginationQuerySchema, rateLimit } from '../middleware';
 import { LendingController } from '../controllers/LendingController';
 import { positionService } from '../services/PositionService';
 
@@ -55,7 +55,7 @@ export const lendingRoutes = new Elysia({ prefix: '/lending' })
 
   // POST /pools - Create pool (auth required)
   .use(validate({ body: createPoolSchema }))
-  .post('/pools', async (ctx) => LendingController.createPool(ctx))
+  .post('/pools', async (ctx) => LendingController.createPool(ctx), { beforeHandle: [rateLimit()] })
 
   // GET /pools/:id - Get single pool
   .use(validate({ params: poolIdParamSchema }))
@@ -63,19 +63,19 @@ export const lendingRoutes = new Elysia({ prefix: '/lending' })
 
   // POST /pools/:id/deposit - Deposit into pool (auth required)
   .use(validate({ body: depositSchema }))
-  .post('/pools/:id/deposit', async (ctx) => LendingController.deposit(ctx))
+  .post('/pools/:id/deposit', async (ctx) => LendingController.deposit(ctx), { beforeHandle: [rateLimit()] })
 
   // POST /pools/:id/withdraw - Withdraw from pool (auth required)
   .use(validate({ body: withdrawSchema }))
-  .post('/pools/:id/withdraw', async (ctx) => LendingController.withdraw(ctx))
+  .post('/pools/:id/withdraw', async (ctx) => LendingController.withdraw(ctx), { beforeHandle: [rateLimit()] })
 
   // POST /pools/:id/borrow - Borrow from pool (auth required)
   .use(validate({ body: borrowSchema }))
-  .post('/pools/:id/borrow', async (ctx) => LendingController.borrow(ctx))
+  .post('/pools/:id/borrow', async (ctx) => LendingController.borrow(ctx), { beforeHandle: [rateLimit()] })
 
   // POST /pools/:id/repay - Repay loan (auth required)
   .use(validate({ body: repaySchema }))
-  .post('/pools/:id/repay', async (ctx) => LendingController.repay(ctx))
+  .post('/pools/:id/repay', async (ctx) => LendingController.repay(ctx), { beforeHandle: [rateLimit()] })
 
   // GET /pools/:id/user/:address/deposits - Get user deposits
   .use(validate({ params: poolUserParamsSchema }))

--- a/akkuea-defi-rwa/apps/api/src/routes/properties.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/properties.ts
@@ -7,6 +7,7 @@ import {
   uuidParamSchema,
   paginationQuerySchema,
   ownerParamSchema,
+  rateLimit,
 } from '../middleware';
 import { PropertyController } from '../controllers/PropertyController';
 import { handleError, UnauthorizedError } from '../utils/errors';
@@ -88,7 +89,7 @@ const createPropertyRoute = new Elysia()
       set.status = errorResponse.statusCode;
       return errorResponse;
     }
-  });
+  }, { beforeHandle: [rateLimit()] });
 
 // PUT /properties/:id - update property
 const updatePropertyRoute = new Elysia()
@@ -145,7 +146,7 @@ const tokenizePropertyRoute = new Elysia()
       set.status = errorResponse.statusCode;
       return errorResponse;
     }
-  });
+  }, { beforeHandle: [rateLimit()] });
 
 // POST /properties/:id/buy-shares - buy property shares
 const buySharesRoute = new Elysia()
@@ -167,7 +168,7 @@ const buySharesRoute = new Elysia()
       set.status = errorResponse.statusCode;
       return errorResponse;
     }
-  });
+  }, { beforeHandle: [rateLimit()] });
 
 // GET /properties/:id/shares/:owner - get user shares
 const getUserSharesRoute = new Elysia()

--- a/akkuea-defi-rwa/apps/api/src/routes/users.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 import { z } from 'zod';
-import { validate, uuidParamSchema } from '../middleware';
+import { validate, uuidParamSchema, rateLimit } from '../middleware';
 import { UserController } from '../controllers/UserController';
 
 const walletParamSchema = z.object({
@@ -50,4 +50,4 @@ export const userRoutes = new Elysia({ prefix: '/users' })
 
   // POST /users/auth - Authenticate by wallet (get or create)
   .use(validate({ body: authWalletSchema }))
-  .post('/auth', async (ctx) => UserController.authenticateByWallet(ctx));
+  .post('/auth', async (ctx) => UserController.authenticateByWallet(ctx), { beforeHandle: [rateLimit()] });

--- a/akkuea-defi-rwa/apps/api/src/routes/webhooks.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/webhooks.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { webhookController } from '../controllers/WebhookController';
 import type { WebhookPayload } from '../services/WebhookService';
+import { rateLimit } from '../middleware';
 
 export const webhookRoutes = new Elysia({ prefix: '/webhooks' })
     .post(
@@ -15,6 +16,7 @@ export const webhookRoutes = new Elysia({ prefix: '/webhooks' })
                 network: t.Optional(t.String()),
                 timestamp: t.Optional(t.String()),
             }),
+            beforeHandle: [rateLimit()],
             detail: {
                 summary: 'Handle transaction webhooks',
                 description: 'Receives notifications from Stellar network and updates transaction status',


### PR DESCRIPTION
Closes: #721 
- Added reusable rateLimit() middleware with configurable thresholds
- Tracks authenticated users via x-user-address header, anonymous by IP
- Returns 429 with RATE_LIMITED error code when exceeded
- Adds X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset headers
