### PR TITLE
a11y: add skip-to-content link in main webapp layout

### DIFF
--- a/apps/webapp/src/app/layout.tsx
+++ b/apps/webapp/src/app/layout.tsx
@@ -31,7 +31,15 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body className="antialiased min-h-screen bg-black text-white">
-        <Providers>{children}</Providers>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded"
+        >
+          Skip to content
+        </a>
+        <Providers>
+          <main id="main-content">{children}</main>
+        </Providers>
       </body>
     </html>
   );


### PR DESCRIPTION
 ## What

Adds a skip-to-content link to the root layout, fixing WCAG 2.1 Success Criterion 2.4.1 (Bypass Blocks).

## Why

Keyboard-only users had to tab through the entire navigation bar on every page before reaching main content. This is a WCAG Level A failure.

## Changes

- `apps/webapp/src/app/layout.tsx` — skip link added as the first focusable element in `<body>`; `children` wrapped in `<main id="main-content">` as the jump target

## Verification

- Press Tab on any page → skip link is the first focused element
- Skip link is visually hidden until focused (Tailwind `sr-only` / `focus:not-sr-only`)
- Activating the link moves focus past the nav to `#main-content`

Closes #897
