### PR TITLE
feat: added Redis caching for /properties and /lending/pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ bun run typecheck
 - **Stellar Native**: Built specifically for Stellar's features and capabilities
 - **Institutional Focus**: Privacy and compliance features for institutional adoption
 - **Scalable Design**: Modular architecture for easy feature additions
+- **Redis Caching Layer**: Optional Redis cache (via `REDIS_URL`) reduces database load on hot read endpoints. `GET /properties` responses are cached for 30 seconds and `GET /lending/pools` for 10 seconds, keyed by pagination and filter params. Cache is invalidated on every write operation. The app falls back to direct PostgreSQL queries when Redis is unavailable.
 
 ## Technology Stack
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -12,6 +12,12 @@ WEBHOOK_SECRET=your_webhook_secret_here
 # Must match OPERATIONS_BACKEND_CREDENTIAL on the Next.js server (webapp proxy).
 OPERATIONS_BACKEND_CREDENTIAL=generate-a-long-random-secret
 
+# Redis Caching (optional)
+# When set, GET /properties (30s TTL) and GET /lending/pools (10s TTL) are cached.
+# Cache is invalidated automatically on write operations.
+# If not set or Redis is unreachable, the app falls back to direct DB queries.
+# REDIS_URL=redis://localhost:6379
+
 # Soroban / Stellar Configuration
 REAL_ESTATE_TOKEN_CONTRACT_ID=your_real_estate_token_contract_id
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "elysia": "^1.4.26",
     "file-type": "^21.3.4",
     "install": "^0.13.0",
+    "ioredis": "^5.4.2",
     "postgres": "^3.4.8",
     "soroban-client": "^1.0.1",
     "stellar-sdk": "^13.3.0",

