### PR TITLE
fix: register oracleRoutes in app.ts — all /oracle endpoints return 404

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,29 @@
+import { Elysia } from 'elysia';
+import { cors } from '@elysiajs/cors';
+import { propertyRoutes } from './routes/properties';
+import { lendingRoutes } from './routes/lending';
+import { userRoutes } from './routes/users';
+import { kycRoutes } from './routes/kyc';
+import { webhookRoutes } from './routes/webhooks';
+import { internalOperationsRoutes } from './routes/internalOperations';
+import { oracleRoutes } from './routes/oracle';
+import { errorHandler } from './middleware/errorHandler';
+import { requestLogger } from './middleware';
+
+/**
+ * Base Elysia app without swagger
+ * This allows tests to import the app without triggering @scalar/themes Zod incompatibility
+ */
+const app = new Elysia()
+  .use(requestLogger)
+  .use(cors())
+  .use(errorHandler)
+  .use(propertyRoutes)
+  .use(lendingRoutes)
+  .use(userRoutes)
+  .use(kycRoutes)
+  .use(webhookRoutes)
+  .use(internalOperationsRoutes)
+  .use(oracleRoutes);
+
+export default app;


### PR DESCRIPTION
## Summary

Closes #754

`oracleRoutes` (defined in `src/routes/oracle.ts`) was never mounted in `app.ts`, making `POST /oracle/valuations` and `GET /oracle/valuations/:propertyId` return 404.

## Changes

### `apps/api/src/app.ts`

```diff
+import { oracleRoutes } from './routes/oracle';
 
 const app = new Elysia()
   ...
   .use(internalOperationsRoutes)
+  .use(oracleRoutes);
```

## Now Reachable

| Method | Endpoint | Handler |
|--------|----------|---------|
| POST | `/oracle/valuations` | `ValuationController.submit` |
| GET | `/oracle/valuations/:propertyId` | `ValuationController.get` |