### PR TITLE
feat(webapp,api): add admin property verification ops dashboard

### DIFF
--- a/akkuea-defi-rwa/apps/api/.env.example
+++ b/akkuea-defi-rwa/apps/api/.env.example
@@ -9,8 +9,8 @@ NODE_ENV=development
 WEBHOOK_SECRET=your_webhook_secret_here
 
 # Internal operations (property verification dashboard backend)
-# Must match INTERNAL_OPERATIONS_API_KEY on the Next.js server (webapp proxy).
-INTERNAL_OPERATIONS_API_KEY=generate-a-long-random-secret
+# Must match OPERATIONS_BACKEND_CREDENTIAL on the Next.js server (webapp proxy).
+OPERATIONS_BACKEND_CREDENTIAL=generate-a-long-random-secret
 
 # Soroban / Stellar Configuration
 REAL_ESTATE_TOKEN_CONTRACT_ID=your_real_estate_token_contract_id

--- a/akkuea-defi-rwa/apps/api/.env.example
+++ b/akkuea-defi-rwa/apps/api/.env.example
@@ -8,6 +8,10 @@ PORT=3001
 NODE_ENV=development
 WEBHOOK_SECRET=your_webhook_secret_here
 
+# Internal operations (property verification dashboard backend)
+# Must match INTERNAL_OPERATIONS_API_KEY on the Next.js server (webapp proxy).
+INTERNAL_OPERATIONS_API_KEY=generate-a-long-random-secret
+
 # Soroban / Stellar Configuration
 REAL_ESTATE_TOKEN_CONTRACT_ID=your_real_estate_token_contract_id
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/akkuea-defi-rwa/apps/api/drizzle/migrations/0002_property_review_operations.sql
+++ b/akkuea-defi-rwa/apps/api/drizzle/migrations/0002_property_review_operations.sql
@@ -1,0 +1,7 @@
+CREATE TYPE "public"."property_review_status" AS ENUM('pending_review', 'approved', 'rejected', 'changes_requested', 'on_hold');--> statement-breakpoint
+ALTER TABLE "properties" ADD COLUMN "review_status" "property_review_status" DEFAULT 'pending_review' NOT NULL;--> statement-breakpoint
+ALTER TABLE "properties" ADD COLUMN "last_review_note" text;--> statement-breakpoint
+ALTER TABLE "properties" ADD COLUMN "last_reviewed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "properties" ADD COLUMN "last_reviewer_wallet" varchar(56);--> statement-breakpoint
+UPDATE "properties" SET "review_status" = 'approved' WHERE "verified" = true;--> statement-breakpoint
+UPDATE "properties" SET "review_status" = 'pending_review' WHERE "verified" = false;

--- a/akkuea-defi-rwa/apps/api/drizzle/migrations/meta/_journal.json
+++ b/akkuea-defi-rwa/apps/api/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1769110547236,
       "tag": "0000_opposite_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1742832000000,
+      "tag": "0002_property_review_operations",
+      "breakpoints": true
     }
   ]
 }

