### PR TITLE
fix(ratelimit): remove any and export elysia context type

### DIFF
--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,22 +1,17 @@
 import { describe, it, expect } from 'bun:test';
-import { rateLimit as originalRateLimit, createRedisStore, createMemoryStore } from './rateLimit';
+import { rateLimit, createRedisStore, createMemoryStore } from './rateLimit';
 import type { RateLimitRedisClient } from './rateLimit';
 import type { Context } from 'elysia';
-
-const rateLimit = originalRateLimit as unknown as (
-  options?: Parameters<typeof originalRateLimit>[0]
-) => (ctx: { request: Request; set: Context['set'] }) => Promise<any>;
 
 function createMockRequest(options: { headers?: Record<string, string> } = {}) {
   const headers = new Headers(options.headers ?? {});
   return { headers } as unknown as Request;
 }
 
-function createMockSet() {
+function createMockSet(): Context['set'] {
   return {
-    status: undefined as number | string | undefined,
-    headers: {} as Record<string, string>,
-  } as unknown as Context['set'];
+    headers: {},
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { rateLimit, createRedisStore, createMemoryStore } from './rateLimit';
+import { rateLimit as originalRateLimit, createRedisStore, createMemoryStore } from './rateLimit';
 import type { RateLimitRedisClient } from './rateLimit';
+import type { Context } from 'elysia';
+
+const rateLimit = originalRateLimit as unknown as (
+  options?: Parameters<typeof originalRateLimit>[0]
+) => (ctx: { request: Request; set: Context['set'] }) => Promise<any>;
 
 function createMockRequest(options: { headers?: Record<string, string> } = {}) {
   const headers = new Headers(options.headers ?? {});
@@ -10,8 +15,8 @@ function createMockRequest(options: { headers?: Record<string, string> } = {}) {
 function createMockSet() {
   return {
     status: undefined as number | string | undefined,
-    headers: undefined as Record<string, string> | undefined,
-  };
+    headers: {} as Record<string, string>,
+  } as unknown as Context['set'];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -128,7 +128,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
       'X-RateLimit-Limit': String(max),
       'X-RateLimit-Remaining': String(result.remaining),
       'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
-    };
+    } as Context['set']['headers'];
 
     if (!result.allowed) {
       set.status = 429;

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -114,7 +114,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
     storeReady = Promise.resolve(createMemoryStore());
   }
 
-  return async function rateLimitMiddleware({ request, set }: Context) {
+  return async function rateLimitMiddleware({ request, set }: Pick<Context, 'request' | 'set'>) {
     if (request.headers.get('x-test-bypass-ratelimit') === 'true') {
       return;
     }
@@ -123,12 +123,12 @@ export function rateLimit(options: RateLimitOptions = {}) {
     const store = await storeReady;
     const result = await store.checkLimit(identifier, windowMs, max);
 
-    set.headers = {
-      ...(set.headers ?? {}),
-      'X-RateLimit-Limit': String(max),
-      'X-RateLimit-Remaining': String(result.remaining),
-      'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
-    } as Context['set']['headers'];
+    if (!set.headers) {
+      set.headers = {};
+    }
+    set.headers['X-RateLimit-Limit'] = String(max);
+    set.headers['X-RateLimit-Remaining'] = String(result.remaining);
+    set.headers['X-RateLimit-Reset'] = String(Math.ceil(result.resetAt / 1000));
 
     if (!result.allowed) {
       set.status = 429;

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,3 +1,5 @@
+import type { Context } from 'elysia';
+
 interface RateLimitOptions {
   windowMs?: number;
   max?: number;
@@ -98,8 +100,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
 
   if (redisUrl) {
     storeReady = import('ioredis').then(({ default: Redis }) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const client = new (Redis as any)(redisUrl, {
+      const client = new Redis(redisUrl, {
         enableOfflineQueue: false,
         maxRetriesPerRequest: 1,
         connectTimeout: 3000,
@@ -113,8 +114,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
     storeReady = Promise.resolve(createMemoryStore());
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return async function rateLimitMiddleware({ request, set }: any) {
+  return async function rateLimitMiddleware({ request, set }: Context) {
     if (request.headers.get('x-test-bypass-ratelimit') === 'true') {
       return;
     }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One or two sentences. -->
Fix any types in rateLimit.ts middleware

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

apps/api/src/middleware/rateLimit.ts has two any usages that defeat type safety:

- Line 102: new (Redis as any)(redisUrl, {...}) — unnecessary cast, ioredis already has types
- Line 117: async function rateLimitMiddleware({ request, set }: any) — Elysia exports a Context type

## How to Test

1. Run: cd apps/api && bun run type-check, it should run tsc --emit with no errors.
2. Run: cd apps/api && bun test. 0 failed
3. No `any` in `apps/api/src/middleware/rateLimit.ts`

<img width="382" height="112" alt="image" src="https://github.com/user-attachments/assets/625135ac-719e-46bc-8ab4-f9f8a87ac8f0" />


## Checklist

- [ ] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [x] No `.env` files or secrets are committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

<!-- Closes #<issue_number> -->
Closes #907 