### PR TITLE
feat: implement SSE ledger streaming endpoint and integrate real-time…

### DIFF
--- a/apps/akkuea-land/next-env.d.ts
+++ b/apps/akkuea-land/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/akkuea-land/next-env.d.ts
+++ b/apps/akkuea-land/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/akkuea-land/src/app/dashboard/page.tsx
+++ b/apps/akkuea-land/src/app/dashboard/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import { useRouter } from "next/navigation";
 import {
   Coins,
@@ -334,7 +340,7 @@ export default function DashboardPage() {
   const MAX_SSE_RETRIES = 3;
   const SSE_RETRY_DELAY_MS = 2_000;
   const FALLBACK_POLL_MS = 5_000;
-  const SSE_ENDPOINT = '/api/ledger/stream';
+  const SSE_ENDPOINT = "/api/ledger/stream";
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -348,7 +354,9 @@ export default function DashboardPage() {
       try {
         const { sequence } = await server.getLatestLedger();
         setCurrentLedger(sequence);
-      } catch { /* keep current value */ }
+      } catch {
+        /* keep current value */
+      }
     }
 
     function startPolling() {
@@ -373,7 +381,10 @@ export default function DashboardPage() {
 
     function connectSSE() {
       closeSSE();
-      if (typeof window === 'undefined') { startPolling(); return; }
+      if (typeof window === "undefined") {
+        startPolling();
+        return;
+      }
 
       try {
         const es = new EventSource(SSE_ENDPOINT);
@@ -388,14 +399,19 @@ export default function DashboardPage() {
           try {
             const data = JSON.parse(event.data) as { sequence: number };
             setCurrentLedger(data.sequence);
-          } catch { /* ignore malformed */ }
+          } catch {
+            /* ignore malformed */
+          }
         };
 
         es.onerror = () => {
           closeSSE();
           if (sseRetriesRef.current < MAX_SSE_RETRIES) {
             sseRetriesRef.current += 1;
-            retryTimeoutRef.current = setTimeout(connectSSE, SSE_RETRY_DELAY_MS);
+            retryTimeoutRef.current = setTimeout(
+              connectSSE,
+              SSE_RETRY_DELAY_MS,
+            );
           } else {
             startPolling(); // fallback after max retries
           }
@@ -415,7 +431,6 @@ export default function DashboardPage() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
 
   // Recompute accrued income on every ledger tick
   const propertiesWithIncome = useMemo(

--- a/apps/akkuea-land/src/app/dashboard/page.tsx
+++ b/apps/akkuea-land/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   Coins,
@@ -330,8 +330,17 @@ export default function DashboardPage() {
   );
   const [eventPage, setEventPage] = useState(1);
 
-  // Poll the Soroban RPC for the latest ledger every 5 s so accrued income
-  // is always computed against a fresh on-chain sequence number.
+  // SSE primary, 5 s RPC poll fallback
+  const MAX_SSE_RETRIES = 3;
+  const SSE_RETRY_DELAY_MS = 2_000;
+  const FALLBACK_POLL_MS = 5_000;
+  const SSE_ENDPOINT = '/api/ledger/stream';
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const sseRetriesRef = useRef(0);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const server = new SorobanRpc.Server(SOROBAN_RPC_URL);
 
@@ -339,17 +348,76 @@ export default function DashboardPage() {
       try {
         const { sequence } = await server.getLatestLedger();
         setCurrentLedger(sequence);
-      } catch {
-        // keep the current value on transient network errors
+      } catch { /* keep current value */ }
+    }
+
+    function startPolling() {
+      if (intervalRef.current) return;
+      void fetchLatestLedger();
+      intervalRef.current = setInterval(fetchLatestLedger, FALLBACK_POLL_MS);
+    }
+
+    function stopPolling() {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
     }
 
-    fetchLatestLedger();
-    const id = setInterval(fetchLatestLedger, 5_000);
-    return () => clearInterval(id);
+    function closeSSE() {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+    }
+
+    function connectSSE() {
+      closeSSE();
+      if (typeof window === 'undefined') { startPolling(); return; }
+
+      try {
+        const es = new EventSource(SSE_ENDPOINT);
+        eventSourceRef.current = es;
+
+        es.onopen = () => {
+          sseRetriesRef.current = 0;
+          stopPolling();
+        };
+
+        es.onmessage = (event) => {
+          try {
+            const data = JSON.parse(event.data) as { sequence: number };
+            setCurrentLedger(data.sequence);
+          } catch { /* ignore malformed */ }
+        };
+
+        es.onerror = () => {
+          closeSSE();
+          if (sseRetriesRef.current < MAX_SSE_RETRIES) {
+            sseRetriesRef.current += 1;
+            retryTimeoutRef.current = setTimeout(connectSSE, SSE_RETRY_DELAY_MS);
+          } else {
+            startPolling(); // fallback after max retries
+          }
+        };
+      } catch {
+        startPolling();
+      }
+    }
+
+    void fetchLatestLedger();
+    connectSSE();
+
+    return () => {
+      closeSSE();
+      stopPolling();
+      if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Recompute accrued income from lastClaimedLedger on every ledger tick.
+
+  // Recompute accrued income on every ledger tick
   const propertiesWithIncome = useMemo(
     () =>
       properties.map((p) => ({

--- a/apps/api/src/__tests__/ledger.test.ts
+++ b/apps/api/src/__tests__/ledger.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+let mockSequence = 100;
+
+// mock must be registered before any dynamic import of the route
+mock.module('@stellar/stellar-sdk', () => ({
+  rpc: {
+    Server: class MockServer {
+      async getLatestLedger() {
+        return { sequence: mockSequence };
+      }
+    },
+  },
+}));
+
+const { ledgerRoutes } = (await import('../routes/ledger')) as {
+  ledgerRoutes: import('elysia').Elysia;
+};
+
+const { Elysia } = (await import('elysia')) as typeof import('elysia');
+
+function makeApp() {
+  return new Elysia().use(ledgerRoutes as unknown as Parameters<InstanceType<typeof Elysia>['use']>[0]);
+}
+
+type AppWithHandle = { handle: (req: Request) => Promise<Response> };
+
+async function readFirstEvent(body: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let accumulated = '';
+  for (let i = 0; i < 20; i++) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    accumulated += decoder.decode(value, { stream: true });
+    if (accumulated.includes('\n\n')) break;
+  }
+  reader.cancel();
+  return accumulated;
+}
+
+describe('GET /api/ledger/stream', () => {
+  beforeEach(() => { mockSequence = 100; });
+
+  test('returns 200 with correct SSE headers', async () => {
+    const app = makeApp();
+    const res = await (app as unknown as AppWithHandle).handle(
+      new Request('http://localhost/api/ledger/stream'),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    expect(res.headers.get('cache-control')).toContain('no-cache');
+    expect(res.headers.get('x-accel-buffering')).toBe('no');
+
+    await res.body?.cancel();
+  });
+
+  test('response body is a ReadableStream', async () => {
+    const app = makeApp();
+    const res = await (app as unknown as AppWithHandle).handle(
+      new Request('http://localhost/api/ledger/stream'),
+    );
+
+    expect(res.body).not.toBeNull();
+    expect(typeof res.body?.getReader).toBe('function');
+    await res.body?.cancel();
+  });
+
+  test('first chunk contains a valid JSON ledger event', async () => {
+    mockSequence = 777;
+
+    const app = makeApp();
+    const res = await (app as unknown as AppWithHandle).handle(
+      new Request('http://localhost/api/ledger/stream'),
+    );
+    expect(res.body).not.toBeNull();
+
+    const accumulated = await readFirstEvent(res.body!);
+    const dataLine = accumulated.split('\n').find((l) => l.startsWith('data:'));
+    expect(dataLine).toBeDefined();
+
+    const json = JSON.parse(dataLine!.replace(/^data:\s*/, '')) as {
+      sequence: number;
+      timestamp: string;
+    };
+
+    expect(typeof json.sequence).toBe('number');
+    expect(json.sequence).toBeGreaterThan(0);
+    expect(typeof json.timestamp).toBe('string');
+    expect(isNaN(Date.parse(json.timestamp))).toBe(false);
+  });
+
+  test('event sequence matches the mocked RPC value', async () => {
+    mockSequence = 42;
+
+    const app = makeApp();
+    const res = await (app as unknown as AppWithHandle).handle(
+      new Request('http://localhost/api/ledger/stream'),
+    );
+    expect(res.body).not.toBeNull();
+
+    const accumulated = await readFirstEvent(res.body!);
+    const dataLine = accumulated.split('\n').find((l) => l.startsWith('data:'));
+    const json = JSON.parse(dataLine!.replace(/^data:\s*/, '')) as { sequence: number };
+    expect(json.sequence).toBe(42);
+  });
+});
+
+describe('LedgerEvent type contract', () => {
+  test('LedgerEvent has required numeric sequence and ISO timestamp', () => {
+    const evt: { sequence: number; timestamp: string } = {
+      sequence: 12345,
+      timestamp: new Date().toISOString(),
+    };
+    expect(typeof evt.sequence).toBe('number');
+    expect(typeof evt.timestamp).toBe('string');
+    expect(isNaN(Date.parse(evt.timestamp))).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/ledger.test.ts
+++ b/apps/api/src/__tests__/ledger.test.ts
@@ -13,14 +13,14 @@ mock.module('@stellar/stellar-sdk', () => ({
   },
 }));
 
-const { ledgerRoutes } = (await import('../routes/ledger')) as {
-  ledgerRoutes: import('elysia').Elysia;
-};
+const { ledgerRoutes } = await import('../routes/ledger');
 
 const { Elysia } = (await import('elysia')) as typeof import('elysia');
 
 function makeApp() {
-  return new Elysia().use(ledgerRoutes as unknown as Parameters<InstanceType<typeof Elysia>['use']>[0]);
+  return new Elysia().use(
+    ledgerRoutes as unknown as Parameters<InstanceType<typeof Elysia>['use']>[0],
+  );
 }
 
 type AppWithHandle = { handle: (req: Request) => Promise<Response> };
@@ -40,7 +40,9 @@ async function readFirstEvent(body: ReadableStream<Uint8Array>): Promise<string>
 }
 
 describe('GET /api/ledger/stream', () => {
-  beforeEach(() => { mockSequence = 100; });
+  beforeEach(() => {
+    mockSequence = 100;
+  });
 
   test('returns 200 with correct SSE headers', async () => {
     const app = makeApp();

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { kycRoutes } from './routes/kyc';
 import { webhookRoutes } from './routes/webhooks';
 import { internalOperationsRoutes } from './routes/internalOperations';
 import { authRoutes } from './routes/auth';
+import { ledgerRoutes } from './routes/ledger';
 import { errorHandler } from './middleware/errorHandler';
 import { requestLogger } from './middleware';
 
@@ -24,6 +25,7 @@ const app = new Elysia()
   .use(userRoutes)
   .use(kycRoutes)
   .use(webhookRoutes)
-  .use(internalOperationsRoutes);
+  .use(internalOperationsRoutes)
+  .use(ledgerRoutes);
 
 export default app;

--- a/apps/api/src/routes/ledger.ts
+++ b/apps/api/src/routes/ledger.ts
@@ -11,7 +11,9 @@ export interface LedgerEvent {
 }
 
 class LedgerBroadcaster {
-  private server = new SorobanRpc.Server(SOROBAN_RPC_URL);
+  // Lazily constructed so that mock.module() replacements are in effect before
+  // the real SorobanRpc.Server constructor is ever called.
+  private server: InstanceType<typeof SorobanRpc.Server> | null = null;
   private listeners = new Set<(evt: LedgerEvent) => void>();
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastSequence = 0;
@@ -23,6 +25,19 @@ class LedgerBroadcaster {
       this.listeners.delete(cb);
       if (this.listeners.size === 0) this.stop();
     };
+  }
+
+  /** Call in beforeEach to prevent cross-test lastSequence contamination. */
+  _resetForTest() {
+    this.lastSequence = 0;
+    this.server = null;
+  }
+
+  private getServer(): InstanceType<typeof SorobanRpc.Server> {
+    if (!this.server) {
+      this.server = new SorobanRpc.Server(SOROBAN_RPC_URL);
+    }
+    return this.server;
   }
 
   private start() {
@@ -40,7 +55,7 @@ class LedgerBroadcaster {
 
   private async poll() {
     try {
-      const { sequence } = await this.server.getLatestLedger();
+      const { sequence } = await this.getServer().getLatestLedger();
       if (sequence === this.lastSequence) return;
       this.lastSequence = sequence;
       const event: LedgerEvent = { sequence, timestamp: new Date().toISOString() };

--- a/apps/api/src/routes/ledger.ts
+++ b/apps/api/src/routes/ledger.ts
@@ -1,0 +1,103 @@
+import { Elysia } from 'elysia';
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
+
+const SOROBAN_RPC_URL =
+  process.env.SOROBAN_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+
+const LEDGER_POLL_MS = Number(process.env.LEDGER_POLL_MS ?? 3_000);
+
+export interface LedgerEvent {
+  sequence: number;
+  timestamp: string;
+}
+
+class LedgerBroadcaster {
+  private server = new SorobanRpc.Server(SOROBAN_RPC_URL);
+  private listeners = new Set<(evt: LedgerEvent) => void>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastSequence = 0;
+
+  subscribe(cb: (evt: LedgerEvent) => void): () => void {
+    this.listeners.add(cb);
+    if (this.listeners.size === 1) this.start();
+    return () => {
+      this.listeners.delete(cb);
+      if (this.listeners.size === 0) this.stop();
+    };
+  }
+
+  private start() {
+    void this.poll();
+    this.timer = setInterval(() => void this.poll(), LEDGER_POLL_MS);
+  }
+
+  private stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.lastSequence = 0;
+  }
+
+  private async poll() {
+    try {
+      const { sequence } = await this.server.getLatestLedger();
+      if (sequence === this.lastSequence) return;
+      this.lastSequence = sequence;
+      const event: LedgerEvent = { sequence, timestamp: new Date().toISOString() };
+      for (const cb of this.listeners) cb(event);
+    } catch {
+      // ignore transient RPC errors
+    }
+  }
+}
+
+const broadcaster = new LedgerBroadcaster();
+
+// GET /api/ledger/stream — SSE stream, emits { sequence, timestamp } on each new ledger
+export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' })
+  .get('/stream', ({ set, request }) => {
+    set.headers['Content-Type'] = 'text/event-stream';
+    set.headers['Cache-Control'] = 'no-cache';
+    set.headers['X-Accel-Buffering'] = 'no';
+
+    const signal = (request as Request & { signal?: AbortSignal }).signal;
+
+    return new ReadableStream({
+      start(controller) {
+        let closed = false;
+
+        const close = () => {
+          if (closed) return;
+          closed = true;
+          unsubscribe();
+          try { controller.close(); } catch { /* already closed */ }
+        };
+
+        const unsubscribe = broadcaster.subscribe((evt: LedgerEvent) => {
+          if (closed) return;
+          try {
+            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(evt)}\n\n`));
+          } catch {
+            close();
+          }
+        });
+
+        // 25 s heartbeat keeps proxy connections alive
+        const heartbeatId = setInterval(() => {
+          if (closed) { clearInterval(heartbeatId); return; }
+          try {
+            controller.enqueue(new TextEncoder().encode(': heartbeat\n\n'));
+          } catch {
+            clearInterval(heartbeatId);
+            close();
+          }
+        }, 25_000);
+
+        signal?.addEventListener('abort', () => {
+          clearInterval(heartbeatId);
+          close();
+        });
+      },
+    });
+  });

--- a/apps/api/src/routes/ledger.ts
+++ b/apps/api/src/routes/ledger.ts
@@ -1,8 +1,7 @@
 import { Elysia } from 'elysia';
 import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
 
-const SOROBAN_RPC_URL =
-  process.env.SOROBAN_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const SOROBAN_RPC_URL = process.env.SOROBAN_RPC_URL ?? 'https://soroban-testnet.stellar.org';
 
 const LEDGER_POLL_MS = Number(process.env.LEDGER_POLL_MS ?? 3_000);
 
@@ -55,8 +54,9 @@ class LedgerBroadcaster {
 const broadcaster = new LedgerBroadcaster();
 
 // GET /api/ledger/stream — SSE stream, emits { sequence, timestamp } on each new ledger
-export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' })
-  .get('/stream', ({ set, request }) => {
+export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' }).get(
+  '/stream',
+  ({ set, request }) => {
     set.headers['Content-Type'] = 'text/event-stream';
     set.headers['Cache-Control'] = 'no-cache';
     set.headers['X-Accel-Buffering'] = 'no';
@@ -71,7 +71,11 @@ export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' })
           if (closed) return;
           closed = true;
           unsubscribe();
-          try { controller.close(); } catch { /* already closed */ }
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
         };
 
         const unsubscribe = broadcaster.subscribe((evt: LedgerEvent) => {
@@ -85,7 +89,10 @@ export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' })
 
         // 25 s heartbeat keeps proxy connections alive
         const heartbeatId = setInterval(() => {
-          if (closed) { clearInterval(heartbeatId); return; }
+          if (closed) {
+            clearInterval(heartbeatId);
+            return;
+          }
           try {
             controller.enqueue(new TextEncoder().encode(': heartbeat\n\n'));
           } catch {
@@ -100,4 +107,5 @@ export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' })
         });
       },
     });
-  });
+  },
+);

--- a/apps/webapp/src/app/dashboard/page.tsx
+++ b/apps/webapp/src/app/dashboard/page.tsx
@@ -63,17 +63,16 @@ export default function DashboardPage() {
   const { healthFactor, status: hfStatus } = useHealthFactor(borrows);
 
   // SSE ledger stream — falls back to 30 s polling on failure
-  const onLedgerUpdate = useCallback(() => { refetch(); }, [refetch]);
+  const onLedgerUpdate = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
-  const { connectionStatus } = useLiveUpdates(
-    async () => ({ ledger: true }),
-    {
-      endpoint: '/api/ledger/stream',
-      pollingInterval: 30_000,
-      onUpdate: onLedgerUpdate,
-      enabled: isConnected,
-    },
-  );
+  const { connectionStatus } = useLiveUpdates(async () => ({ ledger: true }), {
+    endpoint: "/api/ledger/stream",
+    pollingInterval: 30_000,
+    onUpdate: onLedgerUpdate,
+    enabled: isConnected,
+  });
 
   const copyAddress = () => {
     if (address) {
@@ -174,11 +173,11 @@ export default function DashboardPage() {
                 {/* Live-connection indicator */}
                 <div
                   className={`w-2 h-2 rounded-full shrink-0 ${
-                    connectionStatus === 'connected'
-                      ? 'bg-[#00ff88] shadow-[0_0_4px_#00ff88]'
-                      : connectionStatus === 'connecting'
-                        ? 'bg-amber-400 animate-pulse'
-                        : 'bg-neutral-600'
+                    connectionStatus === "connected"
+                      ? "bg-[#00ff88] shadow-[0_0_4px_#00ff88]"
+                      : connectionStatus === "connecting"
+                        ? "bg-amber-400 animate-pulse"
+                        : "bg-neutral-600"
                   }`}
                   title={`Ledger stream: ${connectionStatus}`}
                 />

--- a/apps/webapp/src/app/dashboard/page.tsx
+++ b/apps/webapp/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { motion } from "framer-motion";
 import {
   Wallet,
@@ -32,6 +32,7 @@ import { useWallet, useWalletConnectModal } from "@/components/auth/hooks";
 import { WalletProviderModal } from "@/components/auth/WalletProviderModal";
 import { usePortfolio } from "@/hooks/usePortfolio";
 import { useHealthFactor } from "@/hooks/useHealthFactor";
+import { useLiveUpdates } from "@/hooks/useLiveUpdates";
 import {
   AllocationChart,
   PropertyReportCard,
@@ -60,6 +61,19 @@ export default function DashboardPage() {
   const { properties, borrows, summary, isLoading, error, refetch } =
     usePortfolio(isConnected ? address : null);
   const { healthFactor, status: hfStatus } = useHealthFactor(borrows);
+
+  // SSE ledger stream — falls back to 30 s polling on failure
+  const onLedgerUpdate = useCallback(() => { refetch(); }, [refetch]);
+
+  const { connectionStatus } = useLiveUpdates(
+    async () => ({ ledger: true }),
+    {
+      endpoint: '/api/ledger/stream',
+      pollingInterval: 30_000,
+      onUpdate: onLedgerUpdate,
+      enabled: isConnected,
+    },
+  );
 
   const copyAddress = () => {
     if (address) {
@@ -157,6 +171,17 @@ export default function DashboardPage() {
                 </p>
               </div>
               <div className="flex items-center gap-2">
+                {/* Live-connection indicator */}
+                <div
+                  className={`w-2 h-2 rounded-full shrink-0 ${
+                    connectionStatus === 'connected'
+                      ? 'bg-[#00ff88] shadow-[0_0_4px_#00ff88]'
+                      : connectionStatus === 'connecting'
+                        ? 'bg-amber-400 animate-pulse'
+                        : 'bg-neutral-600'
+                  }`}
+                  title={`Ledger stream: ${connectionStatus}`}
+                />
                 <Button
                   variant="outline"
                   size="sm"

--- a/apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts
+++ b/apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
-import { getTimeSinceUpdate, type LiveUpdateOptions } from "@/hooks/useLiveUpdates";
+import {
+  getTimeSinceUpdate,
+  type LiveUpdateOptions,
+} from "@/hooks/useLiveUpdates";
 
 describe("useLiveUpdates - utility functions", () => {
   describe("getTimeSinceUpdate", () => {
@@ -115,7 +118,8 @@ describe("useLiveUpdates - SSE option shape", () => {
   it("maxReconnectAttempts defaults to 3 in SSE error path", () => {
     const DEFAULT_MAX_RECONNECT_ATTEMPTS = 3;
     const opts: LiveUpdateOptions<unknown> = {};
-    const effective = opts.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    const effective =
+      opts.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
     expect(effective).toBe(3);
   });
 

--- a/apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts
+++ b/apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
-import { getTimeSinceUpdate } from "@/hooks/useLiveUpdates";
+import { getTimeSinceUpdate, type LiveUpdateOptions } from "@/hooks/useLiveUpdates";
 
 describe("useLiveUpdates - utility functions", () => {
   describe("getTimeSinceUpdate", () => {
@@ -75,5 +75,54 @@ describe("useLiveUpdates - connection status types", () => {
     validStatuses.forEach((status) => {
       expect(["connected", "connecting", "disconnected"]).toContain(status);
     });
+  });
+});
+
+describe("useLiveUpdates - SSE option shape", () => {
+  it("LiveUpdateOptions accepts an SSE endpoint", () => {
+    const opts: LiveUpdateOptions<{ sequence: number }> = {
+      endpoint: "/api/ledger/stream",
+      pollingInterval: 30_000,
+      enabled: true,
+      maxReconnectAttempts: 3,
+      reconnectDelay: 2_000,
+    };
+    expect(opts.endpoint).toBe("/api/ledger/stream");
+    expect(opts.pollingInterval).toBe(30_000);
+    expect(opts.maxReconnectAttempts).toBe(3);
+    expect(opts.reconnectDelay).toBe(2_000);
+  });
+
+  it("LiveUpdateOptions works without an endpoint (polling-only mode)", () => {
+    const opts: LiveUpdateOptions<number> = {
+      pollingInterval: 5_000,
+      enabled: true,
+    };
+    expect(opts.endpoint).toBeUndefined();
+    expect(opts.pollingInterval).toBe(5_000);
+  });
+
+  it("onUpdate callback is invoked with the received data", async () => {
+    const received: unknown[] = [];
+    const opts: LiveUpdateOptions<{ sequence: number }> = {
+      onUpdate: (data) => received.push(data),
+    };
+    opts.onUpdate?.({ sequence: 999 });
+    expect(received).toHaveLength(1);
+    expect((received[0] as { sequence: number }).sequence).toBe(999);
+  });
+
+  it("maxReconnectAttempts defaults to 3 in SSE error path", () => {
+    const DEFAULT_MAX_RECONNECT_ATTEMPTS = 3;
+    const opts: LiveUpdateOptions<unknown> = {};
+    const effective = opts.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    expect(effective).toBe(3);
+  });
+
+  it("reconnectDelay defaults to 2000 ms", () => {
+    const DEFAULT_RECONNECT_DELAY = 2000;
+    const opts: LiveUpdateOptions<unknown> = {};
+    const effective = opts.reconnectDelay ?? DEFAULT_RECONNECT_DELAY;
+    expect(effective).toBe(2_000);
   });
 });


### PR DESCRIPTION

## Summary

- Close #925

#### 🆕 `apps/api/src/routes/ledger.ts`
- `GET /api/ledger/stream` endpoint emitting `text/event-stream` SSE
- `LedgerBroadcaster` singleton: polls Soroban RPC every 3 s (configurable via `LEDGER_POLL_MS`), fans out only when the ledger sequence actually advances (deduplicates events)
- Lazy start / eager stop — loop only runs while at least one client is connected
- 25 s heartbeat comments keep proxy connections alive
- Wires into `app.ts` (available in test harness) — no separate `index.ts` change needed

#### ✏️ `apps/akkuea-land/src/app/dashboard/page.tsx` (lines 333–350)
- Replaced `setInterval` with an `EventSource` SSE connection to `/api/ledger/stream`
- **Fallback**: after 3 failed SSE reconnect attempts, reverts to 5 s `setInterval` polling (original behaviour)
- Uses `useRef` to safely track the `EventSource`, interval, and retry timeout across renders

#### ✏️ `apps/webapp/src/app/dashboard/page.tsx`
- Wired in the existing `useLiveUpdates` hook against `/api/ledger/stream`
- Each SSE ledger event calls `refetch()` on the portfolio data
- Live connection status dot (green 🟢 / amber pulsing / grey) shown in the header toolbar

#### 🆕 `apps/api/src/__tests__/ledger.test.ts` — 5 tests
- SSE headers, ReadableStream body, JSON event shape, sequence value, `LedgerEvent` type contract

#### ✏️ `apps/webapp/src/hooks/__tests__/useLiveUpdates.test.ts` — +5 tests  
- `LiveUpdateOptions` with/without endpoint, `onUpdate` callback, reconnect constants