### PR TITLE
feat(api): implement notification delivery worker (#759)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,17 @@ OPERATIONS_BACKEND_CREDENTIAL=generate-a-long-random-secret
 # If not set or Redis is unreachable, the app falls back to direct DB queries.
 # REDIS_URL=redis://localhost:6379
 
+# Notification delivery worker
+# Set NOTIFICATIONS_ENABLED=false to disable the background worker entirely.
+# When enabled, the worker polls pending notifications and POSTs them to
+# NOTIFICATION_WEBHOOK_URL. If NOTIFICATION_WEBHOOK_URL is unset, the worker
+# runs but logs a warning and leaves notifications in PENDING.
+NOTIFICATIONS_ENABLED=true
+# NOTIFICATION_WEBHOOK_URL=https://your-delivery-endpoint.example.com/notifications
+# NOTIFICATION_WEBHOOK_SECRET=change-me
+# NOTIFICATION_POLL_INTERVAL_MS=5000
+# NOTIFICATION_REQUEST_TIMEOUT_MS=10000
+
 # Soroban / Stellar Configuration
 REAL_ESTATE_TOKEN_CONTRACT_ID=your_real_estate_token_contract_id
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/apps/api/src/__tests__/notificationWorker.test.ts
+++ b/apps/api/src/__tests__/notificationWorker.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { NotificationWorker } from '../workers/notificationWorker';
+import type { NotificationService } from '../services/NotificationService';
+import type { Notification } from '../db/schema';
+
+type MockedService = {
+  getPendingNotifications: ReturnType<typeof mock>;
+  getNotificationsReadyForRetry: ReturnType<typeof mock>;
+  markAsDelivered: ReturnType<typeof mock>;
+  markAsFailed: ReturnType<typeof mock>;
+};
+
+function sampleNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 'n-1',
+    userId: 'u-1',
+    eventType: 'SYSTEM_ALERT',
+    title: 'Test',
+    message: 'Test message',
+    channel: 'EMAIL',
+    recipient: 'user@example.com',
+    relatedEntityType: null,
+    relatedEntityId: null,
+    deliveryStatus: 'PENDING',
+    retryCount: '0',
+    maxRetries: '3',
+    isRead: false,
+    readAt: null,
+    sentAt: null,
+    deliveredAt: null,
+    failureReason: null,
+    nextRetryAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Notification;
+}
+
+function makeService(overrides: Partial<MockedService> = {}): MockedService {
+  return {
+    getPendingNotifications: mock(() => Promise.resolve([])),
+    getNotificationsReadyForRetry: mock(() => Promise.resolve([])),
+    markAsDelivered: mock(() => Promise.resolve(undefined)),
+    markAsFailed: mock(() => Promise.resolve(undefined)),
+    ...overrides,
+  };
+}
+
+describe('NotificationWorker', () => {
+  describe('successful delivery', () => {
+    it('POSTs the notification to the webhook and marks it delivered', async () => {
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([sampleNotification()])),
+      });
+      const fetchImpl = mock(async () => new Response(null, { status: 200 }));
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: 'https://example.com/hook',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      await worker.tick();
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!;
+      expect(url).toBe('https://example.com/hook');
+      expect((init as RequestInit).method).toBe('POST');
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.id).toBe('n-1');
+      expect(body.eventType).toBe('SYSTEM_ALERT');
+
+      expect(service.markAsDelivered).toHaveBeenCalledWith('n-1');
+      expect(service.markAsFailed).not.toHaveBeenCalled();
+    });
+
+    it('processes pending and retry-ready notifications in the same tick', async () => {
+      const pending = sampleNotification({ id: 'p-1' });
+      const retry = sampleNotification({ id: 'r-1', deliveryStatus: 'FAILED' });
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([pending])),
+        getNotificationsReadyForRetry: mock(() => Promise.resolve([retry])),
+      });
+      const fetchImpl = mock(async () => new Response(null, { status: 200 }));
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: 'https://example.com/hook',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      await worker.tick();
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(service.markAsDelivered).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('retry on failure', () => {
+    it('marks the notification as failed when the webhook returns a non-2xx response', async () => {
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([sampleNotification()])),
+      });
+      const fetchImpl = mock(async () => new Response('bad gateway', { status: 502 }));
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: 'https://example.com/hook',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      await worker.tick();
+
+      expect(service.markAsDelivered).not.toHaveBeenCalled();
+      expect(service.markAsFailed).toHaveBeenCalledTimes(1);
+      const call = (service.markAsFailed as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0]!;
+      expect(call[0]).toBe('n-1');
+      expect(String(call[1])).toContain('502');
+    });
+
+    it('marks the notification as failed when fetch throws', async () => {
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([sampleNotification()])),
+      });
+      const fetchImpl = mock(async () => {
+        throw new Error('network down');
+      });
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: 'https://example.com/hook',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      await worker.tick();
+
+      expect(service.markAsFailed).toHaveBeenCalledWith('n-1', 'network down');
+    });
+  });
+
+  describe('permanent failure', () => {
+    it('still calls markAsFailed on the last attempt — the service decides the terminal state', async () => {
+      // This notification is on its 3rd attempt (retryCount=2, maxRetries=3).
+      // NotificationService.markAsFailed is responsible for flipping to permanent FAILED;
+      // the worker must always delegate retry accounting to it.
+      const note = sampleNotification({ retryCount: '2', maxRetries: '3' });
+
+      const markAsFailed = mock((_id: string, _reason: string) =>
+        Promise.resolve({
+          ...note,
+          deliveryStatus: 'FAILED',
+          retryCount: '3',
+          nextRetryAt: null,
+        } as Notification),
+      );
+
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([note])),
+        markAsFailed,
+      });
+      const fetchImpl = mock(async () => new Response(null, { status: 500 }));
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: 'https://example.com/hook',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      await worker.tick();
+
+      expect(markAsFailed).toHaveBeenCalledTimes(1);
+      const [id, reason] = (markAsFailed as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0]!;
+      expect(id).toBe('n-1');
+      expect(String(reason)).toMatch(/500/);
+    });
+  });
+
+  describe('configuration and lifecycle', () => {
+    it('skips dispatch without marking failed when no webhook URL is configured', async () => {
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([sampleNotification()])),
+      });
+      const fetchImpl = mock(async () => new Response(null, { status: 200 }));
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: undefined,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      await worker.tick();
+
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(service.markAsDelivered).not.toHaveBeenCalled();
+      expect(service.markAsFailed).not.toHaveBeenCalled();
+    });
+
+    it('start() and stop() do not leave timers behind', async () => {
+      const service = makeService();
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 1_000_000,
+        webhookUrl: 'https://example.com/hook',
+      });
+      worker.start();
+      worker.start();
+      await worker.stop();
+      expect(worker.isRunning()).toBe(false);
+    });
+
+    it('overlapping ticks are prevented — a second tick is a no-op while the first is running', async () => {
+      let resolveFetch: ((value: Response) => void) | null = null;
+      const service = makeService({
+        getPendingNotifications: mock(() => Promise.resolve([sampleNotification()])),
+      });
+      const fetchImpl = mock(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+
+      const worker = new NotificationWorker(service as unknown as NotificationService, {
+        pollIntervalMs: 10_000,
+        webhookUrl: 'https://example.com/hook',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      const firstTick = worker.tick();
+      // Yield so the first tick can reach the fetch call before we fire the second.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      const secondTick = worker.tick();
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      resolveFetch!(new Response(null, { status: 200 }));
+      await Promise.all([firstTick, secondTick]);
+    });
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,8 @@ import { oracleRoutes } from './routes/oracle';
 import { riskMonitoringRoutes } from './routes/riskMonitoring';
 import { errorHandler } from './middleware/errorHandler';
 import { cacheService } from './services/CacheService';
+import { NotificationService } from './services/NotificationService';
+import { createNotificationWorkerFromEnv } from './workers/notificationWorker';
 
 app
   .use(
@@ -58,9 +60,17 @@ console.log(`📚 Swagger docs available at http://localhost:${process.env.PORT 
 // Connect to Redis (non-blocking — app works without it)
 cacheService.connect();
 
+// Start the notification delivery worker (opt-out via NOTIFICATIONS_ENABLED=false)
+const notificationWorker = createNotificationWorkerFromEnv(new NotificationService());
+notificationWorker?.start();
+
 const shutdown = async (signal: string) => {
   console.log(`\n${signal} received, closing connections...`);
-  await Promise.all([closeDatabaseConnection(), cacheService.disconnect()]);
+  await Promise.all([
+    closeDatabaseConnection(),
+    cacheService.disconnect(),
+    notificationWorker?.stop() ?? Promise.resolve(),
+  ]);
 
   console.log('Connections closed. Exiting...');
   process.exit(0);

--- a/apps/api/src/repositories/NotificationRepository.ts
+++ b/apps/api/src/repositories/NotificationRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql, gte } from 'drizzle-orm';
+import { eq, and, desc, sql, lte, or, isNull } from 'drizzle-orm';
 import { db } from '../db';
 import {
   notifications,
@@ -127,14 +127,19 @@ export class NotificationRepository extends BaseRepository<
   }
 
   /**
-   * Find notifications ready for retry
+   * Find notifications ready for retry (FAILED and nextRetryAt is due or null).
    */
   async findReadyForRetry(): Promise<Notification[]> {
     const now = new Date();
     return db
       .select()
       .from(notifications)
-      .where(and(eq(notifications.deliveryStatus, 'FAILED'), gte(notifications.nextRetryAt, now)))
+      .where(
+        and(
+          eq(notifications.deliveryStatus, 'FAILED'),
+          or(lte(notifications.nextRetryAt, now), isNull(notifications.nextRetryAt)),
+        ),
+      )
       .orderBy(notifications.nextRetryAt);
   }
 

--- a/apps/api/src/workers/notificationWorker.ts
+++ b/apps/api/src/workers/notificationWorker.ts
@@ -1,0 +1,202 @@
+import { NotificationService } from '../services/NotificationService';
+import { logger } from '../services/logger';
+import type { Notification } from '../db/schema';
+
+export interface NotificationWorkerConfig {
+  pollIntervalMs?: number;
+  webhookUrl?: string;
+  webhookSecret?: string;
+  requestTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+interface ResolvedConfig {
+  pollIntervalMs: number;
+  webhookUrl?: string;
+  webhookSecret?: string;
+  requestTimeoutMs: number;
+  fetchImpl: typeof fetch;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+export class NotificationWorker {
+  private readonly service: NotificationService;
+  private readonly config: ResolvedConfig;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+  private processing = false;
+
+  constructor(service: NotificationService, config?: NotificationWorkerConfig) {
+    this.service = service;
+    const envPoll = Number(process.env.NOTIFICATION_POLL_INTERVAL_MS);
+    const envTimeout = Number(process.env.NOTIFICATION_REQUEST_TIMEOUT_MS);
+    this.config = {
+      pollIntervalMs:
+        config?.pollIntervalMs ??
+        (Number.isFinite(envPoll) && envPoll > 0 ? envPoll : DEFAULT_POLL_INTERVAL_MS),
+      webhookUrl: config?.webhookUrl ?? process.env.NOTIFICATION_WEBHOOK_URL,
+      webhookSecret: config?.webhookSecret ?? process.env.NOTIFICATION_WEBHOOK_SECRET,
+      requestTimeoutMs:
+        config?.requestTimeoutMs ??
+        (Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : DEFAULT_REQUEST_TIMEOUT_MS),
+      fetchImpl: config?.fetchImpl ?? fetch,
+    };
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    logger.info('Notification worker started', {
+      operation: 'NOTIFICATION_WORKER_START',
+      pollIntervalMs: this.config.pollIntervalMs,
+      webhookConfigured: Boolean(this.config.webhookUrl),
+    });
+    this.scheduleNext();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    while (this.processing) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    logger.info('Notification worker stopped', { operation: 'NOTIFICATION_WORKER_STOP' });
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  async tick(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+    try {
+      const [pending, readyForRetry] = await Promise.all([
+        this.service.getPendingNotifications(),
+        this.service.getNotificationsReadyForRetry(),
+      ]);
+
+      const seen = new Set<string>();
+      const queue = [...pending, ...readyForRetry].filter((n) => {
+        if (seen.has(n.id)) return false;
+        seen.add(n.id);
+        return true;
+      });
+
+      for (const notification of queue) {
+        await this.dispatch(notification);
+      }
+    } catch (error) {
+      logger.error('Notification worker tick failed', {
+        operation: 'NOTIFICATION_WORKER_TICK',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.processing = false;
+      this.scheduleNext();
+    }
+  }
+
+  private scheduleNext(): void {
+    if (!this.running) return;
+    this.timer = setTimeout(() => {
+      void this.tick();
+    }, this.config.pollIntervalMs);
+    // Don't keep the event loop alive just for the worker poll.
+    const t = this.timer as unknown as { unref?: () => void };
+    if (typeof t.unref === 'function') t.unref();
+  }
+
+  private async dispatch(notification: Notification): Promise<void> {
+    if (!this.config.webhookUrl) {
+      logger.warn('No NOTIFICATION_WEBHOOK_URL configured, skipping dispatch', {
+        operation: 'NOTIFICATION_DISPATCH_SKIPPED',
+        notificationId: notification.id,
+      });
+      return;
+    }
+
+    const payload = {
+      id: notification.id,
+      userId: notification.userId,
+      eventType: notification.eventType,
+      title: notification.title,
+      message: notification.message,
+      channel: notification.channel,
+      recipient: notification.recipient,
+      relatedEntityType: notification.relatedEntityType,
+      relatedEntityId: notification.relatedEntityId,
+      metadata: this.parseMetadata(notification.metadata),
+      createdAt: notification.createdAt,
+    };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.config.requestTimeoutMs);
+
+    try {
+      const response = await this.config.fetchImpl(this.config.webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(this.config.webhookSecret ? { 'X-Webhook-Secret': this.config.webhookSecret } : {}),
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const reason = `Webhook responded with ${response.status}`;
+        await this.service.markAsFailed(notification.id, reason);
+        logger.warn('Notification delivery failed', {
+          operation: 'NOTIFICATION_DELIVERY_FAILED',
+          notificationId: notification.id,
+          status: response.status,
+        });
+        return;
+      }
+
+      await this.service.markAsDelivered(notification.id);
+      logger.info('Notification delivered', {
+        operation: 'NOTIFICATION_DELIVERED',
+        notificationId: notification.id,
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      await this.service.markAsFailed(notification.id, reason);
+      logger.error('Notification delivery error', {
+        operation: 'NOTIFICATION_DELIVERY_ERROR',
+        notificationId: notification.id,
+        error: reason,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private parseMetadata(raw: string | null): Record<string, unknown> | null {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function createNotificationWorkerFromEnv(
+  service: NotificationService,
+): NotificationWorker | null {
+  const enabled = (process.env.NOTIFICATIONS_ENABLED ?? 'true').toLowerCase() !== 'false';
+  if (!enabled) {
+    logger.info('Notification worker disabled via NOTIFICATIONS_ENABLED=false', {
+      operation: 'NOTIFICATION_WORKER_DISABLED',
+    });
+    return null;
+  }
+  return new NotificationWorker(service);
+}


### PR DESCRIPTION
## Summary

Implements the missing notification delivery worker described in #759. NotificationService already queued messages and exposed the delivery primitives (`getPendingNotifications`, `markAsDelivered`, `markAsFailed`), but nothing consumed the queue — every KYC/risk/liquidation notification was silently dropped after being stored.

This PR adds a background worker that polls the queue on a configurable interval, dispatches each message through a webhook channel, and delegates retry accounting to the existing service so `maxRetries` / `retryDelayMs` are honoured end-to-end.

---

## Changes

### New files
- `apps/api/src/workers/notificationWorker.ts` — `NotificationWorker` class + `createNotificationWorkerFromEnv()` factory
- `apps/api/src/__tests__/notificationWorker.test.ts` — 8 unit tests covering the acceptance criteria

### Modified files
- `apps/api/src/index.ts` — worker is started alongside the API and stopped as part of the graceful shutdown, next to the Redis client
- `apps/api/src/repositories/NotificationRepository.ts` — fixed `findReadyForRetry`: the predicate used `gte(nextRetryAt, now)` which matched only retries scheduled for the **future**, so no retry ever fired. Now uses `lte(nextRetryAt, now) OR nextRetryAt IS NULL` so due retries are actually picked up
- `apps/api/.env.example` — documents `NOTIFICATIONS_ENABLED`, `NOTIFICATION_WEBHOOK_URL`, `NOTIFICATION_WEBHOOK_SECRET`, `NOTIFICATION_POLL_INTERVAL_MS`, `NOTIFICATION_REQUEST_TIMEOUT_MS`

### Design notes
- **Delivery channel**: `POST` to `NOTIFICATION_WEBHOOK_URL` with a JSON body (`id`, `userId`, `eventType`, `title`, `message`, `channel`, `recipient`, `relatedEntity*`, `metadata`, `createdAt`). An optional `NOTIFICATION_WEBHOOK_SECRET` is sent as `X-Webhook-Secret`. Each request is bounded by an `AbortController` (default 10s, override via `NOTIFICATION_REQUEST_TIMEOUT_MS`).
- **Retry logic**: on any non-2xx response or thrown error the worker calls `NotificationService.markAsFailed(id, reason)`. That method is the single source of truth for retry accounting — it increments `retryCount`, schedules `nextRetryAt = now + retryDelayMs * retryCount`, and flips to permanent `FAILED` once `retryCount >= maxRetries`. The worker deliberately doesn't duplicate this logic.
- **Non-blocking**: the poll loop uses a recursive `setTimeout` that is `unref()`-ed, so it never holds the event loop open on its own. A `processing` flag prevents overlapping ticks. Failures inside a tick are caught and logged — they never kill the loop.
- **Toggle**: `NOTIFICATIONS_ENABLED=false` short-circuits `createNotificationWorkerFromEnv` and the worker is never constructed. Defaults to enabled.
- **No webhook configured**: the worker still runs, but logs a warning and leaves notifications in `PENDING` rather than marking them failed — this avoids draining the retry budget on misconfigured environments.

---

## Acceptance criteria

- [x] Worker starts with the API and can be disabled via `NOTIFICATIONS_ENABLED=false`
- [x] At least one delivery channel implemented (webhook `POST`)
- [x] Retry logic honours existing `maxRetries` / `retryDelayMs` config (delegated to `NotificationService.markAsFailed`)
- [x] Worker does not block the main event loop (`setTimeout` + `unref`, async dispatch, overlap guard)
- [x] Unit tests cover successful delivery, retry on failure, and permanent failure

---

## Test plan

- [x] `bun test` — 160 pass / 0 fail (8 new tests for the worker)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [ ] Manual: set `NOTIFICATION_WEBHOOK_URL` to a local `nc -l 8080` or `webhook.site`, create a notification via the service, confirm a `POST` arrives and the row flips to `DELIVERED`
- [ ] Manual: point `NOTIFICATION_WEBHOOK_URL` at an endpoint returning 500, confirm `retryCount` increments and `nextRetryAt` is populated each tick, then flips to `FAILED` once `maxRetries` is reached
- [ ] Manual: start the API with `NOTIFICATIONS_ENABLED=false` and confirm no worker log appears

Closes #759