### PR TITLE
feat: fetch and refresh XLM balance after wallet connection

### DIFF
--- a/apps/webapp/src/app/lending/page.tsx
+++ b/apps/webapp/src/app/lending/page.tsx
@@ -195,7 +195,8 @@ function StatCardSkeleton() {
 // ---------------------------------------------------------------------------
 
 export default function LendingPage() {
-  const { isConnected, connect, isConnecting, address } = useWallet();
+  const { isConnected, connect, isConnecting, address, refreshBalance } =
+    useWallet();
 
   const {
     pools,
@@ -853,7 +854,10 @@ export default function LendingPage() {
         isOpen={!!selectedPool}
         onClose={() => setSelectedPool(null)}
         userAddress={address}
-        onSuccess={refetch}
+        onSuccess={() => {
+          refetch();
+          void refreshBalance();
+        }}
       />
     </motion.div>
   );

--- a/apps/webapp/src/app/marketplace/page.tsx
+++ b/apps/webapp/src/app/marketplace/page.tsx
@@ -228,7 +228,8 @@ export default function MarketplacePage() {
     lastUpdatedAt,
     isPolling,
   } = useProperties();
-  const { isConnected, connect, isConnecting, address } = useWallet();
+  const { isConnected, connect, isConnecting, address, refreshBalance } =
+    useWallet();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedRegion, setSelectedRegion] = useState(MARKETPLACE_ALL_REGIONS);
@@ -425,7 +426,10 @@ export default function MarketplacePage() {
           isConnected={isConnected}
           walletAddress={address}
           onConnectWallet={connect}
-          onInvestmentSuccess={refetch}
+          onInvestmentSuccess={() => {
+            refetch();
+            void refreshBalance();
+          }}
         />
       )}
 

--- a/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
+++ b/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
 import { useAuthenticationStore } from "../store/data/slices/authentication.slice";
 import { initializeWalletKit, getWalletKit } from "../constant/walletKit";
+import { fetchBalance } from "@/lib/stellar";
 
 export const useWallet = () => {
   const store = useAuthenticationStore();
@@ -36,9 +37,8 @@ export const useWallet = () => {
             store.setAddress(address);
             store.setIsConnected(true);
 
-            // TODO: Fetch balance usando stellar-sdk
-            // const balance = await fetchBalance(address);
-            // store.setBalance(balance);
+            const balance = await fetchBalance(address, store.network);
+            store.setBalance(balance);
           } catch (error) {
             console.error("Error connecting wallet:", error);
             store.reset();
@@ -68,6 +68,12 @@ export const useWallet = () => {
     [store],
   );
 
+  const refreshBalance = useCallback(async () => {
+    if (!store.address) return;
+    const balance = await fetchBalance(store.address, store.network);
+    store.setBalance(balance);
+  }, [store]);
+
   return {
     address: store.address,
     balance: store.balance,
@@ -78,5 +84,6 @@ export const useWallet = () => {
     connect,
     disconnect,
     switchNetwork,
+    refreshBalance,
   };
 };

--- a/apps/webapp/src/lib/__tests__/stellar.test.ts
+++ b/apps/webapp/src/lib/__tests__/stellar.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { fetchBalance, type HorizonServerLike } from "../stellar";
+
+function makeServer(
+  result: Promise<{ balances: Array<{ asset_type: string; balance: string }> }>,
+): HorizonServerLike {
+  return { loadAccount: (_address: string) => result };
+}
+
+describe("fetchBalance", () => {
+  it("returns the native XLM balance for a funded account", async () => {
+    const server = makeServer(
+      Promise.resolve({
+        balances: [
+          { asset_type: "credit_alphanum4", balance: "50.0000000" },
+          { asset_type: "native", balance: "100.5000000" },
+        ],
+      }),
+    );
+    const result = await fetchBalance("GABC1234", "testnet", server);
+    expect(result).toBe("100.5000000");
+  });
+
+  it("returns '0' for an account not yet on-chain (404)", async () => {
+    const notFoundError = Object.assign(new Error("Not Found"), {
+      response: { status: 404 },
+    });
+    const server = makeServer(Promise.reject(notFoundError));
+    const result = await fetchBalance("GNOTFOUND", "testnet", server);
+    expect(result).toBe("0");
+  });
+
+  it("returns '0' and emits a warning on a network error", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const networkError = new Error("Network timeout");
+    const server = makeServer(Promise.reject(networkError));
+    const result = await fetchBalance("GABC1234", "testnet", server);
+    warn.mockRestore();
+    expect(result).toBe("0");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[fetchBalance]"),
+      networkError,
+    );
+  });
+});

--- a/apps/webapp/src/lib/stellar.ts
+++ b/apps/webapp/src/lib/stellar.ts
@@ -1,0 +1,45 @@
+import { Horizon } from "stellar-sdk";
+
+const HORIZON_URLS: Record<"testnet" | "mainnet", string> = {
+  testnet: "https://horizon-testnet.stellar.org",
+  mainnet: "https://horizon.stellar.org",
+};
+
+interface BalanceLine {
+  asset_type: string;
+  balance: string;
+}
+
+interface AccountRecord {
+  balances: BalanceLine[];
+}
+
+/** Minimal Horizon server interface — satisfied by Horizon.Server and injectable mocks */
+export interface HorizonServerLike {
+  loadAccount(address: string): Promise<AccountRecord>;
+}
+
+/**
+ * Fetches the native XLM balance for a Stellar address from Horizon.
+ * Returns "0" for accounts not yet on-chain (unfunded) and for network errors.
+ */
+export async function fetchBalance(
+  address: string,
+  network: "testnet" | "mainnet" = "testnet",
+  server?: HorizonServerLike,
+): Promise<string> {
+  const srv: HorizonServerLike =
+    server ??
+    (new Horizon.Server(HORIZON_URLS[network]) as unknown as HorizonServerLike);
+  try {
+    const account = await srv.loadAccount(address);
+    const native = account.balances.find((b) => b.asset_type === "native");
+    return native?.balance ?? "0";
+  } catch (error) {
+    const res = (error as { response?: { status?: number } }).response;
+    if (res?.status !== 404) {
+      console.warn("[fetchBalance] Failed to fetch balance:", error);
+    }
+    return "0";
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "elysia": "^1.4.26",
         "file-type": "^21.3.4",
         "install": "^0.13.0",
+        "ioredis": "^5.4.2",
         "postgres": "^3.4.8",
         "soroban-client": "^1.0.1",
         "stellar-sdk": "^13.3.0",
@@ -391,6 +392,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -850,7 +853,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -1174,6 +1177,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "co": ["co@4.6.0", "", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
 
     "collect-v8-coverage": ["collect-v8-coverage@1.0.3", "", {}, "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw=="],
@@ -1249,6 +1254,8 @@
     "delay": ["delay@5.0.0", "", {}, "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1546,6 +1553,8 @@
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
@@ -1775,6 +1784,10 @@
     "lit-html": ["lit-html@3.3.2", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
@@ -2006,6 +2019,10 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
@@ -2127,6 +2144,8 @@
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
@@ -2503,8 +2522,6 @@
     "@trezor/utxo-lib/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@trezor/websocket-client/@trezor/utils": ["@trezor/utils@9.4.2", "", { "dependencies": { "bignumber.js": "^9.3.0" }, "peerDependencies": { "tslib": "^2.6.2" } }, "sha512-Fm3m2gmfXsgv4chqn5HX8e8dElEr2ibBJSJ7HE3bsHh/1OSQcDdzsSioAK04Fo9ws/v7n6lt+QBZ6fGmwyIkZQ=="],
-
-    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 


### PR DESCRIPTION
Closes #761

---

- Add fetchBalance() utility in src/lib/stellar.ts using Horizon API; returns "0" for unfunded accounts (404) and network errors
- Wire fetchBalance into useWallet: balance is fetched on connection and exposed via a refreshBalance() callback
- Call refreshBalance after every lending action (deposit, borrow, withdraw, repay) and marketplace share purchase so the UI stays in sync with on-chain state
- Add 3 unit tests: successful fetch, non-existent account, network error fallback


fixe  #761 