### PR TITLE
fix(webapp): move API client types to shared

### DIFF
--- a/apps/shared/src/types/api.ts
+++ b/apps/shared/src/types/api.ts
@@ -1,0 +1,120 @@
+/**
+ * API response wrapper type shared by app clients.
+ */
+export interface ApiResponse<T> {
+  data: T;
+  status: number;
+  message?: string;
+}
+
+/**
+ * API error response payload.
+ */
+export interface ApiError {
+  status: number;
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Request configuration options for API clients.
+ */
+export interface RequestConfig {
+  headers?: Record<string, string>;
+  timeout?: number;
+  retries?: number;
+  retryDelay?: number;
+}
+
+/**
+ * Query parameters accepted by REST endpoints that use page-based pagination.
+ */
+export interface ApiPaginationParams {
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+}
+
+/**
+ * Page metadata returned by REST endpoints.
+ */
+export interface ApiPaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * Paginated REST response wrapper.
+ */
+export interface ApiPaginatedResponse<T> {
+  data: T[];
+  pagination: ApiPaginationMeta;
+}
+
+/**
+ * HTTP request error raised by frontend API clients.
+ */
+export class ApiRequestError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    message: string,
+    public details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+    Object.setPrototypeOf(this, ApiRequestError.prototype);
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      status: this.status,
+      code: this.code,
+      message: this.message,
+      details: this.details,
+    };
+  }
+}
+
+export class ApiAuthenticationError extends ApiRequestError {
+  constructor(message: string = "Authentication required") {
+    super(401, "UNAUTHORIZED", message);
+    this.name = "AuthenticationError";
+    Object.setPrototypeOf(this, ApiAuthenticationError.prototype);
+  }
+}
+
+export class ApiNetworkError extends Error {
+  constructor(message: string = "Network error occurred") {
+    super(message);
+    this.name = "NetworkError";
+    Object.setPrototypeOf(this, ApiNetworkError.prototype);
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+    };
+  }
+}
+
+export class ApiTimeoutError extends Error {
+  constructor(message: string = "Request timed out") {
+    super(message);
+    this.name = "TimeoutError";
+    Object.setPrototypeOf(this, ApiTimeoutError.prototype);
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+    };
+  }
+}

--- a/apps/shared/src/types/index.ts
+++ b/apps/shared/src/types/index.ts
@@ -79,6 +79,7 @@ export interface ContractValuationPayload {
 }
 export * from "./risk";
 export * from "./pagination";
+export * from "./api";
 export type {
   GameEvent,
   GameEventType,

--- a/apps/webapp/src/services/api/types.ts
+++ b/apps/webapp/src/services/api/types.ts
@@ -1,125 +1,14 @@
-/**
- * API response wrapper type
- */
-export interface ApiResponse<T> {
-  data: T;
-  status: number;
-  message?: string;
-}
+export type {
+  ApiError,
+  ApiPaginatedResponse as PaginatedResponse,
+  ApiPaginationParams as PaginationParams,
+  ApiResponse,
+  RequestConfig,
+} from "@real-estate-defi/shared";
 
-/**
- * API error response
- */
-export interface ApiError {
-  status: number;
-  code: string;
-  message: string;
-  details?: Record<string, unknown>;
-}
-
-/**
- * Request configuration options
- */
-export interface RequestConfig {
-  headers?: Record<string, string>;
-  timeout?: number;
-  retries?: number;
-  retryDelay?: number;
-}
-
-/**
- * Pagination parameters
- */
-export interface PaginationParams {
-  page?: number;
-  limit?: number;
-  sortBy?: string;
-  sortOrder?: "asc" | "desc";
-}
-
-/**
- * Paginated response
- */
-export interface PaginatedResponse<T> {
-  data: T[];
-  pagination: {
-    page: number;
-    limit: number;
-    total: number;
-    totalPages: number;
-  };
-}
-
-/**
- * Custom error classes
- */
-export class ApiRequestError extends Error {
-  constructor(
-    public status: number,
-    public code: string,
-    message: string,
-    public details?: Record<string, unknown>,
-  ) {
-    super(message);
-    this.name = "ApiRequestError";
-    // Ensure proper prototype chain for instanceof checks
-    Object.setPrototypeOf(this, ApiRequestError.prototype);
-  }
-
-  /**
-   * Serialize error to JSON
-   */
-  toJSON() {
-    return {
-      name: this.name,
-      status: this.status,
-      code: this.code,
-      message: this.message,
-      details: this.details,
-    };
-  }
-}
-
-export class AuthenticationError extends ApiRequestError {
-  constructor(message: string = "Authentication required") {
-    super(401, "UNAUTHORIZED", message);
-    this.name = "AuthenticationError";
-    Object.setPrototypeOf(this, AuthenticationError.prototype);
-  }
-}
-
-export class NetworkError extends Error {
-  constructor(message: string = "Network error occurred") {
-    super(message);
-    this.name = "NetworkError";
-    Object.setPrototypeOf(this, NetworkError.prototype);
-  }
-
-  /**
-   * Serialize error to JSON
-   */
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-    };
-  }
-}
-
-export class TimeoutError extends Error {
-  constructor(message: string = "Request timed out") {
-    super(message);
-    this.name = "TimeoutError";
-    Object.setPrototypeOf(this, TimeoutError.prototype);
-  }
-
-  /**
-   * Serialize error to JSON
-   */
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-    };
-  }
-}
+export {
+  ApiAuthenticationError as AuthenticationError,
+  ApiNetworkError as NetworkError,
+  ApiRequestError,
+  ApiTimeoutError as TimeoutError,
+} from "@real-estate-defi/shared";


### PR DESCRIPTION
## Summary
- move webapp API response/request/error types into `apps/shared/src/types/api.ts`
- export the shared API types from `apps/shared/src/types/index.ts`
- keep the webapp API type module as a compatibility re-export from shared

## Verification
- `grep -n "any" apps/webapp/src/services/api/client.ts`
- `cd apps/webapp && bun run type-check`
- `cd apps/webapp && bun test`

Closes #908