### PR TITLE
fix: enable webapp unit tests in CI and add coverage upload

### DIFF
--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -62,12 +62,20 @@ jobs:
           cd apps/webapp
           bun run build
 
-      # - name: Run unit tests
-      #   run: |
-      #     cd apps/webapp
+      - name: Run unit tests
+        run: |
+          cd apps/webapp
 
-      #     # Run tests with coverage
-      #     bun test --coverage --watchAll=false
+          # Run tests with coverage
+          bun test --coverage --watchAll=false
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: webapp-coverage
+          path: apps/webapp/coverage/
+          retention-days: 14
 
       # - name: E2E tests
       #   run: |


### PR DESCRIPTION
## What Was Fixed

### 1. Re-enabled Unit Test Execution
The commented-out test step has been restored and is now fully active. Tests run automatically on every PR and push using:
\`\`\`
bun test --coverage --watchAll=false
\`\`\`

### 2. Verified CI Step Ordering
Confirmed the test step runs in the correct position within the build-and-test job:
- Checkout → Setup Bun → Cache → Install Dependencies → Type Check → Lint → Format Check → Build → **Run Tests** → Upload Coverage → Bundle Analysis → Upload Artifacts

### 3. Confirmed No Silent Failures
Verified that neither the test step nor the parent job has continue-on-error: true, meaning any test failure will correctly block PR merges.

### 4. Confirmed Test Discoverability
Inspected all 12+ test files (useHealthFactor.test.ts, InvestModal.test.tsx, client.test.ts, etc.) and confirmed they follow *.test.ts and *.test.tsx naming conventions, which are natively discovered by bun test without any additional glob configuration.

### 5. Added Coverage Report Upload
Added an actions/upload-artifact@v4 step immediately after test execution to persist the coverage report as a CI artifact, with:
- if: always() to ensure upload even when tests fail
- retention-days: 14 to manage storage

## Files Changed
- .github/workflows/webapp-ci.yml

Closes #764 