### PR TITLE
fix:Fix any in Drizzle ORM relations across schema files  

### DIFF
--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   NODE_VERSION: '20'
-  BUN_VERSION: 'latest'
+  BUN_VERSION: '1.x'
 
 jobs:
   monorepo-integrity:
@@ -106,17 +106,16 @@ jobs:
     - name: Audit all dependencies
       run: |
         cd .
-        
+
         # Install root dependencies
-        bun install
-        bun install --workspaces
-        
+        bun install --frozen-lockfile
+        bun install --workspaces --frozen-lockfile
+
         # Audit Bun workspaces
         bun audit --workspaces || true
-        
-        # Audit Bun workspaces
-        cd apps/api && bun install && bun audit || true
-        cd ../shared && bun install && bun audit || true
+
+        cd apps/api && bun install --frozen-lockfile && bun audit || true
+        cd ../shared && bun install --frozen-lockfile && bun audit || true
         
     - name: Check for license conflicts
       run: |
@@ -158,27 +157,38 @@ jobs:
     - name: Build performance test
       run: |
         cd .
-        
+
         echo "Testing build performance..."
-        
+
+        # Retry helper — platform-specific binaries (e.g. @next/swc-linux-x64-gnu)
+        # can fail on transient registry/CDN errors; three attempts is enough.
+        bun_install() {
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && return 0
+            echo "bun install attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          return 1
+        }
+
         # Record build times
         START_TIME=$(date +%s)
-        
+
         # Build webapp
         cd apps/webapp
-        bun install
+        bun_install
         bun run build
         WEBAPP_BUILD_TIME=$(date +%s)
-        
+
         # Build API
         cd ../api
-        bun install
+        bun_install
         bun run build
         API_BUILD_TIME=$(date +%s)
-        
+
         # Build shared
         cd ../shared
-        bun install
+        bun_install
         bun run build
         SHARED_BUILD_TIME=$(date +%s)
         
@@ -249,13 +259,13 @@ jobs:
 
         # Build shared library first
         cd apps/shared
-        bun install
+        bun install --frozen-lockfile
         bun run build
         cd ../..
 
         # Test API imports from shared
         cd apps/api
-        bun install
+        bun install --frozen-lockfile
         echo "Testing API imports..."
         bun -e "const shared = await import('../shared/dist/index.js'); console.log('✅ API can import shared library'); const { ValidationService } = shared; console.log('✅ ValidationService available:', typeof ValidationService);"
         cd ../..

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -1,18 +1,27 @@
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
-import { db, closeDatabaseConnection } from './index';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
 
 async function runMigrations() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('Migration failed: DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
   console.log('Running migrations...');
+
+  const client = postgres(connectionString, { max: 1 });
+  const db = drizzle(client);
 
   try {
     await migrate(db, { migrationsFolder: './drizzle/migrations' });
-
     console.log('Migrations completed successfully');
   } catch (error) {
     console.error('Migration failed:', error);
     process.exit(1);
   } finally {
-    await closeDatabaseConnection();
+    await client.end();
   }
 }
 

