### PR TITLE
Migrate CONTRACT_IDS to JSON and document testnet deployment

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -40,9 +40,17 @@ NOTIFICATIONS_ENABLED=true
 # NOTIFICATION_REQUEST_TIMEOUT_MS=10000
 
 # Soroban / Stellar Configuration
-REAL_ESTATE_TOKEN_CONTRACT_ID=your_real_estate_token_contract_id
+#
+# Contract IDs default to the committed per-network deployment artifacts in
+# apps/shared/src/contracts.<network>.json (exposed via CONTRACT_IDS), selected
+# by STELLAR_NETWORK / STELLAR_NETWORK_PASSPHRASE below. The variables below are
+# OPTIONAL overrides - set them only to point the API at a custom/local
+# deployment. Leave them unset to use the shared testnet/mainnet addresses.
+# REAL_ESTATE_TOKEN_CONTRACT_ID=C...
 # DeFi RWA lending contract (used by the liquidation endpoint)
-DEFI_RWA_CONTRACT_ID=your_defi_rwa_contract_id
+# DEFI_RWA_CONTRACT_ID=C...
+# Network selector for the shared contract artifacts: "testnet" (default) or "mainnet".
+STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/apps/api/src/config/contracts.ts
+++ b/apps/api/src/config/contracts.ts
@@ -1,0 +1,50 @@
+import { CONTRACT_IDS } from '@real-estate-defi/shared';
+
+/**
+ * Resolves Soroban contract IDs for the API.
+ *
+ * Source of truth is the shared per-network deployment artifacts
+ * (`apps/shared/src/contracts.<network>.json`, surfaced via `CONTRACT_IDS`).
+ * An explicit environment variable still wins when set, so operators can point
+ * the API at a custom/local deployment without editing committed artifacts.
+ */
+
+type NetworkKey = 'TESTNET' | 'MAINNET';
+
+const MAINNET_PASSPHRASE = 'Public Global Stellar Network ; September 2015';
+
+/**
+ * Determine the active network from configuration. `STELLAR_NETWORK` takes
+ * precedence; otherwise the network passphrase is inspected. Defaults to
+ * testnet, matching the rest of the Stellar configuration in this service.
+ */
+export function resolveNetworkKey(): NetworkKey {
+  const network = (process.env.STELLAR_NETWORK ?? '').trim().toLowerCase();
+  if (network === 'mainnet' || network === 'public') {
+    return 'MAINNET';
+  }
+  if (network === 'testnet') {
+    return 'TESTNET';
+  }
+
+  const passphrase = process.env.STELLAR_NETWORK_PASSPHRASE ?? '';
+  return passphrase === MAINNET_PASSPHRASE ? 'MAINNET' : 'TESTNET';
+}
+
+/** Real Estate Token contract ID (env override → shared deployment artifact). */
+export function getRealEstateTokenContractId(): string {
+  const fromEnv = process.env.REAL_ESTATE_TOKEN_CONTRACT_ID?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return CONTRACT_IDS.REAL_ESTATE_TOKEN[resolveNetworkKey()] ?? '';
+}
+
+/** DeFi RWA / lending contract ID (env override → shared deployment artifact). */
+export function getDefiRwaContractId(): string {
+  const fromEnv = process.env.DEFI_RWA_CONTRACT_ID?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return CONTRACT_IDS.DEFI_LENDING[resolveNetworkKey()] ?? '';
+}

--- a/apps/api/src/controllers/LendingController.ts
+++ b/apps/api/src/controllers/LendingController.ts
@@ -9,6 +9,7 @@ import { cacheService } from '../services/CacheService';
 import { RiskMonitoringController } from './RiskMonitoringController';
 import { stellarService } from '../services/StellarService';
 import { isLiquidatorAuthorized } from '../utils/liquidatorAuth';
+import { getDefiRwaContractId } from '../config/contracts';
 
 const POOLS_CACHE_TTL = 10; // seconds
 const POOLS_CACHE_PREFIX = 'lending:pools:';
