### PR TITLE
Deploy game contracts to Stellar testnet

### DIFF
--- a/apps/shared/src/contracts/game-contracts.testnet.json
+++ b/apps/shared/src/contracts/game-contracts.testnet.json
@@ -1,0 +1,34 @@
+{
+  "network": "testnet",
+  "networkPassphrase": "Test SDF Network ; September 2015",
+  "rpcUrl": "https://soroban-testnet.stellar.org",
+  "description": "Deployed Soroban contract IDs for the Akkuea Land game contracts on Stellar testnet. Updated by the deploy pipeline (see docs/contracts/deployment.md). Each contract ID starts with 'C'.",
+  "deployedBy": "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",
+  "deployedOn": "2026-06-24",
+  "contracts": {
+    "GAME_PROPERTY_NFT": {
+      "contractId": "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",
+      "deployTx": "2b982bdbc7e29c7f334d35d57f9566d124fd9b30722f551fff23df310d298fc5",
+      "initializeTx": "889d9a0f7da7c543cc6abeb913506eb55b6b31f67177c4d3f2fc18670c81bbb2",
+      "wasmHash": "b944946b65564da7695fdb0bf10d437923c6c243aff8a042b5c0b835abddbc6b"
+    },
+    "GAME_LAND_TOKEN": {
+      "contractId": "CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K",
+      "deployTx": "3a7619ea0d637ac60f2d6c43dfac10cc7810c663b3ea65b84f54d7b1f07cbdf7",
+      "initializeTx": "1e3d8961cce31d0d5016705ef1f8aecf78761ef1203136cb41ccc6c08729be53",
+      "wasmHash": "d3490f518f2fb7361be646f80f67e3d8cbecffef5bc3d43e0c5bbff8fb5537a3"
+    },
+    "GAME_MARKETPLACE": {
+      "contractId": "CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3",
+      "deployTx": "a84eabafffc0bf75bb75676c8add0616ff970cda82c75f2ebf439ca14528fbbb",
+      "initializeTx": "4fbaa0df4a51c266fb3258490b202cd962209b04c495264d85096da5ef623560",
+      "wasmHash": "af0da63d3de31be65c8a6e53e5e9948991e545f9e2584eb7c37095341a819fb0"
+    },
+    "GAME_ENGINE": {
+      "contractId": "CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH",
+      "deployTx": "fc8bcb20360d909ea4fbd7187edadadf3ed25f3aa29810e5b806917318d0cafa",
+      "initializeTx": "33641f100f7c6d23452a417b2d4d16a111554398c69aa5cab969f224a98a7714",
+      "wasmHash": "dc0fc784f2d78a1de82cc5b1bcb7eb202df1f01d91ea5b6ada0ee4af39edb3f6"
+    }
+  }
+}

--- a/docs/contracts/deployment.md
+++ b/docs/contracts/deployment.md
@@ -349,6 +349,95 @@ stellar transaction --id $TRANSACTION_ID --network testnet
 
 This deployment process ensures your smart contracts are properly deployed and integrated with the entire Real Estate DeFi Platform.
 