--- a/apps/api/src/db/schema/lending.ts
+++ b/apps/api/src/db/schema/lending.ts
@@ -56,14 +56,12 @@ export const borrowPositions = pgTable('borrow_positions', {
   lastAccrualAt: timestamp('last_accrual_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const lendingPoolsRelations = relations(lendingPools, ({ many }: any) => ({
+export const lendingPoolsRelations = relations(lendingPools, ({ many }) => ({
   depositPositions: many(depositPositions),
   borrowPositions: many(borrowPositions),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const depositPositionsRelations = relations(depositPositions, ({ one }: any) => ({
+export const depositPositionsRelations = relations(depositPositions, ({ one }) => ({
   pool: one(lendingPools, {
     fields: [depositPositions.poolId],
     references: [lendingPools.id],
@@ -74,8 +72,7 @@ export const depositPositionsRelations = relations(depositPositions, ({ one }: a
   }),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const borrowPositionsRelations = relations(borrowPositions, ({ one }: any) => ({
+export const borrowPositionsRelations = relations(borrowPositions, ({ one }) => ({
   pool: one(lendingPools, {
     fields: [borrowPositions.poolId],
     references: [lendingPools.id],

--- a/apps/api/src/db/schema/properties.ts
+++ b/apps/api/src/db/schema/properties.ts
@@ -94,8 +94,7 @@ export const shareOwnerships = pgTable('share_ownerships', {
   lastDividendClaimed: timestamp('last_dividend_claimed', { withTimezone: true }),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const propertiesRelations = relations(properties, ({ one, many }: any) => ({
+export const propertiesRelations = relations(properties, ({ one, many }) => ({
   owner: one(users, {
     fields: [properties.ownerId],
     references: [users.id],
@@ -104,16 +103,14 @@ export const propertiesRelations = relations(properties, ({ one, many }: any) =>
   shareOwnerships: many(shareOwnerships),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const propertyDocumentsRelations = relations(propertyDocuments, ({ one }: any) => ({
+export const propertyDocumentsRelations = relations(propertyDocuments, ({ one }) => ({
   property: one(properties, {
     fields: [propertyDocuments.propertyId],
     references: [properties.id],
   }),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const shareOwnershipsRelations = relations(shareOwnerships, ({ one }: any) => ({
+export const shareOwnershipsRelations = relations(shareOwnerships, ({ one }) => ({
   property: one(properties, {
     fields: [shareOwnerships.propertyId],
     references: [properties.id],

--- a/apps/api/src/db/schema/transactions.ts
+++ b/apps/api/src/db/schema/transactions.ts
@@ -34,8 +34,7 @@ export const transactions = pgTable('transactions', {
   metadata: jsonb('metadata').$type<Record<string, unknown>>(),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const transactionsRelations = relations(transactions, ({ one }: any) => ({
+export const transactionsRelations = relations(transactions, ({ one }) => ({
   fromUser: one(users, {
     fields: [transactions.fromUserId],
     references: [users.id],

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -52,13 +52,11 @@ export const kycDocuments = pgTable('kyc_documents', {
   reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const usersRelations = relations(users, ({ many }: any) => ({
+export const usersRelations = relations(users, ({ many }) => ({
   kycDocuments: many(kycDocuments),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const kycDocumentsRelations = relations(kycDocuments, ({ one }: any) => ({
+export const kycDocumentsRelations = relations(kycDocuments, ({ one }) => ({
   user: one(users, {
     fields: [kycDocuments.userId],
     references: [users.id],


### PR DESCRIPTION
## Summary

- **Remove `: any` from Drizzle ORM relation callbacks** across all four affected schema files (`lending.ts`, `properties.ts`, `transactions.ts`, `users.ts`). Drizzle infers `{ one, many }` types automatically from the table argument — the explicit `: any` annotation was defeating that inference and suppressing type safety. Also removed the paired `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comments that were only needed to silence the resulting lint warning.

## Type of Change

- **Fix `db:migrate` crash when `DATABASE_URL` is unset.** `migrate.ts` was importing the lazy Proxy `db` from `index.ts`. That Proxy is intentionally designed for test environments — it silently returns `undefined` for every property when no connection string is available — so the drizzle migrator crashed with `TypeError: undefined is not an object (evaluating 'db.dialect.migrate')`. The script now creates its own dedicated `postgres` + `drizzle` connection scoped to the migration run, and exits early with a clear error message if `DATABASE_URL` is missing.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

<!-- Describe the key changes and the reasoning behind them. -->

## How to Test

<!-- Step-by-step instructions so a reviewer can verify the change. -->

1.
2.

## Checklist

- [ ] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [ ] No `.env` files or secrets are committed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

closes #911 
