### PR TITLE
fix(api): remove N+1 on property listing (join owner)

### DIFF
--- a/apps/api/src/__tests__/PropertyController.getProperties.queries.test.ts
+++ b/apps/api/src/__tests__/PropertyController.getProperties.queries.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, spyOn, beforeEach } from 'bun:test';
+import { PropertyController } from '../controllers/PropertyController';
+import { propertyRepository, type PropertyListRow } from '../repositories/PropertyRepository';
+import { userRepository } from '../repositories/UserRepository';
+import { cacheService } from '../services/CacheService';
+import { logger } from '../services/logger';
+
+function listRow(id: string, ownerId: string, wallet: string): PropertyListRow {
+  return {
+    id,
+    name: 'Test property',
+    description: 'A test property description with enough characters',
+    propertyType: 'residential',
+    location: { address: '1 Main', city: 'Miami', country: 'US' },
+    totalValue: '100000.00',
+    tokenAddress: null,
+    sorobanPropertyId: null,
+    totalShares: 100,
+    availableShares: 100,
+    pricePerShare: '1000.00',
+    images: [],
+    verified: true,
+    reviewStatus: 'approved',
+    lastReviewNote: null,
+    lastReviewedAt: null,
+    lastReviewerWallet: null,
+    listedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ownerId,
+    ownerWalletAddress: wallet,
+    ownerKycStatus: 'approved',
+    ownerKycTier: 'basic',
+  };
+}
+
+describe('PropertyController.getProperties', () => {
+  beforeEach(() => {
+    spyOn(logger, 'info').mockImplementation(() => {});
+    spyOn(logger, 'error').mockImplementation(() => {});
+    spyOn(cacheService, 'get').mockResolvedValue(null);
+    spyOn(cacheService, 'set').mockResolvedValue(undefined);
+  });
+
+  it('loads owner wallets in one repository call without per-row user lookups', async () => {
+    const rows: PropertyListRow[] = [
+      listRow(
+        '11111111-1111-1111-1111-111111111101',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2T',
+      ),
+      listRow(
+        '11111111-1111-1111-1111-111111111102',
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB2T',
+      ),
+      listRow(
+        '11111111-1111-1111-1111-111111111103',
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC2T',
+      ),
+    ];
+
+    const findPaginatedSpy = spyOn(propertyRepository, 'findPaginated').mockResolvedValue({
+      data: rows,
+      pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+    });
+    const findUserByIdSpy = spyOn(userRepository, 'findById');
+
+    const out = await PropertyController.getProperties({ page: 1, limit: 20 });
+
+    expect(findPaginatedSpy).toHaveBeenCalledTimes(1);
+    expect(findUserByIdSpy).not.toHaveBeenCalled();
+    expect(out.data).toHaveLength(3);
+    expect(out.data.map((p) => p.owner)).toEqual(rows.map((r) => r.ownerWalletAddress));
+  });
+});

--- a/apps/api/src/controllers/OperationalPropertyController.ts
+++ b/apps/api/src/controllers/OperationalPropertyController.ts
@@ -114,19 +114,14 @@ export class OperationalPropertyController {
       reviewStatuses ? { reviewStatuses } : undefined,
     );
 
