### PR TITLE
Feat/city map interactive tiles

### DIFF
--- a/apps/akkuea-land/next-env.d.ts
+++ b/apps/akkuea-land/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/akkuea-land/src/app/globals.css
+++ b/apps/akkuea-land/src/app/globals.css
@@ -181,3 +181,13 @@ body {
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
 }
+
+/* Tile real-time event flash */
+@keyframes tile-flash {
+  0% { box-shadow: 0 0 0 0 rgba(0, 212, 255, 0.8); }
+  30% { box-shadow: 0 0 24px 6px rgba(0, 212, 255, 0.5); }
+  100% { box-shadow: 0 0 0 0 rgba(0, 212, 255, 0); }
+}
+.animate-tile-flash {
+  animation: tile-flash 0.7s ease-out;
+}

--- a/apps/akkuea-land/src/app/map/page.tsx
+++ b/apps/akkuea-land/src/app/map/page.tsx
@@ -1,18 +1,16 @@
 import { GameShell } from "@/components/layout/GameShell";
+import { CityMap } from "@/components/game/CityMap";
 
 export const metadata = {
   title: "City Map | Akkuea Land",
+  description:
+    "Explore the 20×20 Akkuea City grid. Discover, select, and trade virtual land parcels.",
 };
 
 export default function MapPage() {
   return (
     <GameShell>
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <h1 className="text-2xl font-bold text-land-fg">City Map</h1>
-        <p className="text-land-fg-muted">
-          The interactive tile grid will render here.
-        </p>
-      </div>
+      <CityMap />
     </GameShell>
   );
 }

