### PR TITLE
#916 [ci] Add test coverage threshold to API CI workflow FIXED

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -75,14 +75,14 @@ jobs:
         cd apps/api
         bun run db:migrate
 
-    - name: Run integration tests
+    - name: Run tests
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/akkuea_test
         TEST_DATABASE_URL: postgresql://test:test@localhost:5432/akkuea_test
       run: |
         cd apps/api
         # Run tests sequentially to avoid database race conditions in the shared service container
-        bun test --max-concurrency=1
+        bun test --coverage --coverage-threshold=60 --max-concurrency=1
 
   security-audit:
     name: Security Audit


### PR DESCRIPTION

Summary

Enforces 60% test coverage in API CI to match the webapp CI.

Prevents coverage from silently dropping without failing CI.


Type of Change

✅ Bug fix

✅ Docs / CI configuration update

❌ New feature

❌ Refactor / cleanup

❌ Breaking change


What Changed

File: .github/workflows/api-ci.yml

CI Test Step Update

Renamed:

Run integration tests → Run tests



Test Command Update

Before:

bun test --max-concurrency=1

After:

bun test --coverage --coverage-threshold=60 --max-concurrency=1


Why This Change Was Made

Webapp CI already enforces a 60% coverage threshold.

API CI did not enforce coverage.

Coverage could drop to 0% without causing CI failures.

This change brings API and webapp CI behavior into parity.


Source Code Impact

No application source code changes.

CI workflow configuration only.


How to Test

1. Verify Coverage Enforcement

cd apps/api
bun test --coverage --coverage-threshold=60 --max-concurrency=1

Expected:

183 passing tests

63 skipped tests

0 failures

64.46% line coverage

Passes 60% threshold


2. Verify Workflow Configuration

Check that .github/workflows/api-ci.yml contains:

--coverage --coverage-threshold=60

3. Run Standard API Checks

bun run type-check
bun run lint
bun run build

Expected: All pass successfully.

Checklist

✅ All CI workflows pass

⬜ Tests added/updated (not applicable)

⬜ Documentation updated (not required)

✅ No secrets or .env files committed

✅ Conventional Commit format followed


Suggested Commit Message

ci(api): enforce 60% test coverage threshold in CI

Related Issues

Closes API CI coverage enforcement gap.

Establishes coverage threshold parity with the webapp CI.


CLOSE #916