+## Game Contracts Testnet Deployment Record (2026-06-24)
+
+All four Akkuea Land game contracts were built with `stellar contract build` (target `wasm32v1-none`) and deployed to Stellar testnet. Deployment order: PropertyNFT and LandToken first (no inter-dependencies), then GameMarketplace and GameEngine (both depend on the first two).
+
+- **Network**: testnet (`Test SDF Network ; September 2015`)
+- **Deployer / admin account**: `GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M`
+- **Deployed on**: 2026-06-24
+- **Source of truth**: [`apps/shared/src/contracts/game-contracts.testnet.json`](../../apps/shared/src/contracts/game-contracts.testnet.json)
+
+| Contract             | Contract ID                                                  | Deploy tx                                                          | Init tx                                                            |
+| -------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `GAME_PROPERTY_NFT`  | `CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE`  | `2b982bdbc7e29c7f334d35d57f9566d124fd9b30722f551fff23df310d298fc5` | `889d9a0f7da7c543cc6abeb913506eb55b6b31f67177c4d3f2fc18670c81bbb2` |
+| `GAME_LAND_TOKEN`    | `CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K`  | `3a7619ea0d637ac60f2d6c43dfac10cc7810c663b3ea65b84f54d7b1f07cbdf7` | `1e3d8961cce31d0d5016705ef1f8aecf78761ef1203136cb41ccc6c08729be53` |
+| `GAME_MARKETPLACE`   | `CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3`  | `a84eabafffc0bf75bb75676c8add0616ff970cda82c75f2ebf439ca14528fbbb` | `4fbaa0df4a51c266fb3258490b202cd962209b04c495264d85096da5ef623560` |
+| `GAME_ENGINE`        | `CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH`  | `fc8bcb20360d909ea4fbd7187edadadf3ed25f3aa29810e5b806917318d0cafa` | `33641f100f7c6d23452a417b2d4d16a111554398c69aa5cab969f224a98a7714` |
+
+### Initialization arguments
+
+```bash
+# 1. PropertyNFT: initialize(treasury, game_engine)
+stellar contract invoke --id CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE \
+  --source akkuea-game-deployer --network testnet \
+  -- initialize \
+  --treasury GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M \
+  --game_engine CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH
+
+# 2. LandToken: initialize(treasury, engine, is_testnet)
+stellar contract invoke --id CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K \
+  --source akkuea-game-deployer --network testnet \
+  -- initialize \
+  --treasury GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M \
+  --engine CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH \
+  --is_testnet true
+
+# 3. GameMarketplace: initialize(nft_contract, land_token)
+stellar contract invoke --id CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3 \
+  --source akkuea-game-deployer --network testnet \
+  -- initialize \
+  --nft_contract CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE \
+  --land_token CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K
+
+# 4. GameEngine: initialize(nft_contract, token_contract, treasury)
+stellar contract invoke --id CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH \
+  --source akkuea-game-deployer --network testnet \
+  -- initialize \
+  --nft_contract CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE \
+  --token_contract CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K \
+  --treasury GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M
+```
+
+### Verification
+
+Each contract ID was verified before being committed by invoking a read-only function:
+
+```bash
+# PropertyNFT — get_property(0) returns tile 0 owned by treasury
+stellar contract invoke --id CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE \
+  --source akkuea-game-deployer --network testnet --send=no \
+  -- get_property --property_id 0
+# => {"approved":null,"id":0,"last_claimed_ledger":3265536,"level":0,"owner":"GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M","x":0,"y":0}
+
+# LandToken — name() returns token name
+stellar contract invoke --id CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K \
+  --source akkuea-game-deployer --network testnet --send=no \
+  -- name
+# => "Akkuea Land Token"
+
+# GameMarketplace — get_all_listings(0,10) returns empty list
+stellar contract invoke --id CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3 \
+  --source akkuea-game-deployer --network testnet --send=no \
+  -- get_all_listings --offset 0 --limit 10
+# => []
+
+# GameEngine — get_accrued_income(0) returns 0 (no epochs elapsed)
+stellar contract invoke --id CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH \
+  --source akkuea-game-deployer --network testnet --send=no \
+  -- get_accrued_income --property_id 0
+# => "0"
+```
+
+Explorer links:
+
+- GAME_PROPERTY_NFT: <https://stellar.expert/explorer/testnet/contract/CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE>
+- GAME_LAND_TOKEN: <https://stellar.expert/explorer/testnet/contract/CBQBXOWI3YB5SFICLVPYHK2EL3SY3XIZUZA6QZIGGXDKMVXAT74IOR3K>
+- GAME_MARKETPLACE: <https://stellar.expert/explorer/testnet/contract/CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3>
+- GAME_ENGINE: <https://stellar.expert/explorer/testnet/contract/CBTPPGX6LT2EPKR7JD7LLUB23E6HI5EFQRXKV3VQNZ6QWJTJ3EZ76RSH>
+
+---
+
 ## Testnet Deployment Record
 
 Both instances were deployed from the same `rwa_defi_contract.wasm` (built with


### PR DESCRIPTION
## Summary

Deploys all four Akkuea Land game contracts to Stellar testnet and records their verified contract IDs and transaction hashes.

## Type of Change

- [x] Docs / config only

## What Changed and Why

Built all four game contract WASMs using `stellar contract build` and deployed them to Stellar testnet in the required dependency order: PropertyNFT and LandToken first (no inter-dependencies), then GameMarketplace and GameEngine (both depend on the first two). Each contract was initialized with the correct constructor arguments and verified via a read-only call before its address was recorded.

**New file:** `apps/shared/src/contracts/game-contracts.testnet.json` — deployment artifact with all four contract IDs, deploy tx hashes, init tx hashes, and WASM hashes.

**Updated:** `docs/contracts/deployment.md` — new deployment log entry with full initialization commands and verification output so the deployment can be reproduced.

## How to Test

1. Install Stellar CLI and run any of the read-only verification commands from the new deployment log entry in `docs/contracts/deployment.md`.
2. Confirm each contract ID begins with `C` and returns a non-error response.

```bash
# Quick spot-check: PropertyNFT tile 0 owned by deployer/treasury
stellar contract invoke --id CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE \
  --source <any-testnet-key> --network testnet --send=no \
  -- get_property --property_id 0
# => {"approved":null,"id":0,...,"owner":"GCPRLG7M...","x":0,"y":0}
```

## Checklist

- [x] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation
- [x] No `.env` files or secrets are committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Closes #847