--- a/apps/akkuea-land/src/components/game/CityMap.css
+++ b/apps/akkuea-land/src/components/game/CityMap.css
@@ -1,0 +1,361 @@
+/* ─── City Map Grid ──────────────────────────────────────────────────────── */
+
+.city-map-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+  -webkit-overflow-scrolling: touch;
+  padding: 16px;
+}
+
+.city-grid {
+  display: grid;
+  grid-template-columns: repeat(20, 1fr);
+  gap: 3px;
+  min-width: 400px;
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
+}
+
+/* ─── Base Tile ──────────────────────────────────────────────────────────── */
+
+.city-tile {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: var(--tile-radius, 8px);
+  cursor: pointer;
+  transition:
+    transform 0.15s ease-out,
+    box-shadow 0.15s ease-out,
+    z-index 0s;
+  will-change: transform;
+  overflow: visible;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ─── Hover ──────────────────────────────────────────────────────────────── */
+
+.city-tile:hover {
+  transform: scale(1.15);
+  z-index: 10;
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow:
+    0 0 16px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--tile-glow-color, rgba(255, 255, 255, 0.1));
+}
+
+/* ─── Selection Ring ─────────────────────────────────────────────────────── */
+
+.tile-selected {
+  box-shadow:
+    0 0 0 2px var(--land-accent, #00d4ff),
+    0 0 16px var(--land-accent-glow, rgba(0, 212, 255, 0.35));
+  border-color: var(--land-accent, #00d4ff);
+  z-index: 5;
+}
+
+.tile-selected:hover {
+  box-shadow:
+    0 0 0 2px var(--land-accent, #00d4ff),
+    0 0 24px var(--land-accent-glow, rgba(0, 212, 255, 0.35));
+}
+
+/* ─── Building Badge ─────────────────────────────────────────────────────── */
+
+.tile-badge {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 800;
+  font-family: var(--font-mono, monospace);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.tile-badge-0 {
+  background: rgba(61, 90, 128, 0.4);
+  color: rgba(232, 240, 254, 0.35);
+}
+
+.tile-badge-1 {
+  background: rgba(0, 230, 118, 0.2);
+  color: rgba(0, 230, 118, 0.85);
+}
+
+.tile-badge-2 {
+  background: rgba(0, 212, 255, 0.2);
+  color: rgba(0, 212, 255, 0.85);
+}
+
+.tile-badge-3 {
+  background: rgba(179, 136, 255, 0.25);
+  color: rgba(179, 136, 255, 0.95);
+  box-shadow: 0 0 6px rgba(179, 136, 255, 0.2);
+}
+
+/* ─── Listed Indicator (pulsing amber dot) ───────────────────────────────── */
+
+.tile-listed-dot {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--land-gold, #f5a623);
+  box-shadow: 0 0 6px var(--land-gold-glow, rgba(245, 166, 35, 0.35));
+  animation: pulse-glow 2s ease-in-out infinite;
+  pointer-events: none;
+}
+
+/* ─── CSS Tooltip ────────────────────────────────────────────────────────── */
+
+.city-tile[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.92);
+  background: rgba(8, 12, 20, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: var(--land-fg, #e8f0fe);
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  line-height: 1.5;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--land-border, #1e2d47);
+  white-space: pre;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s ease-out, transform 0.12s ease-out;
+  z-index: 100;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  min-width: 140px;
+  text-align: left;
+}
+
+.city-tile[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+/* Reposition tooltip for bottom rows so it doesn't overflow */
+.city-grid .city-tile:nth-child(n + 341)[data-tooltip]::after {
+  bottom: auto;
+  top: calc(100% + 8px);
+}
+
+/* Reposition tooltip for left-edge tiles */
+.city-grid .city-tile:nth-child(20n + 1)[data-tooltip]::after {
+  left: 0;
+  transform: translateX(0) scale(0.92);
+}
+.city-grid .city-tile:nth-child(20n + 1)[data-tooltip]:hover::after {
+  transform: translateX(0) scale(1);
+}
+
+/* Reposition tooltip for right-edge tiles */
+.city-grid .city-tile:nth-child(20n)[data-tooltip]::after {
+  left: auto;
+  right: 0;
+  transform: translateX(0) scale(0.92);
+}
+.city-grid .city-tile:nth-child(20n)[data-tooltip]:hover::after {
+  transform: translateX(0) scale(1);
+}
+
+/* ─── Flash Animation (real-time events) ─────────────────────────────────── */
+
+@keyframes tile-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(0, 212, 255, 0.8);
+  }
+  30% {
+    box-shadow: 0 0 24px 6px rgba(0, 212, 255, 0.5);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(0, 212, 255, 0);
+  }
+}
+
+.tile-flash {
+  animation: tile-flash 0.7s ease-out;
+}
+
+/* ─── Map Header ─────────────────────────────────────────────────────────── */
+
+.map-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.map-header h1 {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--land-fg, #e8f0fe);
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.map-stats {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.map-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.map-stat-value {
+  font-size: 14px;
+  font-weight: 800;
+  font-family: var(--font-mono, monospace);
+  color: var(--land-fg, #e8f0fe);
+}
+
+.map-stat-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--land-fg-subtle, #3d5a80);
+  font-weight: 600;
+}
+
+/* ─── Legend ──────────────────────────────────────────────────────────────── */
+
+.map-legend {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+  flex-wrap: wrap;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  color: var(--land-fg-muted, #7a9cc4);
+  font-weight: 500;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────────────── */
+
+/* Small phones */
+@media (max-width: 480px) {
+  .city-map-wrapper {
+    padding: 8px;
+  }
+
+  .city-grid {
+    gap: 2px;
+    min-width: 320px;
+  }
+
+  .tile-badge {
+    width: 12px;
+    height: 12px;
+    font-size: 7px;
+    top: 1px;
+    right: 1px;
+    border-radius: 3px;
+  }
+
+  .tile-listed-dot {
+    width: 5px;
+    height: 5px;
+    bottom: 2px;
+    left: 2px;
+  }
+
+  .map-stats {
+    display: none;
+  }
+
+  .map-legend {
+    gap: 8px;
+    padding: 6px 8px;
+  }
+
+  .legend-item {
+    font-size: 9px;
+  }
+
+  /* Disable tooltip on very small screens — use click instead */
+  .city-tile[data-tooltip]::after {
+    display: none;
+  }
+}
+
+/* Tablets */
+@media (min-width: 481px) and (max-width: 1023px) {
+  .city-grid {
+    gap: 2px;
+    max-width: 700px;
+  }
+
+  .tile-badge {
+    width: 14px;
+    height: 14px;
+    font-size: 8px;
+    top: 2px;
+    right: 2px;
+  }
+}
+
+/* Desktop / ultrawide */
+@media (min-width: 1024px) {
+  .city-grid {
+    gap: 3px;
+  }
+}
+
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  .city-tile {
+    transition: none;
+  }
+  .city-tile:hover {
+    transform: none;
+  }
+  .tile-listed-dot {
+    animation: none;
+  }
+  .tile-flash {
+    animation: none;
+  }
+}

--- a/apps/akkuea-land/src/components/game/CityMap.tsx
+++ b/apps/akkuea-land/src/components/game/CityMap.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import React, { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { AnimatePresence } from "framer-motion";
+import "./CityMap.css";
+import { GameProperty } from "../../types/game.types";
+import { PropertyPanel } from "./PropertyPanel";
+import { addressToHSL, addressToGlow } from "../../lib/colorHash";
+import {
+  generateMockGrid,
+  BUILDING_LABELS,
+  BUILDING_NAMES,
+  abbreviateAddress,
+  getGridCoords,
+} from "../../lib/mockProperties";
+import { useMapEvents } from "../../hooks/useMapEvents";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const FLASH_DURATION = 700; // ms — matches CSS animation duration
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function CityMap() {
+  // ── State ────────────────────────────────────────────────────────────────
+  const [properties, setProperties] = useState<GameProperty[]>(() =>
+    generateMockGrid(),
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  // ── Derived ──────────────────────────────────────────────────────────────
+  const selectedProperty = useMemo(
+    () => (selectedId ? properties.find((p) => p.id === selectedId) ?? null : null),
+    [selectedId, properties],
+  );
+
+  const stats = useMemo(() => {
+    let owned = 0;
+    let listed = 0;
+    let treasury = 0;
+    for (const p of properties) {
+      if (!p.owner || p.owner === "GBTREASURY") {
+        treasury++;
+      } else {
+        owned++;
+        if (p.isListed) listed++;
+      }
+    }
+    return { owned, listed, treasury, total: properties.length };
+  }, [properties]);
+
+  // ── Property update handler ──────────────────────────────────────────────
+  const handlePropertyChange = useCallback((updated: GameProperty) => {
+    setProperties((prev) =>
+      prev.map((p) => (p.id === updated.id ? updated : p)),
+    );
+  }, []);
+
+  // ── Real-time events ────────────────────────────────────────────────────
+  const { lastEvent } = useMapEvents(properties, handlePropertyChange);
+
+  // Flash the tile via direct DOM manipulation (avoids setState in effect)
+  useEffect(() => {
+    if (!lastEvent) return;
+    if (lastEvent.propertyId === selectedId) return;
+
+    const grid = gridRef.current;
+    if (!grid) return;
+
+    const tile = grid.querySelector<HTMLElement>(
+      `[data-property-id="${lastEvent.propertyId}"]`,
+    );
+    if (!tile) return;
+
+    tile.classList.add("tile-flash");
+
+    if (flashTimeoutRef.current) {
+      clearTimeout(flashTimeoutRef.current);
+    }
+    flashTimeoutRef.current = setTimeout(() => {
+      tile.classList.remove("tile-flash");
+    }, FLASH_DURATION);
+  }, [lastEvent, selectedId]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    };
+  }, []);
+
+  // ── Event delegation click handler ───────────────────────────────────────
+  const handleGridClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const target = (e.target as HTMLElement).closest<HTMLElement>(
+        "[data-property-id]",
+      );
+      if (!target) return;
+
+      const propertyId = target.dataset.propertyId!;
+
+      // Toggle selection: clicking same tile deselects
+      setSelectedId((prev) => (prev === propertyId ? null : propertyId));
+    },
+    [],
+  );
+
+  // ── Close panel ──────────────────────────────────────────────────────────
+  const handleClosePanel = useCallback(() => {
+    setSelectedId(null);
+  }, []);
+
+  // ── Render ───────────────────────────────────────────────────────────────
+  return (
+    <div className="relative flex-1 flex flex-col">
+      {/* ── Map Header ──────────────────────────────────────────────────── */}
+      <div className="map-header">
+        <h1>
+          <span className="text-land-accent mr-2">◈</span>
+          City Map
+        </h1>
+        <div className="map-stats">
+          <div className="map-stat">
+            <span className="map-stat-value">{stats.owned}</span>
+            <span className="map-stat-label">Owned</span>
+          </div>
+          <div className="map-stat">
+            <span className="map-stat-value">{stats.listed}</span>
+            <span className="map-stat-label">Listed</span>
+          </div>
+          <div className="map-stat">
+            <span className="map-stat-value">{stats.treasury}</span>
+            <span className="map-stat-label">Treasury</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Legend ───────────────────────────────────────────────────────── */}
+      <div className="map-legend">
+        <div className="legend-item">
+          <div
+            className="legend-swatch"
+            style={{ background: "var(--land-gold)" }}
+          />
+          Treasury
+        </div>
+        <div className="legend-item">
+          <div
+            className="legend-swatch"
+            style={{ background: "var(--tile-empty)" }}
+          />
+          Unowned
+        </div>
+        <div className="legend-item">
+          <div
+            className="legend-swatch"
+            style={{ background: "hsl(210, 60%, 42%)" }}
+          />
+          Player-owned
+        </div>
+        <div className="legend-item">
+          <div
+            className="legend-swatch"
+            style={{
+              background: "var(--land-gold)",
+              borderRadius: "50%",
+              width: 8,
+              height: 8,
+            }}
+          />
+          For Sale
+        </div>
+        <div className="legend-item" style={{ marginLeft: "auto" }}>
+          <span className="text-land-fg-subtle text-[9px]">
+            V=Vacant · R=Residential · C=Commercial · S=Skyscraper
+          </span>
+        </div>
+      </div>
+
+      {/* ── Grid ────────────────────────────────────────────────────────── */}
+      <div className="city-map-wrapper">
+        {/* Single click handler on the container — event delegation */}
+        <div
+          ref={gridRef}
+          className="city-grid"
+          onClick={handleGridClick}
+          role="grid"
+          aria-label="Akkuea City property grid"
+        >
+          {properties.map((prop) => {
+            const { row, col } = getGridCoords(prop.id);
+            const bgColor = addressToHSL(prop.owner);
+            const glowColor = addressToGlow(prop.owner);
+            const isSelected = prop.id === selectedId;
+            const isTreasury =
+              !prop.owner || prop.owner === "GBTREASURY";
+            const isUnowned = !prop.owner;
+
+            // Build tooltip text
+            const tooltipLines = [
+              `📍 (${row}, ${col})`,
+              `👤 ${abbreviateAddress(prop.owner)}`,
+              `🏗 ${BUILDING_NAMES[prop.buildingLevel]}`,
+            ];
+            if (prop.isListed) {
+              tooltipLines.push(`💰 ${prop.pricePerShare} LAND`);
+            }
+            const tooltip = tooltipLines.join("\n");
+
+            const tileClasses = [
+              "city-tile",
+              isSelected && "tile-selected",
+            ]
+              .filter(Boolean)
+              .join(" ");
+
+            return (
+              <div
+                key={prop.id}
+                data-property-id={prop.id}
+                data-tooltip={tooltip}
+                className={tileClasses}
+                style={
+                  {
+                    backgroundColor: isUnowned
+                      ? "var(--tile-empty)"
+                      : bgColor,
+                    "--tile-glow-color": glowColor,
+                    opacity: isUnowned ? 0.45 : isTreasury ? 0.7 : 1,
+                  } as React.CSSProperties
+                }
+                role="gridcell"
+                aria-label={`Tile ${row},${col} — ${abbreviateAddress(prop.owner)} — ${BUILDING_NAMES[prop.buildingLevel]}${prop.isListed ? " — For Sale" : ""}`}
+              >
+                {/* Building Level Badge */}
+                {prop.buildingLevel > 0 && (
+                  <span
+                    className={`tile-badge tile-badge-${prop.buildingLevel}`}
+                  >
+                    {BUILDING_LABELS[prop.buildingLevel]}
+                  </span>
+                )}
+
+                {/* Vacant label for level 0 — only on non-empty tiles to reduce clutter */}
+                {prop.buildingLevel === 0 && !isUnowned && !isTreasury && (
+                  <span className="tile-badge tile-badge-0">
+                    {BUILDING_LABELS[0]}
+                  </span>
+                )}
+
+                {/* Listed-for-sale amber dot */}
+                {prop.isListed && <span className="tile-listed-dot" />}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Property Detail Panel ────────────────────────────────────────── */}
+      <AnimatePresence>
+        {selectedProperty && (
+          <PropertyPanel
+            key={selectedProperty.id}
+            property={selectedProperty}
+            onPropertyUpdate={handlePropertyChange}
+            viewerAddress={null}
+            isConnected={false}
+            onClose={handleClosePanel}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/akkuea-land/src/hooks/useMapEvents.ts
+++ b/apps/akkuea-land/src/hooks/useMapEvents.ts
@@ -1,0 +1,121 @@
+/**
+ * Simulates real-time property events for the city map.
+ *
+ * Randomly picks a tile every 8–15 seconds and applies a mock
+ * transaction (ownership change, level upgrade, or new listing).
+ * Returns the last event so the grid can flash the affected tile.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { GameProperty, BuildingLevel } from "../types/game.types";
+
+export interface MapEvent {
+  propertyId: string;
+  type: "ownership_change" | "level_upgrade" | "listing";
+  timestamp: number;
+}
+
+interface UseMapEventsOptions {
+  /** Minimum interval between events in ms (default 8000) */
+  minInterval?: number;
+  /** Maximum interval between events in ms (default 15000) */
+  maxInterval?: number;
+  /** Whether events are enabled (default true) */
+  enabled?: boolean;
+}
+
+export function useMapEvents(
+  properties: GameProperty[],
+  onPropertyChange: (updated: GameProperty) => void,
+  options: UseMapEventsOptions = {},
+) {
+  const {
+    minInterval = 8000,
+    maxInterval = 15000,
+    enabled = true,
+  } = options;
+
+  const [lastEvent, setLastEvent] = useState<MapEvent | null>(null);
+  const propertiesRef = useRef(properties);
+  const onPropertyChangeRef = useRef(onPropertyChange);
+
+  // Sync refs inside an effect to avoid writing during render (react-hooks/refs)
+  useEffect(() => {
+    propertiesRef.current = properties;
+  }, [properties]);
+
+  useEffect(() => {
+    onPropertyChangeRef.current = onPropertyChange;
+  }, [onPropertyChange]);
+
+  const simulateEvent = useCallback(() => {
+    const props = propertiesRef.current;
+    if (props.length === 0) return;
+
+    const idx = Math.floor(Math.random() * props.length);
+    const prop = props[idx];
+
+    // Randomly pick event type
+    const roll = Math.random();
+    let eventType: MapEvent["type"];
+    let updated: GameProperty;
+
+    if (roll < 0.4) {
+      // Ownership change
+      eventType = "ownership_change";
+      const fakeAddr = `G${Math.random().toString(36).substring(2, 10).toUpperCase()}MOCK${Date.now().toString(36).toUpperCase()}`;
+      updated = {
+        ...prop,
+        owner: fakeAddr,
+        isListed: false,
+      };
+    } else if (roll < 0.7) {
+      // Level upgrade
+      eventType = "level_upgrade";
+      const nextLevel = Math.min(prop.buildingLevel + 1, 3) as BuildingLevel;
+      updated = {
+        ...prop,
+        buildingLevel: nextLevel,
+      };
+    } else {
+      // New listing
+      eventType = "listing";
+      const price = Math.floor(Math.random() * 4000) + 100;
+      updated = {
+        ...prop,
+        isListed: true,
+        pricePerShare: price.toString(),
+      };
+    }
+
+    onPropertyChangeRef.current(updated);
+
+    setLastEvent({
+      propertyId: prop.id,
+      type: eventType,
+      timestamp: Date.now(),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const scheduleNext = () => {
+      const delay = minInterval + Math.random() * (maxInterval - minInterval);
+      timeoutId = setTimeout(() => {
+        simulateEvent();
+        scheduleNext();
+      }, delay);
+    };
+
+    scheduleNext();
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [enabled, minInterval, maxInterval, simulateEvent]);
+
+  return { lastEvent };
+}

--- a/apps/akkuea-land/src/lib/colorHash.ts
+++ b/apps/akkuea-land/src/lib/colorHash.ts
@@ -1,0 +1,66 @@
+/**
+ * Deterministic address → HSL color mapping.
+ *
+ * Uses the DJB2 hash algorithm so the same wallet address always
+ * produces the same tile color across sessions and devices.
+ */
+
+const TREASURY_ADDRESSES = new Set([
+  "",
+  "GBTREASURY",
+  "treasury",
+  "system",
+]);
+
+/**
+ * DJB2 hash – fast, low-collision string hash.
+ * Returns a positive 32-bit integer.
+ */
+function djb2(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    // hash * 33 + charCode
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+/**
+ * Convert a Stellar address to a deterministic HSL color string.
+ *
+ * - Treasury / system addresses → amber (`--land-gold`)
+ * - Empty / unowned → muted blue-grey (`--tile-empty`)
+ * - Player addresses → unique HSL with vibrant saturation
+ */
+export function addressToHSL(address: string): string {
+  // Treasury → amber
+  if (!address || TREASURY_ADDRESSES.has(address.toLowerCase())) {
+    return "var(--land-gold)";
+  }
+
+  const hash = djb2(address);
+
+  // Hue: full 360° spectrum
+  const hue = hash % 360;
+
+  // Saturation: 50–75% (vibrant but not neon)
+  const saturation = 50 + (hash % 26);
+
+  // Lightness: 35–50% (readable on dark bg)
+  const lightness = 35 + ((hash >> 8) % 16);
+
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+}
+
+/**
+ * Returns a lighter variant of the address color for hover glow effects.
+ */
+export function addressToGlow(address: string): string {
+  if (!address || TREASURY_ADDRESSES.has(address.toLowerCase())) {
+    return "var(--land-gold-glow)";
+  }
+
+  const hash = djb2(address);
+  const hue = hash % 360;
+  return `hsla(${hue}, 70%, 55%, 0.35)`;
+}

--- a/apps/akkuea-land/src/lib/colorHash.ts
+++ b/apps/akkuea-land/src/lib/colorHash.ts
@@ -7,7 +7,7 @@
 
 const TREASURY_ADDRESSES = new Set([
   "",
-  "GBTREASURY",
+  "gbtreasury",
   "treasury",
   "system",
 ]);

--- a/apps/akkuea-land/src/lib/mockProperties.ts
+++ b/apps/akkuea-land/src/lib/mockProperties.ts
@@ -1,0 +1,188 @@
+/**
+ * Seeded mock data generator for the 20×20 Akkuea Land city grid.
+ *
+ * Uses a simple linear congruential generator (LCG) for deterministic
+ * pseudo-random numbers so the map layout is identical across refreshes.
+ */
+
+import { GameProperty, BuildingLevel } from "../types/game.types";
+
+// ── Seeded PRNG ──────────────────────────────────────────────────────────────
+
+const LCG_A = 1664525;
+const LCG_C = 1013904223;
+const LCG_M = 2 ** 32;
+
+function createSeededRng(seed: number) {
+  let state = seed >>> 0;
+  return {
+    /** Returns a float in [0, 1) */
+    next(): number {
+      state = (LCG_A * state + LCG_C) % LCG_M;
+      return state / LCG_M;
+    },
+    /** Returns an integer in [min, max] inclusive */
+    int(min: number, max: number): number {
+      return Math.floor(this.next() * (max - min + 1)) + min;
+    },
+    /** Picks a random element from an array */
+    pick<T>(arr: T[]): T {
+      return arr[Math.floor(this.next() * arr.length)];
+    },
+  };
+}
+
+// ── Mock Stellar Addresses ───────────────────────────────────────────────────
+
+const MOCK_PLAYER_ADDRESSES = [
+  "GABC1234EFGH5678IJKL9012MNOP3456QRST7890UVWX1234YZ56",
+  "GDEF5678ABCD1234MNOP9012EFGH3456IJKL7890QRST1234UV56",
+  "GHIJ9012KLMN3456OPQR7890STUV1234WXYZ5678ABCD9012EF56",
+  "GKLM3456NOPQ7890RSTU1234VWXY5678ZABC9012DEFG3456HI56",
+  "GNOP7890QRST1234UVWX5678YZAB9012CDEF3456GHIJ7890KL56",
+  "GQRS1234TUVW5678XYZA9012BCDE3456FGHI7890JKLM1234NO56",
+  "GTUV5678WXYZ1234ABCD9012EFGH3456IJKL7890MNOP5678QR56",
+  "GWXY9012ZABC3456DEFG7890HIJK1234LMNO5678PQRS9012TU56",
+  "GZAB3456CDEF7890GHIJ1234KLMN5678OPQR9012STUV3456WX56",
+  "GCDE7890FGHI1234JKLM5678NOPQ9012RSTU3456VWXY7890ZA56",
+  "GFGH1234IJKL5678MNOP9012QRST3456UVWX7890YZAB1234CD56",
+  "GIJK5678LMNO9012PQRS3456TUVW7890XYZA1234BCDE5678FG56",
+  "GLMN9012OPQR3456STUV7890WXYZ1234ABCD5678EFGH9012IJ56",
+  "GOPQ3456RSTU7890VWXY1234ZABC5678DEFG9012HIJK3456LM56",
+  "GRST7890UVWX1234YZAB5678CDEF9012GHIJ3456KLMN7890OP56",
+];
+
+const TREASURY = "GBTREASURY";
+
+// ── Building Level Labels ────────────────────────────────────────────────────
+
+export const BUILDING_LABELS: Record<BuildingLevel, string> = {
+  0: "V", // Vacant
+  1: "R", // Residential
+  2: "C", // Commercial
+  3: "S", // Skyscraper
+};
+
+export const BUILDING_NAMES: Record<BuildingLevel, string> = {
+  0: "Vacant",
+  1: "Residential",
+  2: "Commercial",
+  3: "Skyscraper",
+};
+
+// ── Grid Generator ───────────────────────────────────────────────────────────
+
+const GRID_SIZE = 20;
+const SEED = 42;
+
+let cachedGrid: GameProperty[] | null = null;
+
+/**
+ * Generate a 20×20 grid of mock GameProperty data.
+ * Results are memoised so repeated calls return the same array.
+ *
+ * Distribution:
+ * - ~60 % owned by players (15 addresses)
+ * - ~25 % treasury
+ * - ~15 % unowned
+ *
+ * Building levels weighted: 40% L0, 30% L1, 20% L2, 10% L3
+ * ~20% of player-owned tiles are listed for sale
+ */
+export function generateMockGrid(): GameProperty[] {
+  if (cachedGrid) return cachedGrid;
+
+  const rng = createSeededRng(SEED);
+  const grid: GameProperty[] = [];
+
+  for (let row = 0; row < GRID_SIZE; row++) {
+    for (let col = 0; col < GRID_SIZE; col++) {
+      // Determine ownership
+      const ownerRoll = rng.next();
+      let owner: string;
+      if (ownerRoll < 0.6) {
+        owner = rng.pick(MOCK_PLAYER_ADDRESSES);
+      } else if (ownerRoll < 0.85) {
+        owner = TREASURY;
+      } else {
+        owner = "";
+      }
+
+      // Building level (weighted)
+      const lvlRoll = rng.next();
+      let buildingLevel: BuildingLevel;
+      if (lvlRoll < 0.4) buildingLevel = 0;
+      else if (lvlRoll < 0.7) buildingLevel = 1;
+      else if (lvlRoll < 0.9) buildingLevel = 2;
+      else buildingLevel = 3;
+
+      // Unowned/treasury always level 0
+      if (!owner || owner === TREASURY) {
+        buildingLevel = 0;
+      }
+
+      // Listing
+      const isPlayerOwned = owner !== "" && owner !== TREASURY;
+      const isListed = isPlayerOwned && rng.next() < 0.2;
+      const listPrice = isListed ? rng.int(50, 5000) : undefined;
+
+      const improveCost = [100, 200, 400, 0][buildingLevel];
+      const earnedIncome = isPlayerOwned ? rng.int(0, 500) : 0;
+
+      const property: GameProperty = {
+        id: `prop-${row}-${col}`,
+        name: `Tile ${String.fromCharCode(65 + col)}${row + 1}`,
+        description: `Land parcel at grid position (${row}, ${col}) in Akkuea City.`,
+        propertyType: "land",
+        location: {
+          address: `Block ${row + 1}, Lot ${col + 1}`,
+          city: "Akkuea City",
+          country: "Stellar",
+          coordinates: {
+            latitude: 40.7128 + row * 0.001,
+            longitude: -74.006 + col * 0.001,
+          },
+        },
+        totalValue: "1000",
+        totalShares: 100,
+        availableShares: owner === TREASURY ? 100 : owner === "" ? 100 : 0,
+        pricePerShare: listPrice?.toString() ?? "100",
+        images: ["https://images.unsplash.com/photo-placeholder"],
+        documents: [],
+        verified: true,
+        listedAt: "2026-01-15T00:00:00Z",
+        owner,
+        buildingLevel,
+        earnedIncome,
+        improveCost,
+        isListed,
+      };
+
+      grid.push(property);
+    }
+  }
+
+  cachedGrid = grid;
+  return grid;
+}
+
+/**
+ * Get grid coordinates from a property ID like "prop-3-7"
+ */
+export function getGridCoords(propertyId: string): { row: number; col: number } {
+  const parts = propertyId.split("-");
+  return {
+    row: parseInt(parts[1], 10),
+    col: parseInt(parts[2], 10),
+  };
+}
+
+/**
+ * Abbreviate a Stellar address for display: "GABC…YZ56"
+ */
+export function abbreviateAddress(address: string): string {
+  if (!address) return "Unowned";
+  if (address === TREASURY) return "Treasury";
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}


### PR DESCRIPTION
# feat(land): Build City Map with Interactive Property Tiles

Closes #841

## Summary

Builds the central city map experience for Akkuea Land — a 20×20 CSS Grid of 400 interactive property tiles rendered at `/map`. Each tile is color-coded by owner address using a deterministic DJB2 hash-to-HSL function, shows building level badges (V/R/C/S), and displays a pulsing amber indicator for properties listed for sale.

## Changes

### New Files

| File | Purpose |
|---|---|
| `src/lib/colorHash.ts` | Deterministic `addressToHSL()` — same wallet always maps to same color |
| `src/lib/mockProperties.ts` | Seeded LCG generator for 400 `GameProperty` objects (consistent across refreshes) |
| `src/components/game/CityMap.tsx` | Core grid component with event delegation and PropertyPanel integration |
| `src/components/game/CityMap.css` | Grid layout, tile hover/tooltip/badge/selection/flash styles + responsive breakpoints |
| `src/hooks/useMapEvents.ts` | Simulated real-time events (ownership change, level upgrade, listing) every 8–15s |

### Modified Files

| File | Change |
|---|---|
| `src/app/map/page.tsx` | Replaced placeholder with `<CityMap />` inside `<GameShell>`, added SEO metadata |
| `src/app/globals.css` | Added `tile-flash` keyframe animation for real-time event feedback |

## Architecture Decisions

- **Raw `<div>` tiles, not React components** — avoids 400 fiber nodes, keeps VDOM diff fast
- **Event delegation** — single `onClick` on the grid container reads `data-property-id` from `event.target.closest()`; zero per-tile listeners
- **CSS-only hover + tooltips** — `transform: scale(1.15)` and `::after` pseudo-elements; no JavaScript on the hover path
- **DOM-based flash animation** — `classList.add/remove` instead of `setState` to flash a single tile without re-rendering 400 tiles
- **Seeded PRNG** — deterministic mock data so the map layout is identical across dev reloads

## Acceptance Criteria

- [x] 20×20 grid renders with correct color-coding, badges, and listing indicators
- [x] Hover tooltip shows coordinates, abbreviated owner address, improvement level, and listing price
- [x] Click opens the detail panel and applies a selection ring to the tile
- [x] Event delegation used instead of per-tile listeners
- [x] Map is usable on screens from 375px wide up to ultrawide
- [x] Simulated real-time events flash affected tiles

## Verification

| Check | Result |
|---|---|
| TypeScript (`tsc --noEmit`) | ✅ Clean |
| ESLint | ✅ Clean |
| Existing tests (5 PropertyPanel tests) | ✅ All pass |

## Screenshots
<img width="1470" height="843" alt="Screenshot 2026-05-28 at 8 42 06 PM" src="https://github.com/user-attachments/assets/528930c4-1fe5-42e7-84ea-5cde737c9eff" />