--- a/apps/api/src/__tests__/CacheService.test.ts
+++ b/apps/api/src/__tests__/CacheService.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { CacheService } from '../services/CacheService';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a CacheService that is already "connected" to a fake Redis client. */
+function makeConnectedCache() {
+  const store = new Map<string, string>();
+
+  const fakeRedis = {
+    get: async (key: string) => store.get(key) ?? null,
+    set: async (key: string, value: string, _mode: string, _ttl: number) => {
+      store.set(key, value);
+      return 'OK';
+    },
+    del: async (...keys: string[]) => {
+      keys.forEach((k) => store.delete(k));
+      return keys.length;
+    },
+    keys: async (pattern: string) => {
+      // Simple glob: replace '*' with a regex wildcard
+      const regex = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+      return [...store.keys()].filter((k) => regex.test(k));
+    },
+    quit: async () => 'OK',
+    on: () => {},
+  };
+
+  const cache = new CacheService();
+  // Inject the fake client directly (bypasses ioredis import)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (cache as any).client = fakeRedis;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (cache as any).available = true;
+
+  return { cache, store };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CacheService', () => {
+  describe('when Redis is available', () => {
+    it('returns null on cache miss', async () => {
+      const { cache } = makeConnectedCache();
+      const result = await cache.get('missing:key');
+      expect(result).toBeNull();
+    });
+
+    it('stores and retrieves a value (cache hit)', async () => {
+      const { cache } = makeConnectedCache();
+      const payload = { data: [1, 2, 3], pagination: { page: 1 } };
+
+      await cache.set('test:key', payload, 30);
+      const result = await cache.get<typeof payload>('test:key');
+
+      expect(result).toEqual(payload);
+    });
+
+    it('invalidates keys matching a pattern', async () => {
+      const { cache, store } = makeConnectedCache();
+
+      await cache.set('properties:list:1:10', { data: [] }, 30);
+      await cache.set('properties:list:2:10', { data: [] }, 30);
+      await cache.set('lending:pools:1:20', { data: [] }, 10);
+
+      await cache.invalidate('properties:list:*');
+
+      expect(store.has('properties:list:1:10')).toBe(false);
+      expect(store.has('properties:list:2:10')).toBe(false);
+      // Unrelated key must survive
+      expect(store.has('lending:pools:1:20')).toBe(true);
+    });
+
+    it('returns null after invalidation (cache miss)', async () => {
+      const { cache } = makeConnectedCache();
+      await cache.set('properties:list:1:10', { data: [] }, 30);
+      await cache.invalidate('properties:list:*');
+      const result = await cache.get('properties:list:1:10');
+      expect(result).toBeNull();
+    });
+
+    it('isAvailable() returns true when connected', () => {
+      const { cache } = makeConnectedCache();
+      expect(cache.isAvailable()).toBe(true);
+    });
+  });
+
+  describe('when Redis is unavailable (REDIS_URL not set)', () => {
+    it('get() returns null without throwing', async () => {
+      const cache = new CacheService(); // client = null, available = false
+      const result = await cache.get('any:key');
+      expect(result).toBeNull();
+    });
+
+    it('set() is a no-op without throwing', async () => {
+      const cache = new CacheService();
+      await expect(cache.set('any:key', { x: 1 }, 30)).resolves.toBeUndefined();
+    });
+
+    it('invalidate() is a no-op without throwing', async () => {
+      const cache = new CacheService();
+      await expect(cache.invalidate('any:*')).resolves.toBeUndefined();
+    });
+
+    it('isAvailable() returns false', () => {
+      const cache = new CacheService();
+      expect(cache.isAvailable()).toBe(false);
+    });
+
+    it('connect() is a no-op when REDIS_URL is absent', async () => {
+      const original = process.env.REDIS_URL;
+      delete process.env.REDIS_URL;
+
+      const cache = new CacheService();
+      await cache.connect(); // must not throw
+
+      expect(cache.isAvailable()).toBe(false);
+      if (original !== undefined) process.env.REDIS_URL = original;
+    });
+  });
+
+  describe('when Redis client throws unexpectedly', () => {
+    it('get() swallows the error and returns null', async () => {
+      const cache = new CacheService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).client = { get: async () => { throw new Error('network error'); } };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).available = true;
+
+      const result = await cache.get('key');
+      expect(result).toBeNull();
+    });
+
+    it('set() swallows the error silently', async () => {
+      const cache = new CacheService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).client = { set: async () => { throw new Error('network error'); } };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).available = true;
+
+      await expect(cache.set('key', {}, 10)).resolves.toBeUndefined();
+    });
+
+    it('invalidate() swallows the error silently', async () => {
+      const cache = new CacheService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).client = { keys: async () => { throw new Error('network error'); } };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).available = true;
+
+      await expect(cache.invalidate('prefix:*')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/__tests__/CacheService.test.ts
+++ b/apps/api/src/__tests__/CacheService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { CacheService } from '../services/CacheService';
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/controllers/LendingController.ts
+++ b/apps/api/src/controllers/LendingController.ts
@@ -5,6 +5,10 @@ import { userRepository } from '../repositories/UserRepository';
 import { CreatePoolDto, DepositDto, WithdrawDto, BorrowDto, RepayDto } from '../dto/lending.dto';
 import { positionService } from '../services/PositionService';
 import { NotificationService } from '../services/NotificationService';
+import { cacheService } from '../services/CacheService';
+
+const POOLS_CACHE_TTL = 10; // seconds
+const POOLS_CACHE_PREFIX = 'lending:pools:';
 
 export class LendingController {
   private static async resolveAuthenticatedUser(
@@ -36,7 +40,7 @@ export class LendingController {
   }
 
   /**
-   * Get paginated list of lending pools
+   * Get paginated list of lending pools (cached for 10 seconds)
    */
   static async getPools(ctx: Context): Promise<Response> {
     const query = ctx.query as Record<string, string | undefined>;
@@ -45,9 +49,14 @@ export class LendingController {
     const asset = query.asset;
     const isActive = query.isActive !== undefined ? query.isActive === 'true' : undefined;
 
+    const cacheKey = `${POOLS_CACHE_PREFIX}${page}:${limit}:${asset ?? ''}:${isActive ?? ''}`;
+    const cached = await cacheService.get(cacheKey);
+    if (cached) return this.jsonResponse(cached);
+
     const filter = asset || isActive !== undefined ? { asset, isActive } : undefined;
     const result = await lendingRepository.findPaginated({ page, limit }, filter);
 
+    await cacheService.set(cacheKey, result, POOLS_CACHE_TTL);
     return this.jsonResponse(result);
   }
 
@@ -91,6 +100,7 @@ export class LendingController {
       reserveFactor: data.reserveFactor,
     });
 
+    await cacheService.invalidate(`${POOLS_CACHE_PREFIX}*`);
     return this.jsonResponse(pool, 201);
   }
 
@@ -117,6 +127,7 @@ export class LendingController {
 
     const position = await lendingRepository.deposit(poolId, user.id, amount, amount);
 
+    await cacheService.invalidate(`${POOLS_CACHE_PREFIX}*`);
     return this.jsonResponse(position);
   }
 
@@ -150,6 +161,7 @@ export class LendingController {
       throw new ApiError(404, 'NOT_FOUND', 'No deposit position found for this user in this pool');
     }
 
+    await cacheService.invalidate(`${POOLS_CACHE_PREFIX}*`);
     return this.jsonResponse(position);
   }
 
@@ -184,6 +196,7 @@ export class LendingController {
       collateralAsset,
     });
 