@@ -276,7 +277,7 @@ export class LendingController {
 
     // Best-effort on-chain liquidation - proceeds even if contract call fails
     let txHash: string | null = null;
-    const contractId = process.env.DEFI_RWA_CONTRACT_ID;
+    const contractId = getDefiRwaContractId();
     const adminPublicKey = process.env.STELLAR_ADMIN_PUBLIC_KEY;
     const adminSecret = process.env.STELLAR_ADMIN_SECRET;
     if (contractId && adminPublicKey && adminSecret) {

--- a/apps/api/src/services/StellarService.ts
+++ b/apps/api/src/services/StellarService.ts
@@ -10,6 +10,7 @@ import {
   xdr,
 } from 'stellar-sdk';
 import { ApiError } from '../errors/ApiError';
+import { getRealEstateTokenContractId } from '../config/contracts';
 
 export interface MintSharesParams {
   contractId: string;
@@ -40,7 +41,7 @@ export class StellarService {
   }
 
   getMintingConfig(): { contractId: string; adminPublicKey: string; adminSecret: string } {
-    const contractId = process.env.REAL_ESTATE_TOKEN_CONTRACT_ID;
+    const contractId = getRealEstateTokenContractId();
     const adminPublicKey = process.env.STELLAR_ADMIN_PUBLIC_KEY;
     const adminSecret = process.env.STELLAR_ADMIN_SECRET;
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react-jsx",
     "allowJs": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,

--- a/apps/shared/src/constants/index.ts
+++ b/apps/shared/src/constants/index.ts
@@ -1,4 +1,9 @@
-// Removed unused imports
+// Contract IDs are loaded from per-network JSON deployment artifacts rather than
+// hard-coded here. These files are updated by the deploy pipeline (see
+// docs/contracts/deployment.md), not by the build, so application code can stay
+// untouched when contracts are (re)deployed.
+import testnetContracts from "../contracts.testnet.json";
+import mainnetContracts from "../contracts.mainnet.json";
 
 export const STELLAR_NETWORKS = {
   MAINNET: "public",
@@ -7,14 +12,19 @@ export const STELLAR_NETWORKS = {
   STANDALONE: "standalone",
 } as const;
 
+/**
+ * Soroban contract IDs per network, derived from the `contracts.<network>.json`
+ * deployment artifacts. An empty string means the contract has not been deployed
+ * to that network yet.
+ */
 export const CONTRACT_IDS = {
   REAL_ESTATE_TOKEN: {
-    TESTNET: "",
-    MAINNET: "",
+    TESTNET: testnetContracts.contracts.REAL_ESTATE_TOKEN,
+    MAINNET: mainnetContracts.contracts.REAL_ESTATE_TOKEN,
   },
   DEFI_LENDING: {
-    TESTNET: "",
-    MAINNET: "",
+    TESTNET: testnetContracts.contracts.DEFI_LENDING,
+    MAINNET: mainnetContracts.contracts.DEFI_LENDING,
   },
 } as const;
 

--- a/apps/shared/src/contracts.mainnet.json
+++ b/apps/shared/src/contracts.mainnet.json
@@ -1,0 +1,10 @@
+{
+  "network": "mainnet",
+  "networkPassphrase": "Public Global Stellar Network ; September 2015",
+  "rpcUrl": "https://rpc.mainnet.stellar.org",
+  "description": "Deployed Soroban contract IDs for the akkuea defi-rwa platform on Stellar mainnet. This file is a deployment artifact: it is updated by the deploy pipeline (see docs/contracts/deployment.md), not by the build. Values are empty placeholders until the contracts are deployed to mainnet; when populated, each value is a Soroban contract address and starts with 'C'.",
+  "contracts": {
+    "REAL_ESTATE_TOKEN": "",
+    "DEFI_LENDING": ""
+  }
+}

--- a/apps/shared/src/contracts.testnet.json
+++ b/apps/shared/src/contracts.testnet.json
@@ -1,0 +1,10 @@
+{
+  "network": "testnet",
+  "networkPassphrase": "Test SDF Network ; September 2015",
+  "rpcUrl": "https://soroban-testnet.stellar.org",
+  "description": "Deployed Soroban contract IDs for the akkuea defi-rwa platform on Stellar testnet. This file is a deployment artifact: it is updated by the deploy pipeline (see docs/contracts/deployment.md), not by the build. Each value is a Soroban contract address and starts with 'C'.",
+  "contracts": {
+    "REAL_ESTATE_TOKEN": "CBFQV2RY5VHVFU3HT2I72FLXWY5YNZC37LWJSOZQCX45B76NBO4YZHM4",
+    "DEFI_LENDING": "CBFOZBCYMIDIZLNHT6ANMBU6LSGC6REM6Z5M4ST35E5T5FDWWZAWZLTX"
+  }
+}

--- a/apps/shared/tsconfig.json
+++ b/apps/shared/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2020"],
     "types": ["bun-types"],
+    "resolveJsonModule": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/docs/contracts/deployment.md
+++ b/docs/contracts/deployment.md
@@ -2,6 +2,15 @@
 
 This guide covers deploying the Real Estate DeFi Platform smart contracts to Stellar networks using Stellar CLI.
 
+> **Where contract IDs live.** Deployed contract addresses are stored as JSON
+> deployment artifacts at `apps/shared/src/contracts.testnet.json` and
+> `apps/shared/src/contracts.mainnet.json`. The shared `CONTRACT_IDS` constant
+> (`apps/shared/src/constants/index.ts`) and the API
+> (`apps/api/src/config/contracts.ts`) read contract IDs from these files, so
+> recording a new deployment is a data change, not a code change. The current
+> testnet deployment is at the [Testnet Deployment Record](#testnet-deployment-record)
+> section below.
+
 ## Prerequisites
 
 1. **Stellar CLI installed**
@@ -11,11 +20,14 @@ This guide covers deploying the Real Estate DeFi Platform smart contracts to Ste
 
 ## Contract Types
 
-The platform includes two main contracts:
+The `defi-rwa` crate (`apps/contracts/contracts/defi-rwa`, package
+`rwa-defi-contract`) compiles to a **single** WASM that exposes both property
+tokenization and lending. The platform deploys that one WASM as **two
+independent contract instances**, each with its own contract ID and admin:
 
-### 1. Real Estate Token Contract
+### 1. Real Estate Token Contract (instance)
 
-- **File**: `apps/contracts/src/real_estate_token.rs`
+- **Source**: `apps/contracts/contracts/defi-rwa` (`PropertyTokenContract`)
 - **Purpose**: Property tokenization and share management
 - **Key Features**:
   - Property tokenization
@@ -23,9 +35,9 @@ The platform includes two main contracts:
   - Transfer controls
   - Metadata management
 
-### 2. DeFi Lending Contract
+### 2. DeFi Lending Contract (instance)
 
-- **File**: `apps/contracts/src/defi_lending.rs`
+- **Source**: `apps/contracts/contracts/defi-rwa` (same WASM, separate instance)
 - **Purpose**: Lending pools and borrowing operations
 - **Key Features**:
   - Pool creation and management
@@ -44,22 +56,23 @@ rustup target add wasm32-unknown-unknown
 ### 2. Build Contracts
 
 ```bash
-cd apps/contracts
+cd apps/contracts/contracts/defi-rwa
 
-# Build release version
-cargo build --target wasm32-unknown-unknown --release
+# Build with the Stellar CLI. This targets wasm32v1-none and produces a WASM
+# the Soroban VM accepts. A plain `cargo build --target wasm32-unknown-unknown`
+# with recent Rust toolchains enables the `reference-types` feature, which the
+# Soroban VM rejects at deploy time ("reference-types not enabled"), so prefer
+# `stellar contract build`.
+stellar contract build
 
-# Output will be in target/wasm32-unknown-unknown/release/
+# Output: apps/contracts/target/wasm32v1-none/release/rwa_defi_contract.wasm
 ```
 
 ### 3. Verify Build
 
 ```bash
-# Check if WASM files were created
-ls -la target/wasm32-unknown-unknown/release/
-
-# You should see files like:
-# real_estate_defi_contracts.wasm
+# Check that the WASM was created
+ls -la apps/contracts/target/wasm32v1-none/release/rwa_defi_contract.wasm
 ```
 
 ## Network Setup
@@ -335,3 +348,71 @@ stellar transaction --id $TRANSACTION_ID --network testnet
 - **Keep admin keys secure** and use hardware wallets
 
 This deployment process ensures your smart contracts are properly deployed and integrated with the entire Real Estate DeFi Platform.
+
+## Testnet Deployment Record
+
+Both instances were deployed from the same `rwa_defi_contract.wasm` (built with
+`stellar contract build`, target `wasm32v1-none`) on **Stellar testnet**.
+
+- **Network**: testnet (`Test SDF Network ; September 2015`)
+- **Deployer / admin account**: `GBN4ABG3ES6NHKY4BURL3EMP5RA6EFQJDR4EET6U66M6YIRADPWJ7OQ6`
+- **Uploaded WASM hash**: `c13878bd0845d4965a5eb26138b77db617fdccbb70a70dc47acd8c460af6a0b1`
+- **Deployed on**: 2026-05-31
+- **Source of truth**: [`apps/shared/src/contracts.testnet.json`](../../apps/shared/src/contracts.testnet.json)
+
+| Contract | Contract ID | Deploy (create) tx |
+| --- | --- | --- |
+| `REAL_ESTATE_TOKEN` | `CBFQV2RY5VHVFU3HT2I72FLXWY5YNZC37LWJSOZQCX45B76NBO4YZHM4` | `ff4c6b52080df05d9ad443a6a3907894fb771e187b04dbd837306c62add89724` |
+| `DEFI_LENDING` | `CBFOZBCYMIDIZLNHT6ANMBU6LSGC6REM6Z5M4ST35E5T5FDWWZAWZLTX` | `490a50682d4da46c85a8080cc5ae6b50d727bf1156c97a2c9a00c532c441bdd4` |
+
+**WASM upload transaction** (shared by both instances; submitted with the first
+deploy): `c5e2fd6753437a1c8dc217e5a9797b4abdd7621aed6747fedbd03c9c72ab8079`
+
+### Verification
+
+Each contract ID was verified **before being committed** by invoking the
+read-only `get_oracle_config` view, which returned the contract defaults
+`(max_age = 3600, min_price = 0)` — confirming the WASM is live and executing:
+
+```bash
+stellar contract invoke \
+  --id CBFQV2RY5VHVFU3HT2I72FLXWY5YNZC37LWJSOZQCX45B76NBO4YZHM4 \
+  --source <account> --network testnet --send=no \
+  -- get_oracle_config
+# => [3600,"0"]
+
+stellar contract invoke \
+  --id CBFOZBCYMIDIZLNHT6ANMBU6LSGC6REM6Z5M4ST35E5T5FDWWZAWZLTX \
+  --source <account> --network testnet --send=no \
+  -- get_oracle_config
+# => [3600,"0"]
+```
+
+Explorer links:
+
+- REAL_ESTATE_TOKEN: <https://stellar.expert/explorer/testnet/contract/CBFQV2RY5VHVFU3HT2I72FLXWY5YNZC37LWJSOZQCX45B76NBO4YZHM4>
+- DEFI_LENDING: <https://stellar.expert/explorer/testnet/contract/CBFOZBCYMIDIZLNHT6ANMBU6LSGC6REM6Z5M4ST35E5T5FDWWZAWZLTX>
+
+### Reproducing this deployment
+
+```bash
+# 1. Build a Soroban-compatible WASM
+cd apps/contracts/contracts/defi-rwa
+stellar contract build
+
+# 2. Fund a testnet deployer key
+stellar keys generate akkuea-deployer --network testnet --fund
+
+# 3. Deploy two instances (constructor takes the admin address)
+ADMIN=$(stellar keys address akkuea-deployer)
+WASM=../../target/wasm32v1-none/release/rwa_defi_contract.wasm
+stellar contract deploy --wasm "$WASM" --source akkuea-deployer --network testnet -- --admin "$ADMIN"
+stellar contract deploy --wasm "$WASM" --source akkuea-deployer --network testnet -- --admin "$ADMIN"
+
+# 4. Record the printed contract IDs in apps/shared/src/contracts.testnet.json
+#    and verify each with `get_oracle_config` before committing.
+```
+
+> **Mainnet** values in `apps/shared/src/contracts.mainnet.json` are intentionally
+> empty placeholders; populate them with the same process against
+> `--network mainnet` when a mainnet deployment is performed.


### PR DESCRIPTION


Closes #831

## What & why

Contract addresses were empty TypeScript constants — useless and the wrong
format for deployment artifacts that change per environment. This PR moves them
to per-network JSON artifacts, wires the shared constants and the API to read
from them, and records a real, verified testnet deployment of the `defi-rwa`
contracts.

## Changes

- **`apps/shared/src/contracts.testnet.json` / `contracts.mainnet.json`** — new
  JSON deployment artifacts holding contract IDs per network. Testnet is
  populated with real deployed addresses; mainnet has empty placeholders.
- **`apps/shared/src/constants/index.ts`** — `CONTRACT_IDS` now derives from the
  JSON (shape unchanged, so existing consumers are unaffected).
  `resolveJsonModule` enabled in `apps/shared/tsconfig.json` (tsc emits the JSON
  into `dist`).
- **`apps/api/src/config/contracts.ts`** (new) — resolves contract IDs from the
  shared artifacts by network, with `REAL_ESTATE_TOKEN_CONTRACT_ID` /
  `DEFI_RWA_CONTRACT_ID` env vars kept as optional overrides. Wired into
  `StellarService.getMintingConfig` and the lending liquidation path.
- **`apps/api/.env.example`** — contract-ID vars documented as optional
  overrides; added `STELLAR_NETWORK` selector.
- **`docs/contracts/deployment.md`** — testnet deployment record (IDs, tx
  hashes, verification) + corrected build instructions.

## Testnet deployment (verified)

Both instances deployed from one `rwa_defi_contract.wasm`
(`stellar contract build`, target `wasm32v1-none`) on testnet.
Each ID was verified **before commit** via the read-only `get_oracle_config`
view (returned `[3600,"0"]`).

| Contract | ID | Deploy tx |
| --- | --- | --- |
| `REAL_ESTATE_TOKEN` | `CBFQV2RY5VHVFU3HT2I72FLXWY5YNZC37LWJSOZQCX45B76NBO4YZHM4` | `ff4c6b52080df05d9ad443a6a3907894fb771e187b04dbd837306c62add89724` |
| `DEFI_LENDING` | `CBFOZBCYMIDIZLNHT6ANMBU6LSGC6REM6Z5M4ST35E5T5FDWWZAWZLTX` | `490a50682d4da46c85a8080cc5ae6b50d727bf1156c97a2c9a00c532c441bdd4` |

- WASM upload tx: `c5e2fd6753437a1c8dc217e5a9797b4abdd7621aed6747fedbd03c9c72ab8079`
- WASM hash: `c13878bd0845d4965a5eb26138b77db617fdccbb70a70dc47acd8c460af6a0b1`
- Deployer/admin: `GBN4ABG3ES6NHKY4BURL3EMP5RA6EFQJDR4EET6U66M6YIRADPWJ7OQ6`

## Testing

- shared: type-check, lint, prettier, build, strict tsc, type-coverage (97.85%),
  tests **119/119** — all pass.
- api: type-check, lint, prettier, build pass; `tokenization.test.ts` passes;
  network-selection + env-override fallback verified manually.
- DB-backed API integration tests run on CI (no local Postgres).

## Acceptance criteria

- [x] JSON structure defines contract IDs per network (testnet, mainnet)
- [x] `CONTRACT_IDS` populated from JSON
- [x] Testnet IDs are real deployed `C…` addresses
- [x] Deploy tx hashes recorded in `docs/contracts/deployment.md`
- [x] API reads contract IDs from this source (not empty constants)
- [x] Addresses verified via read-only call before committing
