### PR TITLE
feat: Redis-backed distributed rate limiting with in-memory fallback

### DIFF
--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,47 +1,169 @@
 import { describe, it, expect } from 'bun:test';
-import { rateLimit } from './rateLimit';
+import { rateLimit, createRedisStore, createMemoryStore } from './rateLimit';
+import type { RateLimitRedisClient } from './rateLimit';
 
-function createMockRequest(
-  options: {
-    headers?: Record<string, string>;
-  } = {},
-) {
+function createMockRequest(options: { headers?: Record<string, string> } = {}) {
   const headers = new Headers(options.headers ?? {});
-  return {
-    headers,
-  } as unknown as Request;
+  return { headers } as unknown as Request;
 }
 
 function createMockSet() {
-  const set = {
+  return {
     status: undefined as number | string | undefined,
     headers: undefined as Record<string, string> | undefined,
   };
-  return set;
 }
+
+// ---------------------------------------------------------------------------
+// createMemoryStore
+// ---------------------------------------------------------------------------
+
+describe('createMemoryStore', () => {
+  it('allows the first request', async () => {
+    const store = createMemoryStore();
+    const result = await store.checkLimit('test-id', 60000, 10);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(9);
+  });
+
+  it('blocks requests over the limit', async () => {
+    const store = createMemoryStore();
+    for (let i = 0; i < 3; i++) await store.checkLimit('id', 60000, 3);
+    const result = await store.checkLimit('id', 60000, 3);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfter).toBeGreaterThan(0);
+  });
+
+  it('resets the window after expiry', async () => {
+    const store = createMemoryStore();
+    await store.checkLimit('id', 1, 1); // 1ms window
+    await store.checkLimit('id', 1, 1); // over limit
+    await new Promise((r) => setTimeout(r, 5));
+    const result = await store.checkLimit('id', 1, 1); // new window
+    expect(result.allowed).toBe(true);
+  });
+
+  it('tracks identifiers independently', async () => {
+    const store = createMemoryStore();
+    await store.checkLimit('a', 60000, 1);
+    const resultA = await store.checkLimit('a', 60000, 1);
+    const resultB = await store.checkLimit('b', 60000, 1);
+    expect(resultA.allowed).toBe(false);
+    expect(resultB.allowed).toBe(true);
+  });
+
+  it('sets resetAt in the future', async () => {
+    const store = createMemoryStore();
+    const before = Date.now();
+    const result = await store.checkLimit('id', 60000, 10);
+    expect(result.resetAt).toBeGreaterThanOrEqual(before + 60000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createRedisStore
+// ---------------------------------------------------------------------------
+
+describe('createRedisStore', () => {
+  function makeFakeRedisClient(): RateLimitRedisClient & { counts: Map<string, number> } {
+    const counts = new Map<string, number>();
+    const ttls = new Map<string, number>();
+    return {
+      counts,
+      async incr(key: string) {
+        const c = (counts.get(key) ?? 0) + 1;
+        counts.set(key, c);
+        return c;
+      },
+      async expire(key: string, seconds: number) {
+        ttls.set(key, seconds);
+        return 1;
+      },
+      async ttl(key: string) {
+        return ttls.get(key) ?? 60;
+      },
+    };
+  }
+
+  it('allows the first request and sets expiry', async () => {
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    const result = await store.checkLimit('user:abc', 60000, 10);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(9);
+  });
+
+  it('only calls expire on the first increment', async () => {
+    const client = makeFakeRedisClient();
+    const expireCalls: string[] = [];
+    const origExpire = client.expire.bind(client);
+    client.expire = async (key, secs) => {
+      expireCalls.push(key);
+      return origExpire(key, secs);
+    };
+
+    const store = createRedisStore(client);
+    await store.checkLimit('id', 60000, 5);
+    await store.checkLimit('id', 60000, 5);
+    await store.checkLimit('id', 60000, 5);
+
+    expect(expireCalls.length).toBe(1);
+  });
+
+  it('blocks requests over the limit', async () => {
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    for (let i = 0; i < 3; i++) await store.checkLimit('id', 60000, 3);
+    const result = await store.checkLimit('id', 60000, 3);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfter).toBeGreaterThanOrEqual(0);
+  });
+
+  it('uses TTL from Redis for resetAt', async () => {
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    const before = Date.now();
+    const result = await store.checkLimit('id', 60000, 10);
+    // TTL defaults to 60s in our fake client
+    expect(result.resetAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('prefixes the key with ratelimit:', async () => {
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    await store.checkLimit('user:xyz', 60000, 5);
+    expect(client.counts.has('ratelimit:user:xyz')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rateLimit middleware (in-memory mode — no REDIS_URL in tests)
+// ---------------------------------------------------------------------------
 
 describe('rateLimit middleware', () => {
   describe('basic rate limiting', () => {
-    it('should allow requests under the limit', () => {
+    it('should allow requests under the limit', async () => {
       const middleware = rateLimit({ max: 10, windowMs: 60000 });
       const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.2.1' } });
       const set = createMockSet();
 
-      const result = middleware({ request, set });
+      const result = await middleware({ request, set });
 
       expect(result).toBeUndefined();
       expect(set.status).toBeUndefined();
     });
 
-    it('should block requests over the limit', () => {
+    it('should block requests over the limit', async () => {
       const middleware = rateLimit({ max: 3, windowMs: 60000 });
       const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.2.2' } });
       const set = createMockSet();
 
-      middleware({ request, set }); // 1st request
-      middleware({ request, set }); // 2nd request
-      middleware({ request, set }); // 3rd request
-      const result = middleware({ request, set }); // 4th request - should be blocked
+      await middleware({ request, set }); // 1st
+      await middleware({ request, set }); // 2nd
+      await middleware({ request, set }); // 3rd
+      const result = await middleware({ request, set }); // 4th — blocked
 
       expect(result).toEqual({
         success: false,
@@ -51,12 +173,12 @@ describe('rateLimit middleware', () => {
       expect(set.status).toBe(429);
     });
 
-    it('should set rate limit headers', () => {
+    it('should set rate limit headers', async () => {
       const middleware = rateLimit({ max: 10, windowMs: 60000 });
       const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.3.1' } });
       const set = createMockSet();
 
-      middleware({ request, set });
+      await middleware({ request, set });
 
       expect(set.headers).toBeDefined();
       expect(set.headers!['X-RateLimit-Limit']).toBe('10');
@@ -66,41 +188,41 @@ describe('rateLimit middleware', () => {
   });
 
   describe('identifier differentiation', () => {
-    it('should track anonymous users by IP', () => {
+    it('should track anonymous users by IP', async () => {
       const middleware = rateLimit({ max: 2, windowMs: 60000 });
 
-      const request1 = createMockRequest({ headers: { 'x-forwarded-for': '198.51.100.1' } });
-      const request2 = createMockRequest({ headers: { 'x-forwarded-for': '198.51.100.2' } });
+      const req1 = createMockRequest({ headers: { 'x-forwarded-for': '198.51.100.1' } });
+      const req2 = createMockRequest({ headers: { 'x-forwarded-for': '198.51.100.2' } });
       const set1 = createMockSet();
       const set2 = createMockSet();
 
-      middleware({ request: request1, set: set1 }); // 1st for IP1
-      middleware({ request: request1, set: set1 }); // 2nd for IP1 - blocked
-      const result2 = middleware({ request: request2, set: set2 }); // 1st for IP2 - should be allowed
+      await middleware({ request: req1, set: set1 }); // 1st for IP1
+      await middleware({ request: req1, set: set1 }); // 2nd for IP1 — blocked
+      const result2 = await middleware({ request: req2, set: set2 }); // 1st for IP2
 
       expect(result2).toBeUndefined();
     });
 
-    it('should track authenticated users by x-user-address header', () => {
+    it('should track authenticated users by x-user-address header', async () => {
       const middleware = rateLimit({ max: 2, windowMs: 60000 });
 
-      const request1 = createMockRequest({
+      const req1 = createMockRequest({
         headers: { 'x-user-address': 'GAAAAAAA123456789', 'x-forwarded-for': '192.0.2.1' },
       });
-      const request2 = createMockRequest({
+      const req2 = createMockRequest({
         headers: { 'x-user-address': 'GBBBBBB987654321', 'x-forwarded-for': '192.0.2.1' },
       });
       const set1 = createMockSet();
       const set2 = createMockSet();
 
-      middleware({ request: request1, set: set1 }); // 1st for user A
-      middleware({ request: request1, set: set1 }); // 2nd for user A - blocked
-      const result2 = middleware({ request: request2, set: set2 }); // 1st for user B - should be allowed
+      await middleware({ request: req1, set: set1 }); // 1st for user A
+      await middleware({ request: req1, set: set1 }); // 2nd for user A — blocked
+      const result2 = await middleware({ request: req2, set: set2 }); // 1st for user B
 
       expect(result2).toBeUndefined();
     });
 
-    it('should prioritize user address over IP for authenticated requests', () => {
+    it('should prioritize user address over IP for authenticated requests', async () => {
       const middleware = rateLimit({ max: 1, windowMs: 60000 });
 
       const request = createMockRequest({
@@ -112,8 +234,8 @@ describe('rateLimit middleware', () => {
       const set1 = createMockSet();
       const set2 = createMockSet();
 
-      middleware({ request, set: set1 }); // 1st request
-      const result = middleware({ request, set: set2 }); // 2nd request - should be blocked since same user
+      await middleware({ request, set: set1 }); // 1st request
+      const result = await middleware({ request, set: set2 }); // 2nd — blocked
 
       expect(result).toEqual({
         success: false,
@@ -124,13 +246,13 @@ describe('rateLimit middleware', () => {
   });
 
   describe('Retry-After header', () => {
-    it('should set Retry-After header when rate limited', () => {
+    it('should set Retry-After header when rate limited', async () => {
       const middleware = rateLimit({ max: 1, windowMs: 60000 });
       const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.5.1' } });
       const set = createMockSet();
 
-      middleware({ request, set }); // 1st request
-      middleware({ request, set }); // 2nd request - blocked
+      await middleware({ request, set }); // 1st
+      await middleware({ request, set }); // 2nd — blocked
 
       expect(set.headers!['Retry-After']).toBeDefined();
       expect(Number(set.headers!['Retry-After'])).toBeGreaterThan(0);
@@ -138,36 +260,36 @@ describe('rateLimit middleware', () => {
   });
 
   describe('custom keyGenerator', () => {
-    it('should use custom key generator when provided', () => {
+    it('should use custom key generator when provided', async () => {
       const middleware = rateLimit({
         max: 1,
         windowMs: 60000,
         keyGenerator: (req) => `custom:${req.headers.get('x-api-key') ?? 'unknown'}`,
       });
 
-      const request1 = createMockRequest({
+      const req1 = createMockRequest({
         headers: { 'x-api-key': 'key1', 'x-forwarded-for': '192.0.2.1' },
       });
-      const request2 = createMockRequest({
+      const req2 = createMockRequest({
         headers: { 'x-api-key': 'key2', 'x-forwarded-for': '192.0.2.1' },
       });
       const set1 = createMockSet();
       const set2 = createMockSet();
 
-      middleware({ request: request1, set: set1 }); // 1st with key1
-      const result2 = middleware({ request: request2, set: set2 }); // 1st with key2 - should be allowed
+      await middleware({ request: req1, set: set1 }); // 1st with key1
+      const result2 = await middleware({ request: req2, set: set2 }); // 1st with key2
 
       expect(result2).toBeUndefined();
     });
   });
 
   describe('default values', () => {
-    it('should use default max of 10 and window of 60000ms', () => {
+    it('should use default max of 10 and window of 60000ms', async () => {
       const middleware = rateLimit();
       const request = createMockRequest({ headers: { 'x-forwarded-for': '192.0.7.1' } });
       const set = createMockSet();
 
-      middleware({ request, set });
+      await middleware({ request, set });
 
       expect(set.headers!['X-RateLimit-Limit']).toBe('10');
       expect(set.headers!['X-RateLimit-Remaining']).toBe('9');

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -4,9 +4,21 @@ interface RateLimitOptions {
   keyGenerator?: (request: Request) => string;
 }
 
-interface RateLimitEntry {
-  count: number;
+interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
   resetAt: number;
+  retryAfter?: number;
+}
+
+export interface RateLimitRedisClient {
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<number>;
+  ttl(key: string): Promise<number>;
+}
+
+export interface RateLimitStore {
+  checkLimit(identifier: string, windowMs: number, max: number): Promise<RateLimitResult>;
 }
 
 const DEFAULT_WINDOW_MS = 60000;
@@ -31,60 +43,85 @@ function getIdentifier(request: Request, keyGenerator?: (request: Request) => st
   return `ip:${getClientIP(request)}`;
 }
 
-function createRateLimitStore() {
-  const store = new Map<string, RateLimitEntry>();
+export function createRedisStore(client: RateLimitRedisClient): RateLimitStore {
+  return {
+    async checkLimit(identifier: string, windowMs: number, max: number): Promise<RateLimitResult> {
+      const key = `ratelimit:${identifier}`;
+      const ttlSeconds = Math.ceil(windowMs / 1000);
 
-  function cleanup() {
-    const now = Date.now();
-    for (const [key, entry] of store.entries()) {
-      if (now >= entry.resetAt) {
-        store.delete(key);
+      const count = await client.incr(key);
+      if (count === 1) {
+        await client.expire(key, ttlSeconds);
       }
-    }
-  }
 
-  function checkLimit(
-    identifier: string,
-    windowMs: number,
-    max: number,
-  ): {
-    allowed: boolean;
-    remaining: number;
-    resetAt: number;
-    retryAfter?: number;
-  } {
-    cleanup();
-    const now = Date.now();
-    const entry = store.get(identifier);
+      const ttl = await client.ttl(key);
+      const resetAt = Date.now() + Math.max(0, ttl) * 1000;
+      const remaining = Math.max(0, max - count);
 
-    if (!entry || now >= entry.resetAt) {
-      const resetAt = now + windowMs;
-      store.set(identifier, { count: 1, resetAt });
-      return { allowed: true, remaining: max - 1, resetAt };
-    }
+      if (count > max) {
+        return { allowed: false, remaining: 0, resetAt, retryAfter: Math.max(0, ttl) };
+      }
 
-    entry.count += 1;
-    const remaining = Math.max(0, max - entry.count);
+      return { allowed: true, remaining, resetAt };
+    },
+  };
+}
 
-    if (entry.count > max) {
-      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-      return { allowed: false, remaining: 0, resetAt: entry.resetAt, retryAfter };
-    }
+export function createMemoryStore(): RateLimitStore {
+  const store = new Map<string, { count: number; resetAt: number }>();
 
-    return { allowed: true, remaining, resetAt: entry.resetAt };
-  }
+  return {
+    async checkLimit(identifier: string, windowMs: number, max: number): Promise<RateLimitResult> {
+      const now = Date.now();
+      const entry = store.get(identifier);
 
-  return { checkLimit };
+      if (!entry || now >= entry.resetAt) {
+        const resetAt = now + windowMs;
+        store.set(identifier, { count: 1, resetAt });
+        return { allowed: true, remaining: max - 1, resetAt };
+      }
+
+      entry.count += 1;
+      const remaining = Math.max(0, max - entry.count);
+
+      if (entry.count > max) {
+        const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+        return { allowed: false, remaining: 0, resetAt: entry.resetAt, retryAfter };
+      }
+
+      return { allowed: true, remaining, resetAt: entry.resetAt };
+    },
+  };
 }
 
 export function rateLimit(options: RateLimitOptions = {}) {
   const { windowMs = DEFAULT_WINDOW_MS, max = DEFAULT_MAX, keyGenerator } = options;
-  const store = createRateLimitStore();
+
+  const redisUrl = process.env.REDIS_URL;
+  let storeReady: Promise<RateLimitStore>;
+
+  if (redisUrl) {
+    storeReady = import('ioredis').then(({ default: Redis }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = new (Redis as any)(redisUrl, {
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 1,
+        connectTimeout: 3000,
+      });
+      return createRedisStore(client);
+    });
+  } else {
+    console.warn(
+      '[rateLimit] REDIS_URL not set — using in-memory rate limiting (not safe for multi-instance deployments)',
+    );
+    storeReady = Promise.resolve(createMemoryStore());
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function rateLimitMiddleware({ request, set }: any) {
+  return async function rateLimitMiddleware({ request, set }: any) {
     const identifier = getIdentifier(request, keyGenerator);
-    const result = store.checkLimit(identifier, windowMs, max);
+    const store = await storeReady;
+    const result = await store.checkLimit(identifier, windowMs, max);
 
     set.headers = {
       ...(set.headers ?? {}),


### PR DESCRIPTION
## Description

Replaces the process-local `Map` in `rateLimit.ts` with a dual-mode store:

- **Redis mode** (when `REDIS_URL` is set): uses atomic `INCR` + `EXPIRE` commands, making rate limiting safe across multiple instances.
- **In-memory fallback** (no `REDIS_URL`): retains the `Map`-based store for single-instance / development environments, with a startup warning logged.

The O(n) cleanup loop that iterated the entire Map on every request has been removed — Redis TTL handles expiry natively.

## Changes

- `apps/api/src/middleware/rateLimit.ts`
  - Added `RateLimitRedisClient` and `RateLimitStore` interfaces (exported for DI/testing)
  - Added `createRedisStore(client)` — Redis implementation using `INCR` + `EXPIRE` + `TTL`
  - Added `createMemoryStore()` — Map-based fallback, no cleanup loop
  - `rateLimit()` middleware is now async; selects store based on `REDIS_URL` at startup, logs a warning when falling back to memory
  - Rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) preserved on all responses

- `apps/api/src/middleware/rateLimit.test.ts`
  - Added `createMemoryStore` unit tests (window reset, independent identifiers, TTL)
  - Added `createRedisStore` unit tests with a fake client (expire-once behaviour, key prefix, over-limit blocking)
  - Updated all middleware tests to `await` the now-async middleware

## Closes

Closes #771

## Notes

- Redis client is initialised lazily on first request via dynamic `import('ioredis')`, consistent with the pattern used in `CacheService.ts`.
- `createRedisStore` accepts any object satisfying `RateLimitRedisClient`, enabling clean unit tests without a real Redis instance.