### PR TITLE
fix: enforce TypeScript type-check in API CI pipeline

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Type checking
       run: |
         cd akkuea-defi-rwa/apps/api
-        bun run type-check || true
+        bun run type-check
         
     - name: Linting with ESLint
       run: |


### PR DESCRIPTION
## Summary

Closes #765

## Problem

The API CI pipeline's type-check step is silenced with `|| true`:

```yaml
- name: Type checking
  run: |
    cd apps/api
    bun run type-check || true  # ← all type errors silently ignored
```

This means **any TypeScript error is invisible to CI**, and PRs with broken types will pass.

## Fix

Remove `|| true` so type errors properly fail the pipeline:

```diff
     - name: Type checking
       run: |
         cd apps/api
-        bun run type-check || true
+        bun run type-check
```

## Impact

- Type errors will now **block merges** (expected behavior)
- If there are existing type errors in `apps/api`, they will need to be fixed before this can merge
- This is intentional — silent type-check suppression defeats the purpose of TypeScript