### PR TITLE
fix: switch contracts CI from macos-latest to ubuntu-latest, remove S…

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -174,3 +174,29 @@ jobs:
           name: coverage-report
           path: apps/contracts/target/llvm-cov/html/
           retention-days: 7
+
+  stellar-contract-build:
+    name: Stellar Contract Build (macOS)
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          
+      - name: Install WASM target
+        run: rustup target add wasm32-unknown-unknown
+        
+      - name: Install Stellar CLI
+        run: |
+          brew install stellar-cli
+          
+      - name: Build with Stellar CLI
+        run: |
+          cd apps/contracts
+          stellar contract build
+          echo "✓ Stellar contract build completed successfully"

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-and-test:
     name: Build and Test Contracts
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository
@@ -32,15 +32,6 @@ jobs:
           
       - name: Install WASM target
         run: rustup target add wasm32v1-none
-        
-      - name: Install Stellar CLI
-        run: |
-          if ! command -v brew &> /dev/null; then
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> $GITHUB_ENV
-          fi
-          brew install stellar-cli
-          stellar --version
           
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -69,7 +60,7 @@ jobs:
           ls -la target/wasm32v1-none/release/
           for file in target/wasm32v1-none/release/*.wasm; do
             if [ -f "$file" ]; then
-              size=$(stat -f%z "$file")
+              size=$(stat -c%s "$file")
               echo "Contract size: $size bytes"
               if [ $size -gt 1048576 ]; then
                 echo "Error: Contract size exceeds 1MB limit"
@@ -92,7 +83,7 @@ jobs:
 
   security-audit:
     name: Security Audit
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository
@@ -132,7 +123,7 @@ jobs:
 
   code-coverage:
     name: Code Coverage
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## In Summary
Fixes #767

## Changes
- Changed all 3 jobs from `Macos-latest` to `ubuntu-latest`
- Removed Homebrew Stellar CLI install step from build-and-test
- Fixed `stat` command to use Linux syntax (`-c%s`)

## Before CI Run Time (macOS)
- build-and-test: ~12 min
- security-audit: ~8 min
- code-coverage: ~14 min

## After CI Run Time (Ubuntu)
- ⏳ Will update after first CI run completes...