### PR TITLE
fix: No as any in Form.tsx, KYCForm.tsx, or FormInput.tsx

### DIFF
--- a/apps/webapp/src/components/forms/Form.tsx
+++ b/apps/webapp/src/components/forms/Form.tsx
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { cn } from "@/lib/utils";
 
-export type FormRenderProps<TSchema extends z.ZodSchema> = UseFormReturn<
+export type FormRenderProps<TSchema extends z.ZodTypeAny> = UseFormReturn<
   z.infer<TSchema>
 > & {
   formError: string | null;
@@ -16,7 +16,7 @@ export type FormRenderProps<TSchema extends z.ZodSchema> = UseFormReturn<
   setFormSuccess: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
-export interface FormProps<TSchema extends z.ZodSchema> {
+export interface FormProps<TSchema extends z.ZodTypeAny> {
   schema: TSchema;
   defaultValues?: DefaultValues<z.infer<TSchema>>;
   onSubmit: (values: z.infer<TSchema>) => void | Promise<void>;
@@ -29,7 +29,7 @@ export interface FormProps<TSchema extends z.ZodSchema> {
   showFeedback?: boolean;
 }
 
-export function Form<TSchema extends z.ZodSchema>({
+export function Form<TSchema extends z.ZodTypeAny>({
   schema,
   defaultValues,
   onSubmit,
@@ -40,8 +40,7 @@ export function Form<TSchema extends z.ZodSchema>({
   showFeedback = true,
 }: FormProps<TSchema>) {
   const methods = useForm<z.infer<TSchema>>({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolver: zodResolver(schema as any),
+    resolver: zodResolver(schema),
     defaultValues,
     mode: "onBlur",
     reValidateMode: "onBlur",

--- a/apps/webapp/src/components/forms/FormInput.tsx
+++ b/apps/webapp/src/components/forms/FormInput.tsx
@@ -2,25 +2,35 @@
 
 import React from "react";
 import type {
+  FieldError,
+  FieldErrors,
   FieldValues,
   Path,
   RegisterOptions,
-  FieldErrors,
 } from "react-hook-form";
 import { useFormContext } from "react-hook-form";
 import { Input } from "@/components/ui";
+
+interface NestedErrorMap {
+  [key: string]: FieldError | NestedErrorMap | undefined;
+}
+
+type NestedErrorNode = FieldError | NestedErrorMap;
 
 function getErrorMessage<TFieldValues extends FieldValues>(
   errors: FieldErrors<TFieldValues>,
   name: Path<TFieldValues>,
 ) {
   const parts = String(name).split(".");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let current: any = errors;
+  let current: NestedErrorNode | undefined = errors as NestedErrorNode;
   for (const part of parts) {
-    current = current?.[part];
+    if (!current || "message" in current) {
+      return undefined;
+    }
+
+    current = (current as NestedErrorMap)[part];
   }
-  const msg = current?.message;
+  const msg = current && "message" in current ? current.message : undefined;
   return typeof msg === "string" ? msg : undefined;
 }
 

--- a/apps/webapp/src/components/forms/FormSelect.tsx
+++ b/apps/webapp/src/components/forms/FormSelect.tsx
@@ -1,21 +1,30 @@
 "use client";
 
 import React from "react";
-import type { FieldErrors, FieldValues, Path } from "react-hook-form";
+import type { FieldError, FieldErrors, FieldValues, Path } from "react-hook-form";
 import { useFormContext } from "react-hook-form";
 import { cn } from "@/lib/utils";
+
+interface NestedErrorMap {
+  [key: string]: FieldError | NestedErrorMap | undefined;
+}
+
+type NestedErrorNode = FieldError | NestedErrorMap;
 
 function getErrorMessage<TFieldValues extends FieldValues>(
   errors: FieldErrors<TFieldValues>,
   name: Path<TFieldValues>,
 ) {
   const parts = String(name).split(".");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let current: any = errors;
+  let current: NestedErrorNode | undefined = errors as NestedErrorNode;
   for (const part of parts) {
-    current = current?.[part];
+    if (!current || "message" in current) {
+      return undefined;
+    }
+
+    current = (current as NestedErrorMap)[part];
   }
-  const msg = current?.message;
+  const msg = current && "message" in current ? current.message : undefined;
   return typeof msg === "string" ? msg : undefined;
 }
 

--- a/apps/webapp/src/components/kyc/KYCForm.tsx
+++ b/apps/webapp/src/components/kyc/KYCForm.tsx
@@ -29,8 +29,7 @@ export default function KYCForm() {
   const [isSubmitted, setIsSubmitted] = useState(false);
 
   const methods = useForm<KycFormData>({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolver: zodResolver(kycSchema as any),
+    resolver: zodResolver(kycSchema),
     mode: "onBlur",
   });
 


### PR DESCRIPTION
Closes #912 
### [typescript] Fix as any in zodResolver calls in Form components

ISSUE-032 — Fix as any in zodResolver calls in Form components

Labels: frontend, good first issue
Difficulty: Medium

Context
Three form-related files use unnecessary any casts:

apps/webapp/src/components/forms/Form.tsx line 44: zodResolver(schema as any)
apps/webapp/src/components/kyc/KYCForm.tsx line 22: zodResolver(kycSchema as any)
apps/webapp/src/components/forms/FormInput.tsx line 19: let current: any = errors;

Steps
For Form.tsx and KYCForm.tsx — make the component generic:

// Before
```function Form({ schema }: { schema: ZodSchema }) {
  const form = useForm({ resolver: zodResolver(schema as any) });
}
```
// After
```function Form<T extends FieldValues>({ schema }: { schema: ZodType<T> }) {
  const form = useForm<T>({ resolver: zodResolver(schema) });
}
```

For FormInput.tsx line 19 — use a typed recursive helper instead of any:
// Before
`let current: any = errors;`

// After
`type NestedErrors = { [key: string]: NestedErrors | FieldError | undefined };`
`let current: NestedErrors = errors as NestedErrors;`
`Run: cd apps/webapp && bun run type-check`

Acceptance Criteria
 ✅ No as any in Form.tsx, KYCForm.tsx, or FormInput.tsx
 ✅ cd apps/webapp && bun run type-check passes
 ✅ cd apps/webapp && bun test passes
 ✅ Forms still work correctly