### PR TITLE
Remove deprecated Skeleton re-export from Loader.tsx

### DIFF
--- a/apps/webapp/src/components/ui/Loader.tsx
+++ b/apps/webapp/src/components/ui/Loader.tsx
@@ -99,8 +99,3 @@ export function AnimatedSkeleton({ className }: AnimatedSkeletonProps) {
     />
   );
 }
-
-/**
- * @deprecated Use AnimatedSkeleton instead, or import Skeleton from './Skeleton'
- */
-export const Skeleton = AnimatedSkeleton;


### PR DESCRIPTION
## Summary

- Removes the `@deprecated` `Skeleton` re-export alias from `apps/webapp/src/components/ui/Loader.tsx` that was pointing to `AnimatedSkeleton`
- No consumer in `apps/webapp/src/` imported `Skeleton` from `Loader.tsx`; all existing `Skeleton` usage imports from `@/components/ui/Skeleton` (the dedicated `Skeleton.tsx` component)
- Eliminates the name conflict in `components/ui/index.ts` where `export * from "./Loader"` and the explicit `Skeleton` export from `"./Skeleton"` both resolved the same name

## Test plan

- [ ] `cd apps/webapp && bun run type-check` passes
- [ ] `cd apps/webapp && bun test` passes
- [ ] No remaining imports of `Skeleton` from `Loader.tsx` in `apps/webapp/src/`

Closes #903