+    await cacheService.invalidate(`${POOLS_CACHE_PREFIX}*`);
     return this.jsonResponse(position);
   }
 
@@ -212,6 +225,8 @@ export class LendingController {
     if (!position) {
       throw new ApiError(404, 'NOT_FOUND', 'No borrow position found for this user in this pool');
     }
+
+    await cacheService.invalidate(`${POOLS_CACHE_PREFIX}*`);
 
     // Send repayment processed notification
     const notificationService = new NotificationService();

--- a/apps/api/src/controllers/PropertyController.ts
+++ b/apps/api/src/controllers/PropertyController.ts
@@ -27,6 +27,10 @@ import {
   type NewProperty,
   type PropertyDocument,
 } from '../db/schema';
+import { cacheService } from '../services/CacheService';
+
+const PROPERTIES_CACHE_TTL = 30; // seconds
+const PROPERTIES_CACHE_PREFIX = 'properties:list:';
 
 /**
  * DTO for creating a property
@@ -203,27 +207,46 @@ export class PropertyController {
         filter.verified = true;
       }
 
+      // Build a stable cache key from pagination + filter params
+      const cacheKey =
+        `${PROPERTIES_CACHE_PREFIX}` +
+        `${pagination.page}:${pagination.limit}:` +
+        `${filter.ownerId ?? ''}:${filter.city ?? ''}:${filter.country ?? ''}:` +
+        `${filter.propertyType ?? ''}:${filter.minPricePerShare ?? ''}:` +
+        `${filter.maxPricePerShare ?? ''}:${filter.minAvailableShares ?? ''}:` +
+        `${filter.hasAvailableShares ?? ''}:${filter.verified ?? ''}`;
+
+      const cached = await cacheService.get<PaginatedResponse<PropertyInfo>>(cacheKey);
+      if (cached) {
+        logger.info('Properties served from cache', { operation: 'READ', entity: 'property' });
+        return cached;
+      }
+
       const result: PaginatedResult<Property> = await propertyRepository.findPaginated(
         pagination,
         Object.keys(filter).length > 0 ? filter : undefined,
       );
 
       // Map properties to PropertyInfo
-      const properties = await Promise.all(
+      const mappedProperties = await Promise.all(
         result.data.map((property) => mapPropertyToPropertyInfo(property)),
       );
+
+      const response: PaginatedResponse<PropertyInfo> = {
+        data: mappedProperties,
+        pagination: result.pagination,
+      };
+
+      await cacheService.set(cacheKey, response, PROPERTIES_CACHE_TTL);
 
       logger.info('Properties fetched successfully', {
         operation: 'READ',
         entity: 'property',
-        count: properties.length,
+        count: mappedProperties.length,
         duration: Date.now() - startTime,
       });
 
-      return {
-        data: properties,
-        pagination: result.pagination,
-      };
+      return response;
     } catch (error) {
       logger.error('Failed to fetch properties', { error, operation: 'READ', entity: 'property' });
       throw error;
@@ -329,6 +352,8 @@ export class PropertyController {
       const property = await propertyRepository.create(newProperty);
       const propertyInfo = await mapPropertyToPropertyInfo(property, userAddress);
 
+      await cacheService.invalidate(`${PROPERTIES_CACHE_PREFIX}*`);
+
       logger.info('Property created successfully', {
         operation: 'CREATE',
         entity: 'property',
@@ -400,6 +425,8 @@ export class PropertyController {
 
       const propertyInfo = await mapPropertyToPropertyInfo(updatedProperty, userAddress);
 
+      await cacheService.invalidate(`${PROPERTIES_CACHE_PREFIX}*`);
+
       logger.info('Property updated successfully', {
         operation: 'UPDATE',
         entity: 'property',
@@ -460,6 +487,8 @@ export class PropertyController {
       if (!deleted) {
         throw new Error('Failed to delete property');
       }
+
+      await cacheService.invalidate(`${PROPERTIES_CACHE_PREFIX}*`);
 
       logger.info('Property deleted successfully', {
         operation: 'DELETE',
@@ -618,6 +647,8 @@ export class PropertyController {
         shares: data.shares,
         duration: Date.now() - startTime,
       });
+
+      await cacheService.invalidate(`${PROPERTIES_CACHE_PREFIX}*`);
 
       return {
         transactionHash,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { kycRoutes } from './routes/kyc';
 import { oracleRoutes } from './routes/oracle';
 import { riskMonitoringRoutes } from './routes/riskMonitoring';
 import { errorHandler } from './middleware/errorHandler';
+import { cacheService } from './services/CacheService';
 
 app
   .use(
@@ -54,11 +55,14 @@ app
 console.log(`🚀 Real Estate DeFi API is running on port ${process.env.PORT || 3001}`);
 console.log(`📚 Swagger docs available at http://localhost:${process.env.PORT || 3001}/swagger`);
 
-const shutdown = async (signal: string) => {
-  console.log(`\n${signal} received, closing database connections...`);
-  await closeDatabaseConnection();
+// Connect to Redis (non-blocking — app works without it)
+cacheService.connect();
 
-  console.log('Database connections closed. Exiting...');
+const shutdown = async (signal: string) => {
+  console.log(`\n${signal} received, closing connections...`);
+  await Promise.all([closeDatabaseConnection(), cacheService.disconnect()]);
+
+  console.log('Connections closed. Exiting...');
   process.exit(0);
 };
 

--- a/apps/api/src/services/CacheService.ts
+++ b/apps/api/src/services/CacheService.ts
@@ -1,0 +1,105 @@
+import { logger } from './logger';
+
+interface RedisClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, expiryMode: string, time: number): Promise<unknown>;
+  del(...keys: string[]): Promise<unknown>;
+  keys(pattern: string): Promise<string[]>;
+  quit(): Promise<unknown>;
+}
+
+/**
+ * CacheService wraps ioredis with graceful fallback when Redis is unavailable.
+ * If REDIS_URL is not set or the connection fails, all operations are no-ops
+ * and the app continues to query the database directly.
+ */
+export class CacheService {
+  private client: RedisClient | null = null;
+  private available = false;
+
+  async connect(): Promise<void> {
+    const redisUrl = process.env.REDIS_URL;
+    if (!redisUrl) {
+      logger.info('REDIS_URL not set — caching disabled');
+      return;
+    }
+
+    try {
+      // Dynamic import so the app starts fine even if ioredis is not installed
+      const { default: Redis } = await import('ioredis');
+      const redis = new Redis(redisUrl, {
+        lazyConnect: true,
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 1,
+        connectTimeout: 3000,
+      });
+
+      await redis.connect();
+      this.client = redis as unknown as RedisClient;
+      this.available = true;
+      logger.info('Redis connected — caching enabled');
+
+      redis.on('error', (err: Error) => {
+        if (this.available) {
+          logger.warn('Redis error — falling back to DB queries', { error: err.message });
+          this.available = false;
+        }
+      });
+
+      redis.on('connect', () => {
+        if (!this.available) {
+          logger.info('Redis reconnected — caching re-enabled');
+          this.available = true;
+        }
+      });
+    } catch (err) {
+      logger.warn('Redis unavailable — caching disabled', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    if (!this.available || !this.client) return null;
+    try {
+      const raw = await this.client.get(key);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+    if (!this.available || !this.client) return;
+    try {
+      await this.client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+    } catch {
+      // silent — cache write failure is non-fatal
+    }
+  }
+
+  async invalidate(pattern: string): Promise<void> {
+    if (!this.available || !this.client) return;
+    try {
+      const keys = await this.client.keys(pattern);
+      if (keys.length > 0) {
+        await this.client.del(...keys);
+      }
+    } catch {
+      // silent
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      await this.client.quit();
+      this.available = false;
+    }
+  }
+
+  isAvailable(): boolean {
+    return this.available;
+  }
+}
+
+export const cacheService = new CacheService();


### PR DESCRIPTION
## What was changed 

CacheService added at 
CacheService.ts
 with get / set / invalidate / disconnect — wraps ioredis with full graceful fallback when Redis is down or REDIS_URL is unset.

GET /properties now caches for 30s, keyed by all pagination + filter params. GET /lending/pools caches for 10s. Both invalidate their respective key namespaces (properties:list:* and lending:pools:*) on every write operation (create, update, delete, buy shares, deposit, withdraw, borrow, repay).

index.ts
 calls cacheService.connect() on startup (non-blocking) and cacheService.disconnect() on shutdown alongside the DB.

REDIS_URL documented in .env.example with explanation. ioredis added to package.json. Architecture section in README.md updated. All 13 unit tests cover cache hit, miss, invalidation, and Redis-unavailable scenarios.



Close #769 