### PR TITLE
Remove deprecated Stellar SDK aliases

### DIFF
--- a/apps/akkuea-land/src/app/dashboard/page.tsx
+++ b/apps/akkuea-land/src/app/dashboard/page.tsx
@@ -25,7 +25,7 @@ import {
   APARTMENT_MULTIPLIER,
   SKYSCRAPER_MULTIPLIER,
 } from "@akkuea/shared";
-import { SorobanRpc } from "stellar-sdk";
+import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
 import { GameProperty, BuildingLevel } from "@/types/game.types";
 import { getWalletKit } from "@/lib/walletKit";
 

--- a/apps/akkuea-land/src/lib/soroban-poller.ts
+++ b/apps/akkuea-land/src/lib/soroban-poller.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, xdr } from "@stellar/stellar-sdk";
+import { rpc as SorobanRpc, xdr } from "@stellar/stellar-sdk";
 import type {
   GameEvent,
   PropertyBoughtEvent,
@@ -19,18 +19,12 @@ const CONTRACT_IDS: string[] = (
 
 /** Parse a raw Soroban event into a typed GameEvent, or null if unrecognised. */
 function parseEvent(
-  raw: SorobanRpc.Api.RawEventResponse,
+  raw: SorobanRpc.Api.EventResponse,
   index: number,
 ): GameEvent | null {
   if (raw.type !== "contract") return null;
 
-  const topics = raw.topic.map((t) => {
-    try {
-      return xdr.ScVal.fromXDR(t, "base64");
-    } catch {
-      return null;
-    }
-  });
+  const topics = raw.topic;
 
   const eventTypeTopic = topics[0];
   if (!eventTypeTopic || eventTypeTopic.switch().name !== "scvSymbol")
@@ -41,7 +35,7 @@ function parseEvent(
   const base = {
     ledger: raw.ledger,
     timestamp: raw.ledgerClosedAt,
-    contractId: raw.contractId ?? "",
+    contractId: raw.contractId?.toString() ?? "",
     id: `${raw.ledger}-${raw.txHash}-${index}`,
   };
 
@@ -50,7 +44,7 @@ function parseEvent(
     if (v.switch().name === "scvString") return v.str().toString();
     if (v.switch().name === "scvSymbol") return v.sym().toString();
     if (v.switch().name === "scvAddress")
-      return v.address().toScAddress().toString();
+      return v.address().toString();
     if (v.switch().name === "scvI128")
       return v.i128().lo().toString();
     return "";
@@ -126,7 +120,7 @@ export async function pollGameEvents(startLedger: number): Promise<PollResult> {
   let maxLedger = startLedger;
 
   for (let i = 0; i < response.events.length; i++) {
-    const raw = response.events[i] as SorobanRpc.Api.RawEventResponse;
+    const raw = response.events[i];
     if (raw.ledger > maxLedger) maxLedger = raw.ledger;
     const parsed = parseEvent(raw, i);
     if (parsed) events.push(parsed);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,8 +32,7 @@
     "install": "^0.13.0",
     "ioredis": "^5.4.2",
     "postgres": "^3.4.8",
-    "soroban-client": "^1.0.1",
-    "stellar-sdk": "^13.3.0",
+    "@stellar/stellar-sdk": "^13.3.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Elysia } from 'elysia';
 import { authRoutes } from '../routes/auth';
-import { Keypair } from 'stellar-sdk';
+import { Keypair } from '@stellar/stellar-sdk';
 import { jwt } from '@elysiajs/jwt';
 import { spyOn } from 'bun:test';
 import { userRepository } from '../repositories/UserRepository';

--- a/apps/api/src/controllers/AuthController.ts
+++ b/apps/api/src/controllers/AuthController.ts
@@ -1,4 +1,4 @@
-import { Keypair } from 'stellar-sdk';
+import { Keypair } from '@stellar/stellar-sdk';
 import { ApiError } from '../errors/ApiError';
 import { userRepository } from '../repositories/UserRepository';
 

--- a/apps/api/src/services/StellarService.ts
+++ b/apps/api/src/services/StellarService.ts
@@ -8,7 +8,7 @@ import {
   Transaction,
   TransactionBuilder,
   xdr,
-} from 'stellar-sdk';
+} from '@stellar/stellar-sdk';
 import {
   createNodeContractSigner,
   DefiLendingContractClient,

--- a/apps/shared/src/types/index.ts
+++ b/apps/shared/src/types/index.ts
@@ -79,7 +79,15 @@ export interface ContractValuationPayload {
 }
 export * from "./risk";
 export * from "./pagination";
-export type { GameEventType, PaginatedGameEvents } from "./game-events";
+export type {
+  GameEvent,
+  GameEventType,
+  PaginatedGameEvents,
+  PropertyBoughtEvent,
+  PropertyListedEvent,
+  PropertyTransferredEvent,
+  RentCollectedEvent,
+} from "./game-events";
 
 // ─── Akkuea Land game types (Cycle 5) ────────────────────────────────────────
 export type {
@@ -92,11 +100,8 @@ export type {
   Property,
   Player,
   Listing,
-  PropertyBoughtEvent,
-  PropertyListedEvent,
   PropertyImprovedEvent,
   RentalClaimedEvent,
-  GameEvent,
 } from "./game";
 
 export {

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -27,8 +27,7 @@
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
     "smart-account-kit": "0.2.10",
-    "soroban-client": "^1.0.1",
-    "stellar-sdk": "^13.3.0",
+    "@stellar/stellar-sdk": "^13.3.0",
     "zod": "^3.25.76",
     "zustand": "^5.0.11"
   },

--- a/apps/webapp/src/app/api/privy/sign/route.ts
+++ b/apps/webapp/src/app/api/privy/sign/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Transaction, Keypair, xdr } from "stellar-sdk";
+import { Transaction, Keypair, xdr } from "@stellar/stellar-sdk";
 import { verifyPrivyWalletOwnership } from "@/lib/privy-server";
 import { PRIVY_APP_CREDENTIAL_ENV, PRIVY_APP_ID_ENV } from "@/lib/privy-env";
 

--- a/apps/webapp/src/lib/stellar.ts
+++ b/apps/webapp/src/lib/stellar.ts
@@ -1,4 +1,4 @@
-import { Horizon } from "stellar-sdk";
+import { Horizon } from "@stellar/stellar-sdk";
 
 const HORIZON_URLS: Record<"testnet" | "mainnet", string> = {
   testnet: "https://horizon-testnet.stellar.org",

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@creit.tech/stellar-wallets-kit": "^1.9.5",
         "@hookform/resolvers": "^5.2.2",
+        "@stellar/stellar-sdk": "^13.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -16,8 +17,6 @@
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
         "react-hook-form": "^7.71.2",
-        "soroban-client": "^1.0.1",
-        "stellar-sdk": "^13.3.0",
       },
       "devDependencies": {
         "@types/node": "^25.3.0",
@@ -68,6 +67,7 @@
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/jwt": "^1.4.2",
         "@elysiajs/swagger": "^1.3.1",
+        "@stellar/stellar-sdk": "^13.3.0",
         "bun": "^1.3.9",
         "drizzle-orm": "^0.38.4",
         "elysia": "^1.4.26",
@@ -75,8 +75,6 @@
         "install": "^0.13.0",
         "ioredis": "^5.4.2",
         "postgres": "^3.4.8",
-        "soroban-client": "^1.0.1",
-        "stellar-sdk": "^13.3.0",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -128,6 +126,7 @@
         "@hookform/resolvers": "^3.10.0",
         "@privy-io/react-auth": "^2.0.0",
         "@privy-io/server-auth": "^1.32.5",
+        "@stellar/stellar-sdk": "^13.3.0",
         "clsx": "^2.1.1",
         "framer-motion": "^11.18.2",
         "lucide-react": "^0.468.0",
@@ -136,8 +135,6 @@
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
         "smart-account-kit": "0.2.10",
-        "soroban-client": "^1.0.1",
-        "stellar-sdk": "^13.3.0",
         "zod": "^3.25.76",
         "zustand": "^5.0.11",
       },
@@ -2541,8 +2538,6 @@
 
     "sonic-boom": ["sonic-boom@3.8.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg=="],
 
-    "soroban-client": ["soroban-client@1.0.1", "", { "dependencies": { "axios": "^1.6.0", "bignumber.js": "^9.1.1", "buffer": "^6.0.3", "stellar-base": "10.0.0", "urijs": "^1.19.1" } }, "sha512-GdLgMuJ/riVnLvjEXFi7NqSwAZXsT6H55vITq5c+v15rTlbzGXvW2v/yA+K1zOXMFh0JAZ1IR+6S4CJMQXOcPA=="],
-
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -2564,10 +2559,6 @@
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
-    "stellar-base": ["stellar-base@10.0.0", "", { "dependencies": { "@stellar/js-xdr": "^3.0.1", "base32.js": "^0.1.0", "bignumber.js": "^9.1.2", "buffer": "^6.0.3", "sha.js": "^2.3.6", "tweetnacl": "^1.0.3" }, "optionalDependencies": { "sodium-native": "^4.0.1" } }, "sha512-WQhxGXQLSwwmIxWbZqv0HcJtlSOiaUgv7yKCCEwP+OoYDHKBjPjQiZWyAkuEY+mRFX9L+hnejLaBorc3P2rk0g=="],
-
-    "stellar-sdk": ["stellar-sdk@13.3.0", "", { "dependencies": { "@stellar/stellar-base": "^13.1.0", "axios": "^1.8.4", "bignumber.js": "^9.3.0", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.1" } }, "sha512-jAA3+U7oAUueldoS4kuEhcym+DigElWq9isPxt7tjMrE7kTJ2vvY29waavUb2FSfQIWwGbuwAJTYddy2BeyJsw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -3261,8 +3252,6 @@
 
     "smart-account-kit/@stellar/stellar-sdk": ["@stellar/stellar-sdk@15.1.0", "", { "dependencies": { "@stellar/stellar-base": "^15.0.0", "axios": "1.15.0", "bignumber.js": "^9.3.1", "commander": "^14.0.3", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.11" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A=="],
 
-    "smart-account-kit-bindings/@stellar/stellar-sdk": ["@stellar/stellar-sdk@15.1.0", "", { "dependencies": { "@stellar/stellar-base": "^15.0.0", "axios": "1.15.0", "bignumber.js": "^9.3.1", "commander": "^14.0.3", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.11" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A=="],
-
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -3579,10 +3568,6 @@
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
-    "smart-account-kit-bindings/@stellar/stellar-sdk/@stellar/stellar-base": ["@stellar/stellar-base@15.0.0", "", { "dependencies": { "@noble/curves": "^1.9.7", "@stellar/js-xdr": "^4.0.0", "base32.js": "^0.1.0", "bignumber.js": "^9.3.1", "buffer": "^6.0.3", "sha.js": "^2.4.12" } }, "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA=="],
-
-    "smart-account-kit-bindings/@stellar/stellar-sdk/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "smart-account-kit/@stellar/stellar-sdk/@stellar/stellar-base": ["@stellar/stellar-base@15.0.0", "", { "dependencies": { "@noble/curves": "^1.9.7", "@stellar/js-xdr": "^4.0.0", "base32.js": "^0.1.0", "bignumber.js": "^9.3.1", "buffer": "^6.0.3", "sha.js": "^2.4.12" } }, "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA=="],
 
     "smart-account-kit/@stellar/stellar-sdk/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
@@ -3856,8 +3841,6 @@
     "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
-
-    "smart-account-kit-bindings/@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@4.0.0", "", {}, "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA=="],
 
     "smart-account-kit/@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@4.0.0", "", {}, "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
     "react-hook-form": "^7.71.2",
-    "soroban-client": "^1.0.1",
-    "stellar-sdk": "^13.3.0"
+    "@stellar/stellar-sdk": "^13.3.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Summary
Removed deprecated soroban-client dependency from the root, API, and webapp package manifests.
Replaced remaining bare stellar-sdk package declarations/imports with canonical @stellar/stellar-sdk.
Updated Bun lockfile to remove the deprecated/old SDK entries.
Adjusted Soroban RPC imports to use the canonical SDK rpc namespace.
Aligned shared game-event exports so the monorepo type-check remains green.

Verification
bun run type-check passes across all packages.
Confirmed no soroban-client remains in any package.json.
Confirmed package manifests now use @stellar/stellar-sdk instead of bare stellar-sdk.

closes #819 
