### PR TITLE
fix(land): replace array index with stable stepName key in onboarding…

### DIFF
--- a/apps/akkuea-land/src/app/onboarding/page.tsx
+++ b/apps/akkuea-land/src/app/onboarding/page.tsx
@@ -76,7 +76,7 @@ function StepDots({ current, steps }: { current: Step; steps: Step[] }) {
     <div className="flex gap-2">
       {steps.map((stepName, i) => (
         <div
-          key={i}
+          key={stepName}
           className={[
             "h-1.5 rounded-full transition-all duration-300",
             i <= idx ? "w-6 bg-indigo-500" : "w-1.5 bg-slate-800",


### PR DESCRIPTION
closes #899 

**Title:** `fix(land): resolve React key warning by replacing array index key in onboarding progress dots`

**Description:**
This PR addresses **ISSUE-035** regarding missing or unstable `key` props during list renders in React components.

#### Changes
- Replaced the array index key (`key={i}`) in the onboarding page (`apps/akkuea-land/src/app/onboarding/page.tsx`) with the stable, unique `stepName` string (`key={stepName}`).
- Verified that the remaining three listed files (`PropertyDetail.tsx`, `Stepper.tsx`, and `CityMap.tsx`) already correctly use stable identifiers (`doc.id`, `step.id`, and `prop.id`, respectively) for keys in their `.map()` rendering.

#### Testing
- Ran tests via `bun test` in `apps/webapp` (119/119 passing)
- Ran tests via `bun test` in `apps/akkuea-land` (5/5 passing)