--- a/akkuea-defi-rwa/apps/api/src/__tests__/errors.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/__tests__/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { NotFoundError as SharedNotFoundError } from '@real-estate-defi/shared';
 import {
   AppError,
   BadRequestError,
@@ -94,6 +95,15 @@ describe('Error Utilities', () => {
       expect(response.message).toBe('Invalid data');
       expect(response.statusCode).toBe(400);
       expect(response.timestamp).toBeDefined();
+    });
+
+    it('should handle shared package AppError subclasses', () => {
+      const error = new SharedNotFoundError('Property', 'abc');
+      const response = handleError(error);
+
+      expect(response.success).toBe(false);
+      expect(response.statusCode).toBe(404);
+      expect(response.message).toContain('abc');
     });
 
     it('should handle standard Error correctly', () => {

--- a/akkuea-defi-rwa/apps/api/src/app.ts
+++ b/akkuea-defi-rwa/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import { lendingRoutes } from './routes/lending';
 import { userRoutes } from './routes/users';
 import { kycRoutes } from './routes/kyc';
 import { webhookRoutes } from './routes/webhooks';
+import { internalOperationsRoutes } from './routes/internalOperations';
 import { errorHandler } from './middleware/errorHandler';
 import { requestLogger } from './middleware';
 
@@ -20,6 +21,7 @@ const app = new Elysia()
   .use(lendingRoutes)
   .use(userRoutes)
   .use(kycRoutes)
-  .use(webhookRoutes);
+  .use(webhookRoutes)
+  .use(internalOperationsRoutes);
 
 export default app;

--- a/akkuea-defi-rwa/apps/api/src/controllers/OperationalPropertyController.ts
+++ b/akkuea-defi-rwa/apps/api/src/controllers/OperationalPropertyController.ts
@@ -1,0 +1,245 @@
+import type { PropertyInfo, ValuationRecord } from '@real-estate-defi/shared';
+import { NotFoundError, ValidationError } from '@real-estate-defi/shared';
+import { PropertyController } from './PropertyController';
+import { propertyRepository, type PropertyReviewStatus } from '../repositories/PropertyRepository';
+import { userRepository } from '../repositories/UserRepository';
+import { OracleService } from '../services/OracleService';
+import type { Property } from '../db/schema';
+
+export type OperationsQueue = 'pending' | 'approved' | 'rejected' | 'hold' | 'changes' | 'all';
+
+export type ReviewAction = 'approve' | 'reject' | 'request_changes' | 'hold';
+
+export interface OperationalPropertyListItem {
+  id: string;
+  name: string;
+  propertyType: Property['propertyType'];
+  city: string;
+  country: string;
+  reviewStatus: PropertyReviewStatus;
+  verified: boolean;
+  ownerWallet: string;
+  ownerKycStatus: string;
+  ownerKycTier: string;
+  tokenized: boolean;
+  sorobanPropertyId: number | null;
+  valuationState: string;
+  documentCount: number;
+  readiness: {
+    kycApproved: boolean;
+    valuationActive: boolean;
+    hasTokenAddress: boolean;
+  };
+  lastReviewedAt: string | null;
+  lastReviewerWallet: string | null;
+  lastReviewNote: string | null;
+  listedAt: string;
+}
+
+export interface OperationalPropertyDetail extends PropertyInfo {
+  reviewStatus: PropertyReviewStatus;
+  lastReviewedAt: string | null;
+  lastReviewerWallet: string | null;
+  lastReviewNote: string | null;
+  ownerKycStatus: string;
+  ownerKycTier: string;
+  valuation: {
+    state: string;
+    record?: ValuationRecord;
+  };
+  audit: {
+    lastActionAt: string | null;
+    lastActorWallet: string | null;
+    lastNote: string | null;
+  };
+}
+
+function queueToStatuses(queue: OperationsQueue): PropertyReviewStatus[] | undefined {
+  switch (queue) {
+    case 'pending':
+      return ['pending_review'];
+    case 'changes':
+      return ['changes_requested'];
+    case 'approved':
+      return ['approved'];
+    case 'rejected':
+      return ['rejected'];
+    case 'hold':
+      return ['on_hold'];
+    case 'all':
+    default:
+      return undefined;
+  }
+}
+
+function valuationSummary(propertyId: string): { state: string; record?: ValuationRecord } {
+  try {
+    const record = OracleService.getLatestValuation(propertyId);
+    if (record.status === 'manual_review') {
+      return { state: 'manual_review', record };
+    }
+    if (record.status === 'rejected') {
+      return { state: 'rejected', record };
+    }
+    if (record.status === 'stale') {
+      return { state: 'stale', record };
+    }
+    return { state: 'active', record };
+  } catch {
+    return { state: 'missing' };
+  }
+}
+
+export class OperationalPropertyController {
+  static async listProperties(query: {
+    queue?: OperationsQueue;
+    page?: string | number;
+    limit?: string | number;
+  }): Promise<{
+    data: OperationalPropertyListItem[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const page =
+      typeof query.page === 'string' ? parseInt(query.page, 10) : Number(query.page) || 1;
+    const limitRaw =
+      typeof query.limit === 'string' ? parseInt(query.limit, 10) : Number(query.limit) || 20;
+    const limit = limitRaw > 0 && limitRaw <= 100 ? limitRaw : 20;
+    const safePage = page > 0 ? page : 1;
+
+    const queue = query.queue ?? 'pending';
+    const reviewStatuses = queueToStatuses(queue);
+
+    const result = await propertyRepository.findPaginated(
+      { page: safePage, limit },
+      reviewStatuses ? { reviewStatuses } : undefined,
+    );
+
+    const ownerIds = [...new Set(result.data.map((p) => p.ownerId))];
+    const owners = await userRepository.findByIds(ownerIds);
+    const ownerById = new Map(owners.map((u) => [u.id, u]));
+
+    const docCounts = await propertyRepository.countDocumentsByPropertyIds(
+      result.data.map((p) => p.id),
+    );
+
+    const data: OperationalPropertyListItem[] = result.data.map((p) => {
+      const owner = ownerById.get(p.ownerId);
+      const wallet = owner?.walletAddress ?? '';
+      const v = valuationSummary(p.id);
+      const kycApproved = owner?.kycStatus === 'approved';
+
+      return {
+        id: p.id,
+        name: p.name,
+        propertyType: p.propertyType,
+        city: p.location.city,
+        country: p.location.country,
+        reviewStatus: p.reviewStatus,
+        verified: p.verified,
+        ownerWallet: wallet,
+        ownerKycStatus: owner?.kycStatus ?? 'not_started',
+        ownerKycTier: owner?.kycTier ?? 'none',
+        tokenized: Boolean(p.tokenAddress),
+        sorobanPropertyId: p.sorobanPropertyId ?? null,
+        valuationState: v.state,
+        documentCount: docCounts[p.id] ?? 0,
+        readiness: {
+          kycApproved,
+          valuationActive: v.state === 'active',
+          hasTokenAddress: Boolean(p.tokenAddress),
+        },
+        lastReviewedAt: p.lastReviewedAt?.toISOString() ?? null,
+        lastReviewerWallet: p.lastReviewerWallet ?? null,
+        lastReviewNote: p.lastReviewNote ?? null,
+        listedAt: p.listedAt.toISOString(),
+      };
+    });
+
+    return { data, pagination: result.pagination };
+  }
+
+  static async getPropertyDetail(id: string): Promise<OperationalPropertyDetail> {
+    const base = await PropertyController.getProperty(id);
+    const row = await propertyRepository.findById(id);
+    if (!row) {
+      throw new NotFoundError('Property', id);
+    }
+
+    const owner = await userRepository.findById(row.ownerId);
+    const v = valuationSummary(id);
+
+    return {
+      ...base,
+      reviewStatus: row.reviewStatus,
+      lastReviewedAt: row.lastReviewedAt?.toISOString() ?? null,
+      lastReviewerWallet: row.lastReviewerWallet ?? null,
+      lastReviewNote: row.lastReviewNote ?? null,
+      ownerKycStatus: owner?.kycStatus ?? 'not_started',
+      ownerKycTier: owner?.kycTier ?? 'none',
+      valuation: v,
+      audit: {
+        lastActionAt: row.lastReviewedAt?.toISOString() ?? null,
+        lastActorWallet: row.lastReviewerWallet ?? null,
+        lastNote: row.lastReviewNote ?? null,
+      },
+    };
+  }
+
+  static async applyReviewAction(
+    propertyId: string,
+    body: { action: ReviewAction; note?: string; actorWallet: string },
+  ): Promise<OperationalPropertyDetail> {
+    const { action, note, actorWallet } = body;
+
+    if (!actorWallet || actorWallet.length < 50) {
+      throw new ValidationError('A valid operator wallet is required for audit logging', [
+        { field: 'actorWallet', message: 'Invalid Stellar public key' },
+      ]);
+    }
+
+    const property = await propertyRepository.findById(propertyId);
+    if (!property) {
+      throw new NotFoundError('Property', propertyId);
+    }
+
+    let reviewStatus: PropertyReviewStatus;
+    let verified: boolean;
+
+    switch (action) {
+      case 'approve':
+        reviewStatus = 'approved';
+        verified = true;
+        break;
+      case 'reject':
+        reviewStatus = 'rejected';
+        verified = false;
+        break;
+      case 'request_changes':
+        reviewStatus = 'changes_requested';
+        verified = false;
+        break;
+      case 'hold':
+        reviewStatus = 'on_hold';
+        verified = false;
+        break;
+      default:
+        throw new ValidationError('Unknown review action', [
+          { field: 'action', message: 'Invalid action' },
+        ]);
+    }
+
+    const updated = await propertyRepository.update(propertyId, {
+      reviewStatus,
+      verified,
+      lastReviewNote: note?.trim() ? note.trim() : null,
+      lastReviewedAt: new Date(),
+      lastReviewerWallet: actorWallet,
+    });
+
+    if (!updated) {
+      throw new NotFoundError('Property', propertyId);
+    }
+
+    return OperationalPropertyController.getPropertyDetail(propertyId);
+  }
+}

--- a/akkuea-defi-rwa/apps/api/src/db/schema/properties.ts
+++ b/akkuea-defi-rwa/apps/api/src/db/schema/properties.ts
@@ -22,6 +22,14 @@ export const propertyTypeEnum = pgEnum('property_type', [
   'mixed',
 ]);
 
+export const propertyReviewStatusEnum = pgEnum('property_review_status', [
+  'pending_review',
+  'approved',
+  'rejected',
+  'changes_requested',
+  'on_hold',
+]);
+
 export const properties = pgTable('properties', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name', { length: 255 }).notNull(),
@@ -42,6 +50,10 @@ export const properties = pgTable('properties', {
   pricePerShare: decimal('price_per_share', { precision: 20, scale: 2 }).notNull(),
   images: jsonb('images').notNull().$type<string[]>(),
   verified: boolean('verified').notNull().default(false),
+  reviewStatus: propertyReviewStatusEnum('review_status').notNull().default('pending_review'),
+  lastReviewNote: text('last_review_note'),
+  lastReviewedAt: timestamp('last_reviewed_at', { withTimezone: true }),
+  lastReviewerWallet: varchar('last_reviewer_wallet', { length: 56 }),
   listedAt: timestamp('listed_at', { withTimezone: true }).notNull().defaultNow(),
   ownerId: uuid('owner_id')
     .notNull()

--- a/akkuea-defi-rwa/apps/api/src/repositories/PropertyRepository.ts
+++ b/akkuea-defi-rwa/apps/api/src/repositories/PropertyRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, gte, lte, gt, sql, type SQL } from 'drizzle-orm';
+import { eq, and, gte, lte, gt, sql, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   properties,
@@ -13,6 +13,13 @@ import { BaseRepository } from './BaseRepository';
 /**
  * Filter options for querying properties
  */
+export type PropertyReviewStatus =
+  | 'pending_review'
+  | 'approved'
+  | 'rejected'
+  | 'changes_requested'
+  | 'on_hold';
+
 export interface PropertyFilter {
   ownerId?: string;
   city?: string;
@@ -23,6 +30,7 @@ export interface PropertyFilter {
   minAvailableShares?: number;
   hasAvailableShares?: boolean;
   verified?: boolean;
+  reviewStatuses?: PropertyReviewStatus[];
 }
 
 /**
@@ -214,12 +222,32 @@ export class PropertyRepository extends BaseRepository<typeof properties, Proper
   }
 
   /**
+   * Document counts per property (for operations queue summaries)
+   */
+  async countDocumentsByPropertyIds(propertyIds: string[]): Promise<Record<string, number>> {
+    if (propertyIds.length === 0) {
+      return {};
+    }
+
+    const rows = await db
+      .select({
+        propertyId: propertyDocuments.propertyId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(propertyDocuments)
+      .where(inArray(propertyDocuments.propertyId, propertyIds))
+      .groupBy(propertyDocuments.propertyId);
+
+    return Object.fromEntries(rows.map((r) => [r.propertyId, r.count]));
+  }
+
+  /**
    * Verify a property
    */
   async verify(id: string): Promise<Property | undefined> {
     const results = await db
       .update(properties)
-      .set({ verified: true })
+      .set({ verified: true, reviewStatus: 'approved' })
       .where(eq(properties.id, id))
       .returning();
 
@@ -302,6 +330,10 @@ export class PropertyRepository extends BaseRepository<typeof properties, Proper
 
     if (filter.verified !== undefined) {
       conditions.push(eq(properties.verified, filter.verified));
+    }
+
+    if (filter.reviewStatuses && filter.reviewStatuses.length > 0) {
+      conditions.push(inArray(properties.reviewStatus, filter.reviewStatuses));
     }
 
     if (filter.minPricePerShare !== undefined) {

--- a/akkuea-defi-rwa/apps/api/src/repositories/UserRepository.ts
+++ b/akkuea-defi-rwa/apps/api/src/repositories/UserRepository.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { db } from '../db';
 import { users, type User, type NewUser } from '../db/schema';
 import { BaseRepository } from './BaseRepository';
@@ -6,6 +6,16 @@ import { BaseRepository } from './BaseRepository';
 export class UserRepository extends BaseRepository<typeof users, User, NewUser> {
   constructor() {
     super(users);
+  }
+
+  /**
+   * Find users by internal IDs (batch)
+   */
+  async findByIds(ids: string[]): Promise<User[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    return db.select().from(users).where(inArray(users.id, ids));
   }
 
   /**

--- a/akkuea-defi-rwa/apps/api/src/routes/internalOperations.ts
+++ b/akkuea-defi-rwa/apps/api/src/routes/internalOperations.ts
@@ -1,0 +1,94 @@
+import { Elysia } from 'elysia';
+import { z } from 'zod';
+import {
+  validateBody,
+  validateQuery,
+  validateParams,
+  uuidParamSchema,
+  paginationQuerySchema,
+} from '../middleware/validation';
+import {
+  OperationalPropertyController,
+  type OperationsQueue,
+} from '../controllers/OperationalPropertyController';
+import { handleError } from '../utils/errors';
+import { isInternalOperationsAuthorized } from '../utils/internalOperationsAuth';
+
+const listQuerySchema = paginationQuerySchema.extend({
+  queue: z.enum(['pending', 'approved', 'rejected', 'hold', 'changes', 'all']).optional(),
+});
+
+const reviewBodySchema = z.object({
+  action: z.enum(['approve', 'reject', 'request_changes', 'hold']),
+  note: z.string().max(2000).optional(),
+  actorWallet: z.string().min(50).max(64),
+});
+
+const internalKeyAuth = new Elysia({ name: 'internal-operations-auth' }).onBeforeHandle(
+  ({ headers, set }) => {
+    if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
+      set.status = 403;
+      return {
+        success: false,
+        error: 'FORBIDDEN',
+        message: 'Operations access denied',
+        timestamp: new Date().toISOString(),
+      };
+    }
+  },
+);
+
+const listPropertiesRoute = new Elysia()
+  .use(internalKeyAuth)
+  .use(validateQuery(listQuerySchema))
+  .get('/properties', async ({ validatedQuery, set }) => {
+    try {
+      const result = await OperationalPropertyController.listProperties({
+        queue: validatedQuery!.queue as OperationsQueue | undefined,
+        page: validatedQuery!.page,
+        limit: validatedQuery!.limit,
+      });
+      return { success: true, ...result };
+    } catch (error) {
+      const errorResponse = handleError(error);
+      set.status = errorResponse.statusCode;
+      return errorResponse;
+    }
+  });
+
+const getPropertyOperationsRoute = new Elysia()
+  .use(internalKeyAuth)
+  .use(validateParams(uuidParamSchema))
+  .get('/properties/:id', async ({ validatedParams, set }) => {
+    try {
+      const data = await OperationalPropertyController.getPropertyDetail(validatedParams!.id);
+      return { success: true, data };
+    } catch (error) {
+      const errorResponse = handleError(error);
+      set.status = errorResponse.statusCode;
+      return errorResponse;
+    }
+  });
+
+const reviewPropertyRoute = new Elysia()
+  .use(internalKeyAuth)
+  .use(validateParams(uuidParamSchema))
+  .use(validateBody(reviewBodySchema))
+  .post('/properties/:id/review', async ({ validatedParams, validatedBody, set }) => {
+    try {
+      const data = await OperationalPropertyController.applyReviewAction(
+        validatedParams!.id,
+        validatedBody!,
+      );
+      return { success: true, data };
+    } catch (error) {
+      const errorResponse = handleError(error);
+      set.status = errorResponse.statusCode;
+      return errorResponse;
+    }
+  });
+
+export const internalOperationsRoutes = new Elysia({ prefix: '/internal/operations' })
+  .use(listPropertiesRoute)
+  .use(getPropertyOperationsRoute)
+  .use(reviewPropertyRoute);

--- a/akkuea-defi-rwa/apps/api/src/utils/errors.ts
+++ b/akkuea-defi-rwa/apps/api/src/utils/errors.ts
@@ -1,3 +1,4 @@
+import { isAppError } from '@real-estate-defi/shared';
 import { ApiError } from '../errors/ApiError';
 
 export class AppError extends Error {
@@ -56,6 +57,16 @@ export function handleError(error: unknown): ErrorResponse {
       error: error.code,
       message: error.message,
       statusCode: error.statusCode,
+      timestamp,
+    };
+  }
+
+  if (isAppError(error)) {
+    return {
+      success: false,
+      error: String(error.code),
+      message: error.message,
+      statusCode: error.status,
       timestamp,
     };
   }

--- a/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.test.ts
@@ -3,11 +3,11 @@ import { isInternalOperationsAuthorized } from './internalOperationsAuth';
 
 describe('isInternalOperationsAuthorized', () => {
   beforeEach(() => {
-    process.env.INTERNAL_OPERATIONS_API_KEY = 'test-internal-ops-key';
+    process.env.OPERATIONS_BACKEND_CREDENTIAL = 'test-internal-ops-key';
   });
 
   afterEach(() => {
-    delete process.env.INTERNAL_OPERATIONS_API_KEY;
+    delete process.env.OPERATIONS_BACKEND_CREDENTIAL;
   });
 
   it('returns false when the header is missing', () => {
@@ -26,8 +26,8 @@ describe('isInternalOperationsAuthorized', () => {
     ).toBe(true);
   });
 
-  it('returns false when INTERNAL_OPERATIONS_API_KEY is unset', () => {
-    delete process.env.INTERNAL_OPERATIONS_API_KEY;
+  it('returns false when OPERATIONS_BACKEND_CREDENTIAL is unset', () => {
+    delete process.env.OPERATIONS_BACKEND_CREDENTIAL;
     expect(
       isInternalOperationsAuthorized({ 'x-internal-api-key': 'test-internal-ops-key' }),
     ).toBe(false);

--- a/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.test.ts
+++ b/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { isInternalOperationsAuthorized } from './internalOperationsAuth';
+
+describe('isInternalOperationsAuthorized', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_OPERATIONS_API_KEY = 'test-internal-ops-key';
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_OPERATIONS_API_KEY;
+  });
+
+  it('returns false when the header is missing', () => {
+    expect(isInternalOperationsAuthorized({})).toBe(false);
+  });
+
+  it('returns false when the key does not match', () => {
+    expect(
+      isInternalOperationsAuthorized({ 'x-internal-api-key': 'wrong' }),
+    ).toBe(false);
+  });
+
+  it('returns true when the key matches', () => {
+    expect(
+      isInternalOperationsAuthorized({ 'x-internal-api-key': 'test-internal-ops-key' }),
+    ).toBe(true);
+  });
+
+  it('returns false when INTERNAL_OPERATIONS_API_KEY is unset', () => {
+    delete process.env.INTERNAL_OPERATIONS_API_KEY;
+    expect(
+      isInternalOperationsAuthorized({ 'x-internal-api-key': 'test-internal-ops-key' }),
+    ).toBe(false);
+  });
+});

--- a/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.ts
+++ b/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.ts
@@ -4,7 +4,7 @@
 export function isInternalOperationsAuthorized(
   headers: Record<string, string | undefined>,
 ): boolean {
-  const expected = process.env.INTERNAL_OPERATIONS_API_KEY;
+  const expected = process.env.OPERATIONS_BACKEND_CREDENTIAL;
   const key = headers['x-internal-api-key'];
   return Boolean(expected && key === expected);
 }

--- a/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.ts
+++ b/akkuea-defi-rwa/apps/api/src/utils/internalOperationsAuth.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared check for /internal/operations routes (header x-internal-api-key).
+ */
+export function isInternalOperationsAuthorized(
+  headers: Record<string, string | undefined>,
+): boolean {
+  const expected = process.env.INTERNAL_OPERATIONS_API_KEY;
+  const key = headers['x-internal-api-key'];
+  return Boolean(expected && key === expected);
+}

--- a/akkuea-defi-rwa/apps/webapp/package.json
+++ b/akkuea-defi-rwa/apps/webapp/package.json
@@ -31,6 +31,9 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/jest": "^30.0.0",
     "@types/node": "^25.2.0",
     "@types/react": "^19.2.11",
     "@types/react-dom": "^19.2.3",

--- a/akkuea-defi-rwa/apps/webapp/src/app/admin/operations/page.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/app/admin/operations/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { PropertyOperationsWorkspace } from "@/components/admin/operations/PropertyOperationsWorkspace";
+import { useWallet } from "@/components/auth/hooks";
+
+export default function AdminOperationsPage() {
+  const { address, isConnected } = useWallet();
+
+  return (
+    <PropertyOperationsWorkspace
+      operatorWallet={address ?? null}
+      isWalletConnected={isConnected}
+    />
+  );
+}

--- a/akkuea-defi-rwa/apps/webapp/src/app/api/admin/operations/[[...path]]/route.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/app/api/admin/operations/[[...path]]/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
 /** Shared secret with the API for the internal operations routes (set in deployment env). */
-const operationsBackendCredential = process.env.OPERATIONS_BACKEND_CREDENTIAL ?? "";
+const operationsBackendCredential =
+  process.env.OPERATIONS_BACKEND_CREDENTIAL ?? "";
 const API_BASE =
-  process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:3001";
 
 function parseAllowlist(): string[] | "wildcard" {
   const raw = process.env.OPERATIONS_ALLOWED_WALLETS ?? "";

--- a/akkuea-defi-rwa/apps/webapp/src/app/api/admin/operations/[[...path]]/route.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/app/api/admin/operations/[[...path]]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const INTERNAL_KEY = process.env.INTERNAL_OPERATIONS_API_KEY ?? "";
+/** Shared secret with the API for the internal operations routes (set in deployment env). */
+const operationsBackendCredential = process.env.OPERATIONS_BACKEND_CREDENTIAL ?? "";
 const API_BASE =
   process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
@@ -30,7 +31,7 @@ async function proxy(
   segments: string[],
   method: string,
 ): Promise<NextResponse> {
-  if (!INTERNAL_KEY) {
+  if (!operationsBackendCredential) {
     return NextResponse.json(
       {
         success: false,
@@ -59,7 +60,7 @@ async function proxy(
   targetUrl.search = incomingUrl.search;
 
   const headers = new Headers();
-  headers.set("x-internal-api-key", INTERNAL_KEY);
+  headers.set("x-internal-api-key", operationsBackendCredential);
   const contentType = req.headers.get("content-type");
   if (contentType) {
     headers.set("content-type", contentType);

--- a/akkuea-defi-rwa/apps/webapp/src/app/api/admin/operations/[[...path]]/route.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/app/api/admin/operations/[[...path]]/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const INTERNAL_KEY = process.env.INTERNAL_OPERATIONS_API_KEY ?? "";
+const API_BASE =
+  process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+function parseAllowlist(): string[] | "wildcard" {
+  const raw = process.env.OPERATIONS_ALLOWED_WALLETS ?? "";
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.includes("*")) return "wildcard";
+  return parts;
+}
+
+function isOperatorAllowed(wallet: string | null): boolean {
+  const mode = parseAllowlist();
+  if (mode === "wildcard") {
+    return Boolean(wallet && wallet.length >= 50);
+  }
+  if (mode.length === 0) {
+    return false;
+  }
+  return Boolean(wallet && mode.includes(wallet));
+}
+
+async function proxy(
+  req: NextRequest,
+  segments: string[],
+  method: string,
+): Promise<NextResponse> {
+  if (!INTERNAL_KEY) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "NOT_CONFIGURED",
+        message: "Operations API is not configured on this deployment",
+      },
+      { status: 503 },
+    );
+  }
+
+  const wallet = req.headers.get("x-operator-wallet");
+  if (!isOperatorAllowed(wallet)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "FORBIDDEN",
+        message: "You are not authorized to access operations tools",
+      },
+      { status: 403 },
+    );
+  }
+
+  const path = segments.join("/");
+  const targetUrl = new URL(`${API_BASE}/internal/operations/${path}`);
+  const incomingUrl = new URL(req.url);
+  targetUrl.search = incomingUrl.search;
+
+  const headers = new Headers();
+  headers.set("x-internal-api-key", INTERNAL_KEY);
+  const contentType = req.headers.get("content-type");
+  if (contentType) {
+    headers.set("content-type", contentType);
+  }
+
+  const init: RequestInit = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    const body = await req.text();
+    if (body) init.body = body;
+  }
+
+  const res = await fetch(targetUrl.toString(), init);
+  const text = await res.text();
+  return new NextResponse(text, {
+    status: res.status,
+    headers: {
+      "content-type": res.headers.get("content-type") ?? "application/json",
+    },
+  });
+}
+
+export async function GET(
+  req: NextRequest,
+  ctx: { params: Promise<{ path?: string[] }> },
+) {
+  const { path = [] } = await ctx.params;
+  return proxy(req, path, "GET");
+}
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ path?: string[] }> },
+) {
+  const { path = [] } = await ctx.params;
+  return proxy(req, path, "POST");
+}

--- a/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/ConfirmReviewActionModal.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/ConfirmReviewActionModal.tsx
@@ -63,7 +63,9 @@ export function ConfirmReviewActionModal({
       description={propertyName}
       size="md"
     >
-      <p className="mb-6 text-sm leading-relaxed text-zinc-400">{copy.description}</p>
+      <p className="mb-6 text-sm leading-relaxed text-zinc-400">
+        {copy.description}
+      </p>
       <div className="flex justify-end gap-3">
         <Button variant="ghost" onClick={onCancel} disabled={isSubmitting}>
           Cancel

--- a/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/ConfirmReviewActionModal.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/ConfirmReviewActionModal.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import type { ReviewAction } from "@/services/api/adminOperations";
+
+const actionLabels: Record<
+  ReviewAction,
+  { title: string; description: string; confirm: string }
+> = {
+  approve: {
+    title: "Approve property",
+    description:
+      "This marks the asset as verified for marketplace eligibility and sets review status to approved. Confirm you have completed operational checks.",
+    confirm: "Approve",
+  },
+  reject: {
+    title: "Reject property",
+    description:
+      "The asset will remain off-market and owners will need a new submission. This action is recorded for audit.",
+    confirm: "Reject",
+  },
+  request_changes: {
+    title: "Request changes",
+    description:
+      "Sends the listing back to the owner with a request for updates. Review status becomes changes requested.",
+    confirm: "Request changes",
+  },
+  hold: {
+    title: "Place on operational hold",
+    description:
+      "Pauses launch readiness for this asset without rejecting it. Use for compliance or data gaps.",
+    confirm: "Place on hold",
+  },
+};
+
+interface ConfirmReviewActionModalProps {
+  isOpen: boolean;
+  action: ReviewAction | null;
+  propertyName: string;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function ConfirmReviewActionModal({
+  isOpen,
+  action,
+  propertyName,
+  isSubmitting,
+  onCancel,
+  onConfirm,
+}: ConfirmReviewActionModalProps) {
+  if (!action) return null;
+
+  const copy = actionLabels[action];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      title={copy.title}
+      description={propertyName}
+      size="md"
+    >
+      <p className="mb-6 text-sm leading-relaxed text-zinc-400">{copy.description}</p>
+      <div className="flex justify-end gap-3">
+        <Button variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button variant="accent" onClick={onConfirm} disabled={isSubmitting}>
+          {isSubmitting ? "Working…" : copy.confirm}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/PropertyOperationsWorkspace.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/PropertyOperationsWorkspace.tsx
@@ -22,7 +22,11 @@ import {
   type ReviewAction,
 } from "@/services/api/adminOperations";
 import { cn, formatCurrency, truncateAddress } from "@/lib/utils";
-import { pageTransition, staggerContainer, staggerItem } from "@/lib/animations";
+import {
+  pageTransition,
+  staggerContainer,
+  staggerItem,
+} from "@/lib/animations";
 
 const QUEUE_TABS: { id: OperationsQueue; label: string }[] = [
   { id: "pending", label: "Pending review" },
@@ -124,7 +128,9 @@ export function PropertyOperationsWorkspace({
         const res = await adminOperationsApi.getProperty(operatorWallet, id);
         setDetail(res.data);
       } catch (e) {
-        setDetailError(e instanceof Error ? e.message : "Failed to load property");
+        setDetailError(
+          e instanceof Error ? e.message : "Failed to load property",
+        );
         setDetail(null);
       } finally {
         setDetailLoading(false);
@@ -145,11 +151,15 @@ export function PropertyOperationsWorkspace({
     if (!confirmAction || !selectedId || !operatorWallet) return;
     setSubmitting(true);
     try {
-      const res = await adminOperationsApi.reviewProperty(operatorWallet, selectedId, {
-        action: confirmAction,
-        note: note.trim() || undefined,
-        actorWallet: operatorWallet,
-      });
+      const res = await adminOperationsApi.reviewProperty(
+        operatorWallet,
+        selectedId,
+        {
+          action: confirmAction,
+          note: note.trim() || undefined,
+          actorWallet: operatorWallet,
+        },
+      );
       setDetail(res.data);
       setConfirmAction(null);
       setNote("");
@@ -195,8 +205,9 @@ export function PropertyOperationsWorkspace({
               Property verification
             </h1>
             <p className="mt-2 max-w-2xl text-sm text-zinc-400">
-              Review tokenized inventory, valuation posture, and owner KYC before marketplace
-              exposure. Critical actions require explicit confirmation.
+              Review tokenized inventory, valuation posture, and owner KYC
+              before marketplace exposure. Critical actions require explicit
+              confirmation.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -223,10 +234,12 @@ export function PropertyOperationsWorkspace({
             <div className="flex gap-3">
               <AlertTriangle className="h-5 w-5 shrink-0 text-amber-400" />
               <div>
-                <p className="font-medium text-amber-100">Connect an authorized wallet</p>
+                <p className="font-medium text-amber-100">
+                  Connect an authorized wallet
+                </p>
                 <p className="mt-1 text-sm text-amber-100/80">
-                  Use the header wallet control to connect. Your address must be on the operations
-                  allowlist for this environment.
+                  Use the header wallet control to connect. Your address must be
+                  on the operations allowlist for this environment.
                 </p>
               </div>
             </div>
@@ -240,8 +253,9 @@ export function PropertyOperationsWorkspace({
               <div>
                 <p className="font-medium text-red-100">Access denied</p>
                 <p className="mt-1 text-sm text-red-100/80">
-                  This wallet is not permitted to use the operations dashboard. Contact platform
-                  administrators if you believe this is an error.
+                  This wallet is not permitted to use the operations dashboard.
+                  Contact platform administrators if you believe this is an
+                  error.
                 </p>
               </div>
             </div>
@@ -281,7 +295,9 @@ export function PropertyOperationsWorkspace({
                   <p className="p-6 text-sm text-red-300">{listError}</p>
                 )}
                 {!listLoading && !listError && items.length === 0 && (
-                  <p className="p-6 text-sm text-zinc-500">No properties in this queue.</p>
+                  <p className="p-6 text-sm text-zinc-500">
+                    No properties in this queue.
+                  </p>
                 )}
                 {!listLoading &&
                   !listError &&
@@ -296,13 +312,19 @@ export function PropertyOperationsWorkspace({
                       )}
                     >
                       <div className="flex items-start justify-between gap-2">
-                        <span className="font-medium text-zinc-100">{row.name}</span>
-                        <Badge variant={statusBadgeVariant(row.reviewStatus)} className="shrink-0">
+                        <span className="font-medium text-zinc-100">
+                          {row.name}
+                        </span>
+                        <Badge
+                          variant={statusBadgeVariant(row.reviewStatus)}
+                          className="shrink-0"
+                        >
                           {formatStatusLabel(row.reviewStatus)}
                         </Badge>
                       </div>
                       <p className="text-xs text-zinc-500">
-                        {row.city}, {row.country} · Owner {truncateAddress(row.ownerWallet)}
+                        {row.city}, {row.country} · Owner{" "}
+                        {truncateAddress(row.ownerWallet)}
                       </p>
                       <div className="flex flex-wrap gap-2 text-[11px] text-zinc-500">
                         <span>KYC: {row.ownerKycStatus}</span>
@@ -322,7 +344,8 @@ export function PropertyOperationsWorkspace({
               <Card className="flex min-h-[320px] flex-col items-center justify-center border-dashed border-zinc-700 bg-zinc-950/40 p-8 text-center">
                 <Building2 className="mb-3 h-10 w-10 text-zinc-600" />
                 <p className="text-sm text-zinc-500">
-                  Select a property from the queue to see audit context, documents, and actions.
+                  Select a property from the queue to see audit context,
+                  documents, and actions.
                 </p>
               </Card>
             )}
@@ -339,22 +362,28 @@ export function PropertyOperationsWorkspace({
                 <Card className="border-zinc-800 bg-zinc-950/80 p-6">
                   <div className="flex flex-wrap items-start justify-between gap-4">
                     <div>
-                      <h2 className="text-xl font-semibold text-white">{detail.name}</h2>
+                      <h2 className="text-xl font-semibold text-white">
+                        {detail.name}
+                      </h2>
                       <p className="mt-1 text-sm text-zinc-500">
-                        {detail.location.city}, {detail.location.country} · Listed{" "}
-                        {new Date(detail.listedAt).toLocaleString()}
+                        {detail.location.city}, {detail.location.country} ·
+                        Listed {new Date(detail.listedAt).toLocaleString()}
                       </p>
                     </div>
                     <div className="flex flex-wrap gap-2">
                       <Badge variant={detail.verified ? "success" : "warning"}>
-                        {detail.verified ? "Verified (marketplace)" : "Not verified"}
+                        {detail.verified
+                          ? "Verified (marketplace)"
+                          : "Not verified"}
                       </Badge>
                       <Badge variant={statusBadgeVariant(detail.reviewStatus)}>
                         {formatStatusLabel(detail.reviewStatus)}
                       </Badge>
                     </div>
                   </div>
-                  <p className="mt-4 text-sm leading-relaxed text-zinc-400">{detail.description}</p>
+                  <p className="mt-4 text-sm leading-relaxed text-zinc-400">
+                    {detail.description}
+                  </p>
                   <dl className="mt-6 grid gap-3 text-sm sm:grid-cols-2">
                     <div>
                       <dt className="text-zinc-500">Total value</dt>
@@ -370,7 +399,9 @@ export function PropertyOperationsWorkspace({
                     </div>
                     <div>
                       <dt className="text-zinc-500">Owner wallet</dt>
-                      <dd className="font-mono text-xs text-zinc-300">{detail.owner}</dd>
+                      <dd className="font-mono text-xs text-zinc-300">
+                        {detail.owner}
+                      </dd>
                     </div>
                     <div>
                       <dt className="text-zinc-500">Token</dt>
@@ -405,7 +436,8 @@ export function PropertyOperationsWorkspace({
                     {readinessSummary && (
                       <li>
                         <span className="text-zinc-500">Documents: </span>
-                        {readinessSummary.verifiedDocs}/{readinessSummary.docsTotal} verified on file
+                        {readinessSummary.verifiedDocs}/
+                        {readinessSummary.docsTotal} verified on file
                       </li>
                     )}
                     <li>
@@ -416,7 +448,8 @@ export function PropertyOperationsWorkspace({
                       {detail.audit.lastActionAt && (
                         <span className="text-zinc-600">
                           {" "}
-                          · {new Date(detail.audit.lastActionAt).toLocaleString()}
+                          ·{" "}
+                          {new Date(detail.audit.lastActionAt).toLocaleString()}
                         </span>
                       )}
                     </li>
@@ -436,7 +469,9 @@ export function PropertyOperationsWorkspace({
                   </h3>
                   <ul className="mt-4 divide-y divide-zinc-800">
                     {(detail.documents ?? []).length === 0 && (
-                      <li className="py-2 text-sm text-zinc-500">No documents uploaded.</li>
+                      <li className="py-2 text-sm text-zinc-500">
+                        No documents uploaded.
+                      </li>
                     )}
                     {(detail.documents ?? []).map((doc) => (
                       <li
@@ -444,7 +479,9 @@ export function PropertyOperationsWorkspace({
                         className="flex flex-wrap items-center justify-between gap-2 py-3 text-sm"
                       >
                         <span className="text-zinc-200">{doc.name}</span>
-                        <span className="text-xs text-zinc-500">{doc.type}</span>
+                        <span className="text-xs text-zinc-500">
+                          {doc.type}
+                        </span>
                         <Badge variant={doc.verified ? "success" : "warning"}>
                           {doc.verified ? "Verified" : "Pending"}
                         </Badge>
@@ -454,7 +491,9 @@ export function PropertyOperationsWorkspace({
                 </Card>
 
                 <Card className="border-zinc-800 bg-zinc-950/80 p-6">
-                  <h3 className="text-sm font-semibold text-zinc-200">Operational note</h3>
+                  <h3 className="text-sm font-semibold text-zinc-200">
+                    Operational note
+                  </h3>
                   <textarea
                     value={note}
                     onChange={(e) => setNote(e.target.value)}

--- a/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/PropertyOperationsWorkspace.tsx
+++ b/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/PropertyOperationsWorkspace.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import {
+  AlertTriangle,
+  Building2,
+  ClipboardList,
+  FileText,
+  RefreshCw,
+  Shield,
+} from "lucide-react";
+import { Navbar } from "@/components/layout";
+import { Badge, Button, Card } from "@/components/ui";
+import { ConfirmReviewActionModal } from "@/components/admin/operations/ConfirmReviewActionModal";
+import {
+  adminOperationsApi,
+  type OperationalPropertyDetail,
+  type OperationalPropertyListItem,
+  type OperationsQueue,
+  type ReviewAction,
+} from "@/services/api/adminOperations";
+import { cn, formatCurrency, truncateAddress } from "@/lib/utils";
+import { pageTransition, staggerContainer, staggerItem } from "@/lib/animations";
+
+const QUEUE_TABS: { id: OperationsQueue; label: string }[] = [
+  { id: "pending", label: "Pending review" },
+  { id: "changes", label: "Changes requested" },
+  { id: "hold", label: "On hold" },
+  { id: "approved", label: "Approved" },
+  { id: "rejected", label: "Rejected" },
+  { id: "all", label: "All" },
+];
+
+function statusBadgeVariant(
+  status: OperationalPropertyListItem["reviewStatus"],
+): "success" | "warning" | "danger" | "info" | "default" {
+  switch (status) {
+    case "approved":
+      return "success";
+    case "rejected":
+      return "danger";
+    case "changes_requested":
+    case "pending_review":
+      return "warning";
+    case "on_hold":
+      return "info";
+    default:
+      return "default";
+  }
+}
+
+function formatStatusLabel(status: string): string {
+  return status.replace(/_/g, " ");
+}
+
+interface PropertyOperationsWorkspaceProps {
+  operatorWallet: string | null;
+  isWalletConnected: boolean;
+}
+
+export function PropertyOperationsWorkspace({
+  operatorWallet,
+  isWalletConnected,
+}: PropertyOperationsWorkspaceProps) {
+  const [queue, setQueue] = useState<OperationsQueue>("pending");
+
+  const selectQueue = (next: OperationsQueue) => {
+    setQueue(next);
+    setSelectedId(null);
+    setPagination((p) => ({ ...p, page: 1 }));
+  };
+  const [items, setItems] = useState<OperationalPropertyListItem[]>([]);
+  const [pagination, setPagination] = useState({
+    page: 1,
+    limit: 20,
+    total: 0,
+    totalPages: 0,
+  });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<OperationalPropertyDetail | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [listLoading, setListLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [note, setNote] = useState("");
+  const [confirmAction, setConfirmAction] = useState<ReviewAction | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const page = pagination.page;
+  const limit = pagination.limit;
+
+  const loadList = useCallback(async () => {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const res = await adminOperationsApi.listQueue(operatorWallet, {
+        queue,
+        page,
+        limit,
+      });
+      setItems(res.data);
+      setPagination((prev) => ({
+        ...prev,
+        ...res.pagination,
+      }));
+    } catch (e) {
+      setListError(e instanceof Error ? e.message : "Failed to load queue");
+    } finally {
+      setListLoading(false);
+    }
+  }, [operatorWallet, queue, page, limit]);
+
+  useEffect(() => {
+    void loadList();
+  }, [loadList]);
+
+  const loadDetail = useCallback(
+    async (id: string) => {
+      setDetailLoading(true);
+      setDetailError(null);
+      try {
+        const res = await adminOperationsApi.getProperty(operatorWallet, id);
+        setDetail(res.data);
+      } catch (e) {
+        setDetailError(e instanceof Error ? e.message : "Failed to load property");
+        setDetail(null);
+      } finally {
+        setDetailLoading(false);
+      }
+    },
+    [operatorWallet],
+  );
+
+  useEffect(() => {
+    if (selectedId) {
+      void loadDetail(selectedId);
+    } else {
+      setDetail(null);
+    }
+  }, [selectedId, loadDetail]);
+
+  const onConfirmAction = async () => {
+    if (!confirmAction || !selectedId || !operatorWallet) return;
+    setSubmitting(true);
+    try {
+      const res = await adminOperationsApi.reviewProperty(operatorWallet, selectedId, {
+        action: confirmAction,
+        note: note.trim() || undefined,
+        actorWallet: operatorWallet,
+      });
+      setDetail(res.data);
+      setConfirmAction(null);
+      setNote("");
+      await loadList();
+    } catch (e) {
+      setDetailError(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const readinessSummary = useMemo(() => {
+    if (!detail) return null;
+    const docs = detail.documents ?? [];
+    const verifiedDocs = docs.filter((d) => d.verified).length;
+    return {
+      docsTotal: docs.length,
+      verifiedDocs,
+      kyc: detail.ownerKycStatus,
+      valuation: detail.valuation.state,
+    };
+  }, [detail]);
+
+  const accessBlocked = !isWalletConnected;
+  const notAllowlisted =
+    isWalletConnected && listError?.toLowerCase().includes("not authorized");
+
+  return (
+    <motion.div
+      className="min-h-screen bg-black text-white"
+      variants={pageTransition}
+      initial="initial"
+      animate="animate"
+    >
+      <Navbar />
+      <main className="mx-auto max-w-7xl px-4 pb-20 pt-8 sm:px-6 lg:px-8">
+        <div className="mb-8 flex flex-col gap-2 border-b border-zinc-800 pb-6 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-widest text-amber-500/90">
+              Internal operations
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight md:text-3xl">
+              Property verification
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-zinc-400">
+              Review tokenized inventory, valuation posture, and owner KYC before marketplace
+              exposure. Critical actions require explicit confirmation.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              leftIcon={<RefreshCw className="h-4 w-4" />}
+              onClick={() => void loadList()}
+              disabled={listLoading || accessBlocked}
+            >
+              Refresh queue
+            </Button>
+            <Link
+              href="/marketplace"
+              className="inline-flex items-center rounded-lg px-3 py-1.5 text-xs font-medium text-neutral-400 transition-colors hover:bg-[#1a1a1a] hover:text-white"
+            >
+              Exit to marketplace
+            </Link>
+          </div>
+        </div>
+
+        {accessBlocked && (
+          <Card className="mb-8 border-amber-500/30 bg-amber-500/5 p-6">
+            <div className="flex gap-3">
+              <AlertTriangle className="h-5 w-5 shrink-0 text-amber-400" />
+              <div>
+                <p className="font-medium text-amber-100">Connect an authorized wallet</p>
+                <p className="mt-1 text-sm text-amber-100/80">
+                  Use the header wallet control to connect. Your address must be on the operations
+                  allowlist for this environment.
+                </p>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {notAllowlisted && (
+          <Card className="mb-8 border-red-500/30 bg-red-500/5 p-6">
+            <div className="flex gap-3">
+              <Shield className="h-5 w-5 shrink-0 text-red-300" />
+              <div>
+                <p className="font-medium text-red-100">Access denied</p>
+                <p className="mt-1 text-sm text-red-100/80">
+                  This wallet is not permitted to use the operations dashboard. Contact platform
+                  administrators if you believe this is an error.
+                </p>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+          className="grid gap-8 lg:grid-cols-5"
+        >
+          <motion.section variants={staggerItem} className="lg:col-span-2">
+            <Card className="overflow-hidden border-zinc-800 bg-zinc-950/80 p-0">
+              <div className="flex flex-wrap gap-1 border-b border-zinc-800 p-2">
+                {QUEUE_TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => selectQueue(tab.id)}
+                    className={cn(
+                      "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+                      queue === tab.id
+                        ? "bg-zinc-100 text-zinc-900"
+                        : "text-zinc-500 hover:bg-zinc-900 hover:text-zinc-200",
+                    )}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+              <div className="max-h-[560px] overflow-y-auto">
+                {listLoading && (
+                  <p className="p-6 text-sm text-zinc-500">Loading queue…</p>
+                )}
+                {listError && !listLoading && (
+                  <p className="p-6 text-sm text-red-300">{listError}</p>
+                )}
+                {!listLoading && !listError && items.length === 0 && (
+                  <p className="p-6 text-sm text-zinc-500">No properties in this queue.</p>
+                )}
+                {!listLoading &&
+                  !listError &&
+                  items.map((row) => (
+                    <button
+                      key={row.id}
+                      type="button"
+                      onClick={() => setSelectedId(row.id)}
+                      className={cn(
+                        "flex w-full flex-col gap-2 border-b border-zinc-800/80 px-4 py-3 text-left transition-colors hover:bg-zinc-900/80",
+                        selectedId === row.id && "bg-zinc-900",
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="font-medium text-zinc-100">{row.name}</span>
+                        <Badge variant={statusBadgeVariant(row.reviewStatus)} className="shrink-0">
+                          {formatStatusLabel(row.reviewStatus)}
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-zinc-500">
+                        {row.city}, {row.country} · Owner {truncateAddress(row.ownerWallet)}
+                      </p>
+                      <div className="flex flex-wrap gap-2 text-[11px] text-zinc-500">
+                        <span>KYC: {row.ownerKycStatus}</span>
+                        <span>·</span>
+                        <span>Valuation: {row.valuationState}</span>
+                        <span>·</span>
+                        <span>Docs: {row.documentCount}</span>
+                      </div>
+                    </button>
+                  ))}
+              </div>
+            </Card>
+          </motion.section>
+
+          <motion.section variants={staggerItem} className="lg:col-span-3">
+            {!selectedId && (
+              <Card className="flex min-h-[320px] flex-col items-center justify-center border-dashed border-zinc-700 bg-zinc-950/40 p-8 text-center">
+                <Building2 className="mb-3 h-10 w-10 text-zinc-600" />
+                <p className="text-sm text-zinc-500">
+                  Select a property from the queue to see audit context, documents, and actions.
+                </p>
+              </Card>
+            )}
+            {selectedId && detailLoading && (
+              <p className="text-sm text-zinc-500">Loading property detail…</p>
+            )}
+            {selectedId && detailError && !detailLoading && (
+              <Card className="border-red-500/30 bg-red-500/5 p-6 text-sm text-red-200">
+                {detailError}
+              </Card>
+            )}
+            {detail && !detailLoading && (
+              <div className="space-y-4">
+                <Card className="border-zinc-800 bg-zinc-950/80 p-6">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                      <h2 className="text-xl font-semibold text-white">{detail.name}</h2>
+                      <p className="mt-1 text-sm text-zinc-500">
+                        {detail.location.city}, {detail.location.country} · Listed{" "}
+                        {new Date(detail.listedAt).toLocaleString()}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant={detail.verified ? "success" : "warning"}>
+                        {detail.verified ? "Verified (marketplace)" : "Not verified"}
+                      </Badge>
+                      <Badge variant={statusBadgeVariant(detail.reviewStatus)}>
+                        {formatStatusLabel(detail.reviewStatus)}
+                      </Badge>
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm leading-relaxed text-zinc-400">{detail.description}</p>
+                  <dl className="mt-6 grid gap-3 text-sm sm:grid-cols-2">
+                    <div>
+                      <dt className="text-zinc-500">Total value</dt>
+                      <dd className="font-medium text-zinc-100">
+                        {formatCurrency(parseFloat(detail.totalValue))}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-zinc-500">Price / share</dt>
+                      <dd className="font-medium text-zinc-100">
+                        {formatCurrency(parseFloat(detail.pricePerShare))}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-zinc-500">Owner wallet</dt>
+                      <dd className="font-mono text-xs text-zinc-300">{detail.owner}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-zinc-500">Token</dt>
+                      <dd className="font-mono text-xs text-zinc-300">
+                        {detail.tokenAddress ?? "Not tokenized"}
+                      </dd>
+                    </div>
+                  </dl>
+                </Card>
+
+                <Card className="border-zinc-800 bg-zinc-950/80 p-6">
+                  <h3 className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+                    <ClipboardList className="h-4 w-4 text-amber-500" />
+                    Readiness &amp; audit context
+                  </h3>
+                  <ul className="mt-4 space-y-2 text-sm text-zinc-400">
+                    <li>
+                      <span className="text-zinc-500">Owner KYC: </span>
+                      {detail.ownerKycStatus} ({detail.ownerKycTier})
+                    </li>
+                    <li>
+                      <span className="text-zinc-500">Valuation: </span>
+                      {detail.valuation.state}
+                      {detail.valuation.record?.price != null && (
+                        <span className="text-zinc-500">
+                          {" "}
+                          — {formatCurrency(detail.valuation.record.price)}{" "}
+                          {detail.valuation.record.currency}
+                        </span>
+                      )}
+                    </li>
+                    {readinessSummary && (
+                      <li>
+                        <span className="text-zinc-500">Documents: </span>
+                        {readinessSummary.verifiedDocs}/{readinessSummary.docsTotal} verified on file
+                      </li>
+                    )}
+                    <li>
+                      <span className="text-zinc-500">Last reviewer: </span>
+                      {detail.audit.lastActorWallet
+                        ? truncateAddress(detail.audit.lastActorWallet)
+                        : "—"}
+                      {detail.audit.lastActionAt && (
+                        <span className="text-zinc-600">
+                          {" "}
+                          · {new Date(detail.audit.lastActionAt).toLocaleString()}
+                        </span>
+                      )}
+                    </li>
+                    {detail.audit.lastNote && (
+                      <li>
+                        <span className="text-zinc-500">Last note: </span>
+                        {detail.audit.lastNote}
+                      </li>
+                    )}
+                  </ul>
+                </Card>
+
+                <Card className="border-zinc-800 bg-zinc-950/80 p-6">
+                  <h3 className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+                    <FileText className="h-4 w-4 text-amber-500" />
+                    Documents
+                  </h3>
+                  <ul className="mt-4 divide-y divide-zinc-800">
+                    {(detail.documents ?? []).length === 0 && (
+                      <li className="py-2 text-sm text-zinc-500">No documents uploaded.</li>
+                    )}
+                    {(detail.documents ?? []).map((doc) => (
+                      <li
+                        key={doc.id}
+                        className="flex flex-wrap items-center justify-between gap-2 py-3 text-sm"
+                      >
+                        <span className="text-zinc-200">{doc.name}</span>
+                        <span className="text-xs text-zinc-500">{doc.type}</span>
+                        <Badge variant={doc.verified ? "success" : "warning"}>
+                          {doc.verified ? "Verified" : "Pending"}
+                        </Badge>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+
+                <Card className="border-zinc-800 bg-zinc-950/80 p-6">
+                  <h3 className="text-sm font-semibold text-zinc-200">Operational note</h3>
+                  <textarea
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    rows={3}
+                    placeholder="Optional context recorded with the next action (audit trail)."
+                    className="mt-3 w-full rounded-xl border border-zinc-800 bg-black/60 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-amber-500/50 focus:outline-none"
+                  />
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <Button
+                      variant="accent"
+                      size="sm"
+                      disabled={!operatorWallet || submitting}
+                      onClick={() => setConfirmAction("approve")}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={!operatorWallet || submitting}
+                      onClick={() => setConfirmAction("request_changes")}
+                    >
+                      Request changes
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={!operatorWallet || submitting}
+                      onClick={() => setConfirmAction("hold")}
+                    >
+                      Hold
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-300 hover:text-red-200"
+                      disabled={!operatorWallet || submitting}
+                      onClick={() => setConfirmAction("reject")}
+                    >
+                      Reject
+                    </Button>
+                  </div>
+                </Card>
+              </div>
+            )}
+          </motion.section>
+        </motion.div>
+      </main>
+
+      <ConfirmReviewActionModal
+        isOpen={confirmAction !== null}
+        action={confirmAction}
+        propertyName={detail?.name ?? ""}
+        isSubmitting={submitting}
+        onCancel={() => setConfirmAction(null)}
+        onConfirm={() => void onConfirmAction()}
+      />
+    </motion.div>
+  );
+}

--- a/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/index.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/components/admin/operations/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmReviewActionModal } from "./ConfirmReviewActionModal";
+export { PropertyOperationsWorkspace } from "./PropertyOperationsWorkspace";

--- a/akkuea-defi-rwa/apps/webapp/src/services/api/adminOperations.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/services/api/adminOperations.ts
@@ -84,7 +84,9 @@ async function adminFetch<T>(
   };
 
   if (!res.ok) {
-    throw new Error(json.message ?? res.statusText ?? "Operations request failed");
+    throw new Error(
+      json.message ?? res.statusText ?? "Operations request failed",
+    );
   }
 
   return json as T;
@@ -94,7 +96,9 @@ export const adminOperationsApi = {
   async listQueue(
     operatorWallet: string | null,
     params: { queue: OperationsQueue; page?: number; limit?: number },
-  ): Promise<PaginatedResponse<OperationalPropertyListItem> & { success: boolean }> {
+  ): Promise<
+    PaginatedResponse<OperationalPropertyListItem> & { success: boolean }
+  > {
     const search = new URLSearchParams();
     search.set("queue", params.queue);
     if (params.page) search.set("page", String(params.page));

--- a/akkuea-defi-rwa/apps/webapp/src/services/api/adminOperations.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/services/api/adminOperations.ts
@@ -1,0 +1,122 @@
+import type { PropertyInfo, ValuationRecord } from "@real-estate-defi/shared";
+import type { PaginatedResponse } from "./types";
+
+export type OperationsQueue =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "hold"
+  | "changes"
+  | "all";
+
+export type PropertyReviewStatus =
+  | "pending_review"
+  | "approved"
+  | "rejected"
+  | "changes_requested"
+  | "on_hold";
+
+export type ReviewAction = "approve" | "reject" | "request_changes" | "hold";
+
+export interface OperationalPropertyListItem {
+  id: string;
+  name: string;
+  propertyType: string;
+  city: string;
+  country: string;
+  reviewStatus: PropertyReviewStatus;
+  verified: boolean;
+  ownerWallet: string;
+  ownerKycStatus: string;
+  ownerKycTier: string;
+  tokenized: boolean;
+  sorobanPropertyId: number | null;
+  valuationState: string;
+  documentCount: number;
+  readiness: {
+    kycApproved: boolean;
+    valuationActive: boolean;
+    hasTokenAddress: boolean;
+  };
+  lastReviewedAt: string | null;
+  lastReviewerWallet: string | null;
+  lastReviewNote: string | null;
+  listedAt: string;
+}
+
+export interface OperationalPropertyDetail extends PropertyInfo {
+  reviewStatus: PropertyReviewStatus;
+  lastReviewedAt: string | null;
+  lastReviewerWallet: string | null;
+  lastReviewNote: string | null;
+  ownerKycStatus: string;
+  ownerKycTier: string;
+  valuation: {
+    state: string;
+    record?: ValuationRecord;
+  };
+  audit: {
+    lastActionAt: string | null;
+    lastActorWallet: string | null;
+    lastNote: string | null;
+  };
+}
+
+async function adminFetch<T>(
+  path: string,
+  operatorWallet: string | null,
+  init?: RequestInit,
+): Promise<T> {
+  const url = `/api/admin/operations/${path.replace(/^\//, "")}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+      ...(operatorWallet ? { "x-operator-wallet": operatorWallet } : {}),
+    },
+  });
+
+  const json = (await res.json()) as T & {
+    success?: boolean;
+    message?: string;
+    error?: string;
+  };
+
+  if (!res.ok) {
+    throw new Error(json.message ?? res.statusText ?? "Operations request failed");
+  }
+
+  return json as T;
+}
+
+export const adminOperationsApi = {
+  async listQueue(
+    operatorWallet: string | null,
+    params: { queue: OperationsQueue; page?: number; limit?: number },
+  ): Promise<PaginatedResponse<OperationalPropertyListItem> & { success: boolean }> {
+    const search = new URLSearchParams();
+    search.set("queue", params.queue);
+    if (params.page) search.set("page", String(params.page));
+    if (params.limit) search.set("limit", String(params.limit));
+    return adminFetch(`properties?${search.toString()}`, operatorWallet);
+  },
+
+  async getProperty(
+    operatorWallet: string | null,
+    propertyId: string,
+  ): Promise<{ success: boolean; data: OperationalPropertyDetail }> {
+    return adminFetch(`properties/${propertyId}`, operatorWallet);
+  },
+
+  async reviewProperty(
+    operatorWallet: string | null,
+    propertyId: string,
+    body: { action: ReviewAction; note?: string; actorWallet: string },
+  ): Promise<{ success: boolean; data: OperationalPropertyDetail }> {
+    return adminFetch(`properties/${propertyId}/review`, operatorWallet, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  },
+};

--- a/akkuea-defi-rwa/apps/webapp/src/services/api/index.ts
+++ b/akkuea-defi-rwa/apps/webapp/src/services/api/index.ts
@@ -4,3 +4,11 @@ export { propertyApi } from "./properties";
 export { lendingApi } from "./lending";
 export { userApi } from "./users";
 export { transactionsApi } from "./transactions";
+export { adminOperationsApi } from "./adminOperations";
+export type {
+  OperationalPropertyDetail,
+  OperationalPropertyListItem,
+  OperationsQueue,
+  PropertyReviewStatus,
+  ReviewAction,
+} from "./adminOperations";

--- a/akkuea-defi-rwa/apps/webapp/tsconfig.json
+++ b/akkuea-defi-rwa/apps/webapp/tsconfig.json
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "types": ["bun-types", "bun-types/test"],
+    "types": ["bun-types", "bun-types/test", "jest", "node"],
     "baseUrl": ".",
     "plugins": [
       {

--- a/akkuea-defi-rwa/apps/webapp/tsconfig.json
+++ b/akkuea-defi-rwa/apps/webapp/tsconfig.json
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "types": ["bun-types", "bun-types/test", "jest"],
+    "types": ["bun-types", "bun-types/test"],
     "baseUrl": ".",
     "plugins": [
       {

--- a/akkuea-defi-rwa/bun.lock
+++ b/akkuea-defi-rwa/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "l-estate-defi-platform",
@@ -102,6 +101,9 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/jest": "^30.0.0",
         "@types/node": "^25.2.0",
         "@types/react": "^19.2.11",
         "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
**Title:** Admin operations dashboard for property verification (C3-007)

#### Summary

This PR delivers an internal **property verification** surface: reviewers can work a **queue**, see **verification / valuation / KYC** context, take **confirmed** operational actions with an **audit trail**, and access is **restricted** via a server-side internal key plus an operator wallet allowlist on the webapp proxy.

#### Motivation / issue

Implements planning issue **C3-007** — operations need a serious internal workflow before and during pilot, not ad hoc admin pages.

#### Backend (`apps/api`)

- **Schema & data model** (`properties`): `property_review_status` enum (`pending_review`, `approved`, `rejected`, `changes_requested`, `on_hold`), optional `last_review_note`, `last_reviewed_at`, `last_reviewer_wallet`. Migration **`0002_property_review_operations.sql`** backfills from existing `verified`.
- **Repository**: filter by review statuses; document counts per property for queue summaries; `verify()` keeps `review_status` aligned when used.
- **Users**: `findByIds` for batch owner/KYC in list views.
- **New controller** `OperationalPropertyController`: list by queue, operational detail (combines public property payload with review/audit, owner KYC, oracle valuation state), `POST` review actions (`approve`, `reject`, `request_changes`, `hold`).
- **New routes** under **`/internal/operations`**, guarded by **`x-internal-api-key`** ↔ env **`INTERNAL_OPERATIONS_API_KEY`** (helper `isInternalOperationsAuthorized`).
- **Error handling**: `handleError` now recognizes **shared** `@real-estate-defi/shared` `AppError` subclasses so `NotFoundError` / `ValidationError` etc. return correct status instead of 500.

#### Frontend (`apps/webapp`)

- **Route**: **`/admin/operations`** — queue tabs, row selection, detail panel (readiness, documents, audit, KYC, valuation), optional note, and **confirmation modal** before destructive/state-changing actions.
- **BFF proxy**: **`/api/admin/operations/[[...path]]`** forwards to the API with the internal key **only on the server**; browser sends **`x-operator-wallet`**. Access is gated by **`OPERATIONS_ALLOWED_WALLETS`** (comma-separated Stellar addresses, or `*` for dev-only “any connected wallet”).
- **Client API** `adminOperationsApi` + exports from `services/api/index.ts`.
- **Tooling fix**: removed **`jest`** from `tsconfig.json` `types` (project uses Bun tests; `@types/jest` was not installed → **TS2688**).

#### Configuration

- **`apps/api/.env.example`**: documents `INTERNAL_OPERATIONS_API_KEY`.
- **`apps/webapp/.env.example`**: `INTERNAL_OPERATIONS_API_KEY`, `OPERATIONS_ALLOWED_WALLETS`, optional `API_URL` / `NEXT_PUBLIC_API_URL`.

#### Tests

- **`internalOperationsAuth.test.ts`**: internal API key behavior.
- **`errors.test.ts`**: shared `NotFoundError` through `handleError`.

#### How to verify

1. Apply migrations (including **0002**); ensure DB state matches your migration journal if **0001** was applied outside Drizzle.
2. Set **the same** `INTERNAL_OPERATIONS_API_KEY` on API and webapp.
3. Set `OPERATIONS_ALLOWED_WALLETS` to allowed operator public keys (or `*` locally).
4. Open `/admin/operations`, connect an allowlisted wallet, load queues, open a property, run an action and confirm the modal; confirm API returns 403 without key / wrong wallet as appropriate.

#### Requirements checklist (C3-007)

| Requirement | PR |
|---------------|----|
| REQ-001 Review queues | Queue tabs + `GET /internal/operations/properties?queue=…` |
| REQ-002 Status / valuation / KYC | Badges + detail (KYC, valuation state, docs, tokenization) |
| REQ-003 Actions + confirmation | Modal + `POST …/review` |
| REQ-004 Audit context | Last actor, time, note; prepared for richer events later |
| REQ-005 Restricted access | Wallet allowlist + proxy + internal API key |

#### Notes / follow-ups

- **0001** (`soroban_property_id`) may already exist in some DBs but was not in `_journal.json` before; align migration history with production as needed.
- Risk/oracle valuation data remains in-memory for valuations in current code paths; UI surfaces **state** clearly when missing.


Closes: #723 