### PR TITLE
docs: add webapp .env.example with all required variables

### DIFF
--- a/apps/webapp/.env.example
+++ b/apps/webapp/.env.example
@@ -1,0 +1,28 @@
+# ──────────────────────────────────────────────────
+# OFFER-HUB WebApp — Environment Variables
+# ──────────────────────────────────────────────────
+# Copy this file to .env.local and fill in the values.
+#   cp .env.example .env.local
+# ──────────────────────────────────────────────────
+
+# ── Public (client-side) ──────────────────────────
+
+# Base URL of the backend API (used in browser requests)
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# Optional: SSE endpoint for live lending-pool updates
+# Leave empty to disable live updates.
+# NEXT_PUBLIC_LENDING_SSE_URL=http://localhost:3001/sse/lending
+
+# ── Server-side only ─────────────────────────────
+
+# Backend API base URL used by server-side API route proxies
+API_URL=http://localhost:3001
+
+# Credential used by the operations proxy route
+# (admin-only; never expose to the client)
+OPERATIONS_BACKEND_CREDENTIAL=
+
+# Comma-separated list of Stellar wallet addresses
+# allowed to access admin/operations routes
+OPERATIONS_ALLOWED_WALLETS=

--- a/apps/webapp/.env.example
+++ b/apps/webapp/.env.example
@@ -1,28 +1,24 @@
-# ──────────────────────────────────────────────────
-# OFFER-HUB WebApp — Environment Variables
-# ──────────────────────────────────────────────────
-# Copy this file to .env.local and fill in the values.
+# ───────────────────────────────────────────────
+# akkuea WebApp — Environment Variables
+# ───────────────────────────────────────────────
+# Copy this file to .env.local and fill in the values for your environment.
 #   cp .env.example .env.local
-# ──────────────────────────────────────────────────
 
-# ── Public (client-side) ──────────────────────────
-
-# Base URL of the backend API (used in browser requests)
+# ── Backend API ──────────────────────────────
+# Public URL for client-side API calls (browser-visible)
 NEXT_PUBLIC_API_URL=http://localhost:3001
 
-# Optional: SSE endpoint for live lending-pool updates
-# Leave empty to disable live updates.
-# NEXT_PUBLIC_LENDING_SSE_URL=http://localhost:3001/sse/lending
-
-# ── Server-side only ─────────────────────────────
-
-# Backend API base URL used by server-side API route proxies
+# Server-side API URL for internal proxy routes (never sent to browser)
 API_URL=http://localhost:3001
 
-# Credential used by the operations proxy route
-# (admin-only; never expose to the client)
+# ── Internal Operations ──────────────────────
+# Credential used by server-side proxy routes to authenticate with the API
+# Must match INTERNAL_OPERATIONS_CREDENTIAL in the API's .env
 OPERATIONS_BACKEND_CREDENTIAL=
 
-# Comma-separated list of Stellar wallet addresses
-# allowed to access admin/operations routes
+# Comma-separated list of Stellar wallet addresses allowed to access admin routes
 OPERATIONS_ALLOWED_WALLETS=
+
+# ── Optional / Feature Flags ─────────────────
+# SSE endpoint for real-time lending pool updates (leave empty to disable)
+NEXT_PUBLIC_LENDING_SSE_URL=


### PR DESCRIPTION
## Summary

Closes #770

Creates `apps/webapp/.env.example` documenting all required and optional environment variables for the webapp. Contributors can now copy this file to get started:

```bash
cp apps/webapp/.env.example apps/webapp/.env.local
```

## Variables Documented

| Variable | Scope | Required | Purpose |
|---|---|---|---|
| `NEXT_PUBLIC_API_URL` | Client | ✅ | Backend API base URL |
| `NEXT_PUBLIC_LENDING_SSE_URL` | Client | ❌ | SSE endpoint for live updates |
| `API_URL` | Server | ✅ | Backend URL for API route proxies |
| `OPERATIONS_BACKEND_CREDENTIAL` | Server | Admin only | Operations proxy credential |
| `OPERATIONS_ALLOWED_WALLETS` | Server | Admin only | Admin wallet allowlist |

## Notes

- Each variable includes a descriptive comment and example value
- Sensitive server-side variables are left blank (no defaults)
- Optional variables are commented out with explanation