-    const ownerIds = [...new Set(result.data.map((p) => p.ownerId))];
-    const owners = await userRepository.findByIds(ownerIds);
-    const ownerById = new Map(owners.map((u) => [u.id, u]));
-
     const docCounts = await propertyRepository.countDocumentsByPropertyIds(
       result.data.map((p) => p.id),
     );
 
     const data: OperationalPropertyListItem[] = result.data.map((p) => {
-      const owner = ownerById.get(p.ownerId);
-      const wallet = owner?.walletAddress ?? '';
+      const wallet = p.ownerWalletAddress;
       const v = valuationSummary(p.id);
-      const kycApproved = owner?.kycStatus === 'approved';
+      const kycApproved = p.ownerKycStatus === 'approved';
 
       return {
         id: p.id,
@@ -137,8 +132,8 @@ export class OperationalPropertyController {
         reviewStatus: p.reviewStatus,
         verified: p.verified,
         ownerWallet: wallet,
-        ownerKycStatus: owner?.kycStatus ?? 'not_started',
-        ownerKycTier: owner?.kycTier ?? 'none',
+        ownerKycStatus: p.ownerKycStatus,
+        ownerKycTier: p.ownerKycTier,
         tokenized: Boolean(p.tokenAddress),
         sorobanPropertyId: p.sorobanPropertyId ?? null,
         valuationState: v.state,

--- a/apps/api/src/controllers/PropertyController.ts
+++ b/apps/api/src/controllers/PropertyController.ts
@@ -17,6 +17,7 @@ import {
   propertyRepository,
   type PropertyFilter,
   type PaginatedResult,
+  type PropertyListRow,
 } from '../repositories/PropertyRepository';
 import { userRepository } from '../repositories/UserRepository';
 import {
@@ -91,9 +92,8 @@ async function mapPropertyToPropertyInfo(
   property: Property & { documents?: PropertyDocument[] },
   ownerAddress?: string,
 ): Promise<PropertyInfo> {
-  // Get owner's wallet address if not provided
   let walletAddress = ownerAddress;
-  if (!walletAddress) {
+  if (walletAddress === undefined) {
     const owner = await userRepository.findById(property.ownerId);
     walletAddress = owner?.walletAddress ?? '';
   }
@@ -222,14 +222,15 @@ export class PropertyController {
         return cached;
       }
 
-      const result: PaginatedResult<Property> = await propertyRepository.findPaginated(
+      const result: PaginatedResult<PropertyListRow> = await propertyRepository.findPaginated(
         pagination,
         Object.keys(filter).length > 0 ? filter : undefined,
       );
 
-      // Map properties to PropertyInfo
       const mappedProperties = await Promise.all(
-        result.data.map((property) => mapPropertyToPropertyInfo(property)),
+        result.data.map((row) =>
+          mapPropertyToPropertyInfo(row, row.ownerWalletAddress),
+        ),
       );
 
       const response: PaginatedResponse<PropertyInfo> = {

--- a/apps/api/src/repositories/PropertyRepository.ts
+++ b/apps/api/src/repositories/PropertyRepository.ts
@@ -1,8 +1,9 @@
-import { eq, and, gte, lte, gt, sql, inArray, type SQL } from 'drizzle-orm';
+import { eq, and, gte, lte, gt, sql, inArray, getTableColumns, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   properties,
   propertyDocuments,
+  users,
   type Property,
   type NewProperty,
   type PropertyDocument,
@@ -53,6 +54,13 @@ export interface PaginatedResult<T> {
     totalPages: number;
   };
 }
+
+/** Property row from paginated list queries with owner joined from `users` (avoids N+1). */
+export type PropertyListRow = Property & {
+  ownerWalletAddress: string;
+  ownerKycStatus: (typeof users.$inferSelect)['kycStatus'];
+  ownerKycTier: (typeof users.$inferSelect)['kycTier'];
+};
 
 export class PropertyRepository extends BaseRepository<typeof properties, Property, NewProperty> {
   constructor() {
@@ -105,7 +113,7 @@ export class PropertyRepository extends BaseRepository<typeof properties, Proper
   async findPaginated(
     options: PaginationOptions,
     filter?: PropertyFilter,
-  ): Promise<PaginatedResult<Property>> {
+  ): Promise<PaginatedResult<PropertyListRow>> {
     const { page, limit } = options;
     const offset = (page - 1) * limit;
 
@@ -119,8 +127,18 @@ export class PropertyRepository extends BaseRepository<typeof properties, Proper
       .where(whereClause);
     const total = countResult[0]?.count ?? 0;
 
-    // Get paginated data
-    const data = await db.select().from(properties).where(whereClause).limit(limit).offset(offset);
+    const data = await db
+      .select({
+        ...getTableColumns(properties),
+        ownerWalletAddress: users.walletAddress,
+        ownerKycStatus: users.kycStatus,
+        ownerKycTier: users.kycTier,
+      })
+      .from(properties)
+      .innerJoin(users, eq(properties.ownerId, users.id))
+      .where(whereClause)
+      .limit(limit)
+      .offset(offset);
 
     return {
       data,


### PR DESCRIPTION
## Summary
- `PropertyRepository.findPaginated` now **inner-joins** `users` and returns owner wallet plus KYC fields in one query per page (plus existing count query).
- `PropertyController.getProperties` passes joined wallet into mapping so **no** `userRepository.findById` per row.
- `OperationalPropertyController.listProperties` uses joined KYC fields instead of a separate `findByIds` batch.

## Test plan
- [x] `bun test` in `apps/api` (includes new unit test: multiple listed properties ⇒ `findById` not called)
- [x] `bun run type-check` / `eslint` in `apps/api`
- [x] `bun run build` in `apps/api`

Fixes #768

Made with [Cursor](https://cursor.com)