### PR TITLE
feat: add live property and market updates with freshness indicators

### DIFF
--- a/akkuea-defi-rwa/apps/webapp/src/app/lending/page.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/app/lending/page.tsx
@@ -26,6 +26,7 @@ import {
   CardContent,
   Button,
   Badge,
+  FreshnessIndicator,
   Input,
   Modal,
 } from "@/components/ui";
@@ -196,9 +197,16 @@ function StatCardSkeleton() {
 export default function LendingPage() {
   const { isConnected, connect, isConnecting, address } = useWallet();
 
-  const { pools, userPositions, isLoading, error, refetch } = useLendingPools(
-    isConnected ? address : null,
-  );
+  const {
+    pools,
+    userPositions,
+    isLoading,
+    error,
+    refetch,
+    connectionStatus,
+    lastUpdatedAt,
+    isPolling,
+  } = useLendingPools(isConnected ? address : null);
 
   // Flatten all borrow positions across all pools for health factor computation
   const allBorrows = useMemo(
@@ -393,8 +401,16 @@ export default function LendingPage() {
             className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
           >
             <div>
-              <h1 className="text-2xl font-bold text-white">DeFi Lending</h1>
-              <p className="text-sm text-neutral-500 mt-1">
+              <div className="flex items-center gap-3 mb-1">
+                <h1 className="text-2xl font-bold text-white">DeFi Lending</h1>
+                <FreshnessIndicator
+                  lastUpdatedAt={lastUpdatedAt}
+                  connectionStatus={connectionStatus}
+                  isPolling={isPolling}
+                  onRefresh={refetch}
+                />
+              </div>
+              <p className="text-sm text-neutral-500">
                 Supply liquidity to earn yields or borrow against your RWA
                 collateral
               </p>

--- a/akkuea-defi-rwa/apps/webapp/src/app/marketplace/page.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/app/marketplace/page.tsx
@@ -33,6 +33,7 @@ import {
   Badge,
   Button,
   Card,
+  FreshnessIndicator,
   Input,
   SkeletonPropertyCard,
 } from "@/components/ui";
@@ -218,7 +219,15 @@ function PropertyCard({
 }
 
 export default function MarketplacePage() {
-  const { properties, isLoading, error, refetch } = useProperties();
+  const {
+    properties,
+    isLoading,
+    error,
+    refetch,
+    connectionStatus,
+    lastUpdatedAt,
+    isPolling,
+  } = useProperties();
   const { isConnected, connect, isConnecting, address } = useWallet();
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -356,15 +365,23 @@ export default function MarketplacePage() {
 
           <motion.div
             variants={staggerItem}
-            className="flex items-center justify-between"
+            className="flex flex-wrap items-center justify-between gap-4"
           >
-            <p className="font-mono text-xs text-neutral-500">
-              Showing{" "}
-              <span className="font-medium text-white">
-                {filteredProperties.length}
-              </span>{" "}
-              properties
-            </p>
+            <div className="flex items-center gap-4">
+              <p className="font-mono text-xs text-neutral-500">
+                Showing{" "}
+                <span className="font-medium text-white">
+                  {filteredProperties.length}
+                </span>{" "}
+                properties
+              </p>
+              <FreshnessIndicator
+                lastUpdatedAt={lastUpdatedAt}
+                connectionStatus={connectionStatus}
+                isPolling={isPolling}
+                onRefresh={() => void refetch()}
+              />
+            </div>
             {!isConnected && (
               <p className="text-xs text-neutral-500">
                 Connect your wallet to unlock investing.

--- a/akkuea-defi-rwa/apps/webapp/src/components/ui/FreshnessIndicator.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/components/ui/FreshnessIndicator.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Wifi, WifiOff, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ConnectionStatus } from "@/hooks/useLiveUpdates";
+import { getTimeSinceUpdate } from "@/hooks/useLiveUpdates";
+
+interface FreshnessIndicatorProps {
+  lastUpdatedAt: Date | null;
+  connectionStatus: ConnectionStatus;
+  isPolling?: boolean;
+  onRefresh?: () => void;
+  className?: string;
+  showLabel?: boolean;
+}
+
+const statusConfig: Record<
+  ConnectionStatus,
+  { color: string; bgColor: string; label: string }
+> = {
+  connected: {
+    color: "text-emerald-400",
+    bgColor: "bg-emerald-500/10 border-emerald-500/30",
+    label: "Live",
+  },
+  connecting: {
+    color: "text-amber-400",
+    bgColor: "bg-amber-500/10 border-amber-500/30",
+    label: "Connecting",
+  },
+  disconnected: {
+    color: "text-neutral-500",
+    bgColor: "bg-neutral-500/10 border-neutral-500/30",
+    label: "Offline",
+  },
+};
+
+export function FreshnessIndicator({
+  lastUpdatedAt,
+  connectionStatus,
+  isPolling = false,
+  onRefresh,
+  className,
+  showLabel = true,
+}: FreshnessIndicatorProps) {
+  const [timeSince, setTimeSince] = useState(() =>
+    getTimeSinceUpdate(lastUpdatedAt),
+  );
+
+  useEffect(() => {
+    setTimeSince(getTimeSinceUpdate(lastUpdatedAt));
+
+    const interval = setInterval(() => {
+      setTimeSince(getTimeSinceUpdate(lastUpdatedAt));
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [lastUpdatedAt]);
+
+  const config = statusConfig[connectionStatus];
+  const StatusIcon =
+    connectionStatus === "disconnected"
+      ? WifiOff
+      : connectionStatus === "connecting"
+        ? RefreshCw
+        : Wifi;
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-2.5 py-1",
+        config.bgColor,
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+      aria-label={`Data status: ${config.label}. Last updated: ${timeSince}`}
+    >
+      <StatusIcon
+        className={cn(
+          "h-3 w-3",
+          config.color,
+          connectionStatus === "connecting" && "animate-spin",
+        )}
+        aria-hidden="true"
+      />
+
+      {showLabel && (
+        <span className={cn("text-[10px] font-medium", config.color)}>
+          {isPolling && connectionStatus === "connected"
+            ? "Polling"
+            : config.label}
+        </span>
+      )}
+
+      <span className="text-[10px] text-neutral-500">{timeSince}</span>
+
+      {onRefresh && connectionStatus !== "connecting" && (
+        <button
+          onClick={onRefresh}
+          className="ml-1 rounded p-0.5 hover:bg-white/10 transition-colors"
+          aria-label="Refresh data"
+        >
+          <RefreshCw className="h-3 w-3 text-neutral-500 hover:text-white" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/akkuea-defi-rwa/apps/webapp/src/components/ui/FreshnessIndicator.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/components/ui/FreshnessIndicator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Wifi, WifiOff, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ConnectionStatus } from "@/hooks/useLiveUpdates";
@@ -44,19 +44,21 @@ export function FreshnessIndicator({
   className,
   showLabel = true,
 }: FreshnessIndicatorProps) {
-  const [timeSince, setTimeSince] = useState(() =>
-    getTimeSinceUpdate(lastUpdatedAt),
-  );
+  // Use a tick counter to force periodic recalculation of timeSince
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
-    setTimeSince(getTimeSinceUpdate(lastUpdatedAt));
-
     const interval = setInterval(() => {
-      setTimeSince(getTimeSinceUpdate(lastUpdatedAt));
+      setTick((t) => t + 1);
     }, 10000);
-
     return () => clearInterval(interval);
-  }, [lastUpdatedAt]);
+  }, []);
+
+  // Derive timeSince from lastUpdatedAt and tick (tick forces recalculation)
+  const timeSince = useMemo(
+    () => getTimeSinceUpdate(lastUpdatedAt),
+    [lastUpdatedAt, tick],
+  );
 
   const config = statusConfig[connectionStatus];
   const StatusIcon =

--- a/akkuea-defi-rwa/apps/webapp/src/components/ui/index.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/components/ui/index.ts
@@ -6,6 +6,7 @@ export * from "./Badge";
 export * from "./Loader";
 export * from "./Toggle";
 export * from "./Stepper";
+export * from "./FreshnessIndicator";
 export {
   Skeleton,
   SkeletonText,

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { getTimeSinceUpdate } from "@/hooks/useLiveUpdates";
+
+describe("useLiveUpdates — utility functions", () => {
+  describe("getTimeSinceUpdate", () => {
+    it("returns 'Never' for null date", () => {
+      expect(getTimeSinceUpdate(null)).toBe("Never");
+    });
+
+    it("returns 'Just now' for dates less than 5 seconds ago", () => {
+      const now = new Date();
+      const result = getTimeSinceUpdate(now);
+      expect(result).toBe("Just now");
+    });
+
+    it("returns seconds for dates 5-59 seconds ago", () => {
+      const thirtySecondsAgo = new Date(Date.now() - 30 * 1000);
+      const result = getTimeSinceUpdate(thirtySecondsAgo);
+      expect(result).toMatch(/^\d+s ago$/);
+    });
+
+    it("returns minutes for dates 1-59 minutes ago", () => {
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+      const result = getTimeSinceUpdate(fiveMinutesAgo);
+      expect(result).toMatch(/^\d+m ago$/);
+    });
+
+    it("returns hours for dates 1+ hours ago", () => {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      const result = getTimeSinceUpdate(twoHoursAgo);
+      expect(result).toMatch(/^\d+h ago$/);
+    });
+  });
+});
+
+describe("useLiveUpdates — polling behavior", () => {
+  let mockFetch: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    mockFetch = mock(async () => ({ data: "test" }));
+  });
+
+  it("fetch function is callable", async () => {
+    const result = await mockFetch();
+    expect(result).toEqual({ data: "test" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetch function can be called multiple times", async () => {
+    await mockFetch();
+    await mockFetch();
+    await mockFetch();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("fetch function handles errors gracefully", async () => {
+    const errorFetch = mock(async () => {
+      throw new Error("Network error");
+    });
+
+    let errorMessage: string | null = null;
+    try {
+      await errorFetch();
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : "Unknown error";
+    }
+
+    expect(errorMessage).toBe("Network error");
+  });
+});
+
+describe("useLiveUpdates — connection status types", () => {
+  it("connection status type values are valid", () => {
+    const validStatuses = ["connected", "connecting", "disconnected"];
+    validStatuses.forEach((status) => {
+      expect(["connected", "connecting", "disconnected"]).toContain(status);
+    });
+  });
+});

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/useLendingPools.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/useLendingPools.ts
@@ -7,10 +7,19 @@ import type {
   BorrowPosition,
 } from "@real-estate-defi/shared";
 import { lendingApi } from "@/services/api";
+import {
+  useLiveUpdates,
+  type ConnectionStatus,
+} from "@/hooks/useLiveUpdates";
 
 export interface UserPositions {
   deposits: DepositPosition[];
   borrows: BorrowPosition[];
+}
+
+export interface UseLendingPoolsOptions {
+  enableLiveUpdates?: boolean;
+  pollingInterval?: number;
 }
 
 export interface UseLendingPoolsReturn {
@@ -24,16 +33,31 @@ export interface UseLendingPoolsReturn {
   error: string | null;
   /** Re-trigger a full reload (pools + positions) */
   refetch: () => void;
+  /** Current connection status for live updates */
+  connectionStatus: ConnectionStatus;
+  /** Last time the data was updated */
+  lastUpdatedAt: Date | null;
+  /** Whether currently using fallback polling */
+  isPolling: boolean;
 }
+
+const SSE_ENDPOINT =
+  typeof process !== "undefined"
+    ? process.env?.NEXT_PUBLIC_LENDING_SSE_URL
+    : undefined;
 
 /**
  * Fetches all lending pools and the current user's positions in each pool.
  *
  * @param userAddress - Connected wallet address, or null/undefined when disconnected.
+ * @param options - Configuration options for live updates.
  */
 export function useLendingPools(
   userAddress?: string | null,
+  options: UseLendingPoolsOptions = {},
 ): UseLendingPoolsReturn {
+  const { enableLiveUpdates = true, pollingInterval = 30000 } = options;
+
   const [pools, setPools] = useState<LendingPool[]>([]);
   const [userPositions, setUserPositions] = useState<
     Record<string, UserPositions>
@@ -41,11 +65,30 @@ export function useLendingPools(
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fetchKey, setFetchKey] = useState(0);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
   /** Expose a refetch handle so consuming components can trigger a reload */
   const refetch = useCallback(() => {
     setFetchKey((k) => k + 1);
   }, []);
+
+  const fetchPoolsOnly = useCallback(async () => {
+    const fetchedPools = await lendingApi.getPools();
+    return fetchedPools;
+  }, []);
+
+  const { connectionStatus, isPolling, data: livePoolData, refresh } = useLiveUpdates(
+    fetchPoolsOnly,
+    {
+      endpoint: SSE_ENDPOINT,
+      pollingInterval,
+      enabled: enableLiveUpdates && !isLoading,
+      onUpdate: (updatedPools) => {
+        setPools(updatedPools);
+        setLastUpdatedAt(new Date());
+      },
+    },
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -59,6 +102,7 @@ export function useLendingPools(
         const fetchedPools = await lendingApi.getPools();
         if (cancelled) return;
         setPools(fetchedPools);
+        setLastUpdatedAt(new Date());
 
         // 2. If a wallet is connected, fetch user positions for every pool
         if (userAddress) {
@@ -102,5 +146,25 @@ export function useLendingPools(
     };
   }, [userAddress, fetchKey]);
 
-  return { pools, userPositions, isLoading, error, refetch };
+  useEffect(() => {
+    if (livePoolData && livePoolData.length > 0) {
+      setPools(livePoolData);
+    }
+  }, [livePoolData]);
+
+  const refetchWithLive = useCallback(() => {
+    refetch();
+    refresh();
+  }, [refetch, refresh]);
+
+  return {
+    pools,
+    userPositions,
+    isLoading,
+    error,
+    refetch: refetchWithLive,
+    connectionStatus,
+    lastUpdatedAt,
+    isPolling,
+  };
 }

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/useLiveUpdates.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/useLiveUpdates.ts
@@ -5,32 +5,20 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export type ConnectionStatus = "connected" | "connecting" | "disconnected";
 
 export interface LiveUpdateOptions<T> {
-  /** SSE endpoint URL for live updates */
   endpoint?: string;
-  /** Fallback polling interval in ms (default: 30000) */
   pollingInterval?: number;
-  /** Called when new data is received */
   onUpdate?: (data: T) => void;
-  /** Whether live updates are enabled */
   enabled?: boolean;
-  /** Maximum reconnection attempts before falling back to polling */
   maxReconnectAttempts?: number;
-  /** Delay between reconnection attempts in ms */
   reconnectDelay?: number;
 }
 
 export interface UseLiveUpdatesReturn<T> {
-  /** Current connection status */
   connectionStatus: ConnectionStatus;
-  /** Last update timestamp */
   lastUpdatedAt: Date | null;
-  /** Whether using fallback polling mode */
   isPolling: boolean;
-  /** Latest data received from live updates */
   data: T | null;
-  /** Manually trigger a refresh */
   refresh: () => void;
-  /** Re-establish connection */
   reconnect: () => void;
 }
 
@@ -66,16 +54,19 @@ export function useLiveUpdates<T>(
     null,
   );
   const mountedRef = useRef(true);
+  const onUpdateRef = useRef(onUpdate);
+  const connectSSERef = useRef<() => void>(() => {});
 
-  const updateData = useCallback(
-    (newData: T) => {
-      if (!mountedRef.current) return;
-      setData(newData);
-      setLastUpdatedAt(new Date());
-      onUpdate?.(newData);
-    },
-    [onUpdate],
-  );
+  useEffect(() => {
+    onUpdateRef.current = onUpdate;
+  }, [onUpdate]);
+
+  const updateData = useCallback((newData: T) => {
+    if (!mountedRef.current) return;
+    setData(newData);
+    setLastUpdatedAt(new Date());
+    onUpdateRef.current?.(newData);
+  }, []);
 
   const fetchData = useCallback(async () => {
     if (!mountedRef.current) return;
@@ -87,20 +78,6 @@ export function useLiveUpdates<T>(
     }
   }, [fetchFn, updateData]);
 
-  const startPolling = useCallback(() => {
-    if (pollingIntervalRef.current) return;
-
-    setIsPolling(true);
-    setConnectionStatus("connected");
-    fetchData();
-
-    pollingIntervalRef.current = setInterval(() => {
-      if (mountedRef.current) {
-        fetchData();
-      }
-    }, pollingInterval);
-  }, [fetchData, pollingInterval]);
-
   const stopPolling = useCallback(() => {
     if (pollingIntervalRef.current) {
       clearInterval(pollingIntervalRef.current);
@@ -109,6 +86,20 @@ export function useLiveUpdates<T>(
     setIsPolling(false);
   }, []);
 
+  const startPolling = useCallback(() => {
+    if (pollingIntervalRef.current) return;
+
+    setIsPolling(true);
+    setConnectionStatus("connected");
+    void fetchData();
+
+    pollingIntervalRef.current = setInterval(() => {
+      if (mountedRef.current) {
+        void fetchData();
+      }
+    }, pollingInterval);
+  }, [fetchData, pollingInterval]);
+
   const closeEventSource = useCallback(() => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -116,79 +107,63 @@ export function useLiveUpdates<T>(
     }
   }, []);
 
-  const connectSSE = useCallback(() => {
-    if (!endpoint || typeof window === "undefined") {
-      startPolling();
-      return;
-    }
-
-    closeEventSource();
-    setConnectionStatus("connecting");
-
-    try {
-      const eventSource = new EventSource(endpoint);
-      eventSourceRef.current = eventSource;
-
-      eventSource.onopen = () => {
-        if (!mountedRef.current) return;
-        setConnectionStatus("connected");
-        reconnectAttemptsRef.current = 0;
-        stopPolling();
-      };
-
-      eventSource.onmessage = (event) => {
-        if (!mountedRef.current) return;
-        try {
-          const parsedData = JSON.parse(event.data) as T;
-          updateData(parsedData);
-        } catch {
-          // Invalid JSON, ignore
-        }
-      };
-
-      eventSource.onerror = () => {
-        if (!mountedRef.current) return;
-
-        closeEventSource();
-        setConnectionStatus("disconnected");
-
-        if (reconnectAttemptsRef.current < maxReconnectAttempts) {
-          reconnectAttemptsRef.current += 1;
-          setConnectionStatus("connecting");
-
-          reconnectTimeoutRef.current = setTimeout(() => {
-            if (mountedRef.current) {
-              connectSSE();
-            }
-          }, reconnectDelay);
-        } else {
-          startPolling();
-        }
-      };
-    } catch {
-      startPolling();
-    }
-  }, [
-    endpoint,
-    closeEventSource,
-    stopPolling,
-    startPolling,
-    updateData,
-    maxReconnectAttempts,
-    reconnectDelay,
-  ]);
-
-  const reconnect = useCallback(() => {
-    reconnectAttemptsRef.current = 0;
-    stopPolling();
-    connectSSE();
-  }, [stopPolling, connectSSE]);
-
-  const refresh = useCallback(() => {
-    fetchData();
-  }, [fetchData]);
-
   useEffect(() => {
+    const connectSSE = () => {
+      if (!endpoint || typeof window === "undefined") {
+        startPolling();
+        return;
+      }
+
+      closeEventSource();
+      setConnectionStatus("connecting");
+
+      try {
+        const eventSource = new EventSource(endpoint);
+        eventSourceRef.current = eventSource;
+
+        eventSource.onopen = () => {
+          if (!mountedRef.current) return;
+          setConnectionStatus("connected");
+          reconnectAttemptsRef.current = 0;
+          stopPolling();
+        };
+
+        eventSource.onmessage = (event) => {
+          if (!mountedRef.current) return;
+          try {
+            const parsedData = JSON.parse(event.data) as T;
+            updateData(parsedData);
+          } catch {
+            // Invalid JSON, ignore
+          }
+        };
+
+        eventSource.onerror = () => {
+          if (!mountedRef.current) return;
+
+          closeEventSource();
+          setConnectionStatus("disconnected");
+
+          if (reconnectAttemptsRef.current < maxReconnectAttempts) {
+            reconnectAttemptsRef.current += 1;
+            setConnectionStatus("connecting");
+
+            reconnectTimeoutRef.current = setTimeout(() => {
+              if (mountedRef.current) {
+                connectSSERef.current();
+              }
+            }, reconnectDelay);
+          } else {
+            startPolling();
+          }
+        };
+      } catch {
+        startPolling();
+      }
+    };
+
+    connectSSERef.current = connectSSE;
+
     mountedRef.current = true;
 
     if (enabled) {
@@ -204,7 +179,26 @@ export function useLiveUpdates<T>(
         clearTimeout(reconnectTimeoutRef.current);
       }
     };
-  }, [enabled, connectSSE, closeEventSource, stopPolling]);
+  }, [
+    enabled,
+    endpoint,
+    closeEventSource,
+    stopPolling,
+    startPolling,
+    updateData,
+    maxReconnectAttempts,
+    reconnectDelay,
+  ]);
+
+  const reconnect = useCallback(() => {
+    reconnectAttemptsRef.current = 0;
+    stopPolling();
+    connectSSERef.current();
+  }, [stopPolling]);
+
+  const refresh = useCallback(() => {
+    void fetchData();
+  }, [fetchData]);
 
   return {
     connectionStatus,

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/useLiveUpdates.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/useLiveUpdates.ts
@@ -1,0 +1,234 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type ConnectionStatus = "connected" | "connecting" | "disconnected";
+
+export interface LiveUpdateOptions<T> {
+  /** SSE endpoint URL for live updates */
+  endpoint?: string;
+  /** Fallback polling interval in ms (default: 30000) */
+  pollingInterval?: number;
+  /** Called when new data is received */
+  onUpdate?: (data: T) => void;
+  /** Whether live updates are enabled */
+  enabled?: boolean;
+  /** Maximum reconnection attempts before falling back to polling */
+  maxReconnectAttempts?: number;
+  /** Delay between reconnection attempts in ms */
+  reconnectDelay?: number;
+}
+
+export interface UseLiveUpdatesReturn<T> {
+  /** Current connection status */
+  connectionStatus: ConnectionStatus;
+  /** Last update timestamp */
+  lastUpdatedAt: Date | null;
+  /** Whether using fallback polling mode */
+  isPolling: boolean;
+  /** Latest data received from live updates */
+  data: T | null;
+  /** Manually trigger a refresh */
+  refresh: () => void;
+  /** Re-establish connection */
+  reconnect: () => void;
+}
+
+const DEFAULT_POLLING_INTERVAL = 30000;
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 3;
+const DEFAULT_RECONNECT_DELAY = 2000;
+
+export function useLiveUpdates<T>(
+  fetchFn: () => Promise<T>,
+  options: LiveUpdateOptions<T> = {},
+): UseLiveUpdatesReturn<T> {
+  const {
+    endpoint,
+    pollingInterval = DEFAULT_POLLING_INTERVAL,
+    onUpdate,
+    enabled = true,
+    maxReconnectAttempts = DEFAULT_MAX_RECONNECT_ATTEMPTS,
+    reconnectDelay = DEFAULT_RECONNECT_DELAY,
+  } = options;
+
+  const [connectionStatus, setConnectionStatus] =
+    useState<ConnectionStatus>("disconnected");
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+  const [data, setData] = useState<T | null>(null);
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const mountedRef = useRef(true);
+
+  const updateData = useCallback(
+    (newData: T) => {
+      if (!mountedRef.current) return;
+      setData(newData);
+      setLastUpdatedAt(new Date());
+      onUpdate?.(newData);
+    },
+    [onUpdate],
+  );
+
+  const fetchData = useCallback(async () => {
+    if (!mountedRef.current) return;
+    try {
+      const result = await fetchFn();
+      updateData(result);
+    } catch {
+      // Silently fail on polling fetch errors
+    }
+  }, [fetchFn, updateData]);
+
+  const startPolling = useCallback(() => {
+    if (pollingIntervalRef.current) return;
+
+    setIsPolling(true);
+    setConnectionStatus("connected");
+    fetchData();
+
+    pollingIntervalRef.current = setInterval(() => {
+      if (mountedRef.current) {
+        fetchData();
+      }
+    }, pollingInterval);
+  }, [fetchData, pollingInterval]);
+
+  const stopPolling = useCallback(() => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+    setIsPolling(false);
+  }, []);
+
+  const closeEventSource = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  const connectSSE = useCallback(() => {
+    if (!endpoint || typeof window === "undefined") {
+      startPolling();
+      return;
+    }
+
+    closeEventSource();
+    setConnectionStatus("connecting");
+
+    try {
+      const eventSource = new EventSource(endpoint);
+      eventSourceRef.current = eventSource;
+
+      eventSource.onopen = () => {
+        if (!mountedRef.current) return;
+        setConnectionStatus("connected");
+        reconnectAttemptsRef.current = 0;
+        stopPolling();
+      };
+
+      eventSource.onmessage = (event) => {
+        if (!mountedRef.current) return;
+        try {
+          const parsedData = JSON.parse(event.data) as T;
+          updateData(parsedData);
+        } catch {
+          // Invalid JSON, ignore
+        }
+      };
+
+      eventSource.onerror = () => {
+        if (!mountedRef.current) return;
+
+        closeEventSource();
+        setConnectionStatus("disconnected");
+
+        if (reconnectAttemptsRef.current < maxReconnectAttempts) {
+          reconnectAttemptsRef.current += 1;
+          setConnectionStatus("connecting");
+
+          reconnectTimeoutRef.current = setTimeout(() => {
+            if (mountedRef.current) {
+              connectSSE();
+            }
+          }, reconnectDelay);
+        } else {
+          startPolling();
+        }
+      };
+    } catch {
+      startPolling();
+    }
+  }, [
+    endpoint,
+    closeEventSource,
+    stopPolling,
+    startPolling,
+    updateData,
+    maxReconnectAttempts,
+    reconnectDelay,
+  ]);
+
+  const reconnect = useCallback(() => {
+    reconnectAttemptsRef.current = 0;
+    stopPolling();
+    connectSSE();
+  }, [stopPolling, connectSSE]);
+
+  const refresh = useCallback(() => {
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (enabled) {
+      connectSSE();
+    }
+
+    return () => {
+      mountedRef.current = false;
+      closeEventSource();
+      stopPolling();
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+    };
+  }, [enabled, connectSSE, closeEventSource, stopPolling]);
+
+  return {
+    connectionStatus,
+    lastUpdatedAt,
+    isPolling,
+    data,
+    refresh,
+    reconnect,
+  };
+}
+
+export function getTimeSinceUpdate(lastUpdatedAt: Date | null): string {
+  if (!lastUpdatedAt) return "Never";
+
+  const now = new Date();
+  const diffMs = now.getTime() - lastUpdatedAt.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 5) return "Just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+
+  const diffHour = Math.floor(diffMin / 60);
+  return `${diffHour}h ago`;
+}

--- a/akkuea-defi-rwa/apps/webapp/src/hooks/useProperties.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/hooks/useProperties.ts
@@ -3,12 +3,24 @@
 import { useCallback, useEffect, useState } from "react";
 import type { PropertyInfo } from "@real-estate-defi/shared";
 import { propertyApi } from "@/services/api/properties";
+import {
+  useLiveUpdates,
+  type ConnectionStatus,
+} from "@/hooks/useLiveUpdates";
+
+interface UsePropertiesOptions {
+  enableLiveUpdates?: boolean;
+  pollingInterval?: number;
+}
 
 interface UsePropertiesResult {
   properties: PropertyInfo[];
   isLoading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
+  connectionStatus: ConnectionStatus;
+  lastUpdatedAt: Date | null;
+  isPolling: boolean;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -19,10 +31,20 @@ function getErrorMessage(error: unknown): string {
   return "We couldn't load marketplace properties. Please try again.";
 }
 
-export function useProperties(): UsePropertiesResult {
+const SSE_ENDPOINT =
+  typeof process !== "undefined"
+    ? process.env?.NEXT_PUBLIC_PROPERTIES_SSE_URL
+    : undefined;
+
+export function useProperties(
+  options: UsePropertiesOptions = {},
+): UsePropertiesResult {
+  const { enableLiveUpdates = true, pollingInterval = 30000 } = options;
+
   const [properties, setProperties] = useState<PropertyInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
   const fetchProperties = useCallback(async () => {
     setIsLoading(true);
@@ -33,21 +55,54 @@ export function useProperties(): UsePropertiesResult {
         limit: 100,
       });
       setProperties(response.data);
+      setLastUpdatedAt(new Date());
+      return response.data;
     } catch (fetchError) {
       setError(getErrorMessage(fetchError));
+      throw fetchError;
     } finally {
       setIsLoading(false);
     }
   }, []);
 
+  const { connectionStatus, isPolling, data, refresh } = useLiveUpdates(
+    async () => {
+      const response = await propertyApi.getAll({ limit: 100 });
+      return response.data;
+    },
+    {
+      endpoint: SSE_ENDPOINT,
+      pollingInterval,
+      enabled: enableLiveUpdates && !isLoading,
+      onUpdate: (updatedProperties) => {
+        setProperties(updatedProperties);
+        setLastUpdatedAt(new Date());
+      },
+    },
+  );
+
   useEffect(() => {
     void fetchProperties();
   }, [fetchProperties]);
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      setProperties(data);
+    }
+  }, [data]);
+
+  const refetch = useCallback(async () => {
+    await fetchProperties();
+    refresh();
+  }, [fetchProperties, refresh]);
 
   return {
     properties,
     isLoading,
     error,
-    refetch: fetchProperties,
+    refetch,
+    connectionStatus,
+    lastUpdatedAt,
+    isPolling,
   };
 }


### PR DESCRIPTION
Closes #719
## Summary

- Implements live updates for property valuation and lending pool data
- Adds connection status and freshness indicators to marketplace and lending pages
- Supports SSE with automatic reconnection and fallback to polling
- Gracefully degrades when realtime channel fails

## Root Cause

The webapp lacked realtime data capabilities, requiring users to manually refresh pages to see updated property valuations and lending pool data.

## Fix Implemented

1. **useLiveUpdates hook**: Generic subscription layer supporting SSE with configurable polling fallback, automatic reconnection (3 attempts), and stale-state recovery

2. **FreshnessIndicator component**: Shows connection status (Live/Polling/Offline), last-updated timestamp, and manual refresh button

3. **Extended data hooks**: `useProperties` and `useLendingPools` now expose `connectionStatus`, `lastUpdatedAt`, and `isPolling`

4. **Page integration**: Marketplace and lending pages display freshness indicators without layout shifts

## Testing Performed

- TypeScript diagnostics pass with no errors
- Unit tests added for `getTimeSinceUpdate()` utility
- Component follows existing accessibility patterns (aria-live, aria-label)

## CI Confirmation

All modified files pass TypeScript type checking.