### PR TITLE
fix: add descriptive alt text to marketplace property card images (fi…

### DIFF
--- a/apps/webapp/src/app/marketplace/page.tsx
+++ b/apps/webapp/src/app/marketplace/page.tsx
@@ -120,7 +120,7 @@ function PropertyCard({
         <div className="relative h-48 overflow-hidden">
           <Image
             src={getPropertyImage(property)}
-            alt={property.name}
+            alt={`${property.name} - ${property.location.city}, ${property.location.country}`}
             fill
             sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
             className="object-cover transition-transform duration-500 group-hover:scale-105"

--- a/apps/webapp/src/components/marketplace/InvestModal.tsx
+++ b/apps/webapp/src/components/marketplace/InvestModal.tsx
@@ -151,7 +151,7 @@ export function InvestModal({
           <div className="flex gap-4 rounded-lg border border-[#262626] bg-[#1a1a1a] p-4">
             <Image
               src={getPropertyImage(property)}
-              alt={property.name}
+              alt={`${property.name} - ${property.location.city}, ${property.location.country}`}
               width={80}
               height={80}
               className="h-20 w-20 rounded-lg object-cover"


### PR DESCRIPTION
# fix: add descriptive alt text to marketplace property card images (fixes #896)

## Summary
Adds descriptive `alt` attributes containing the property name and location to the property card images in the marketplace pages.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why
- Updated the `<Image>` component in [page.tsx](file:///apps/webapp/src/app/marketplace/page.tsx) to include `alt={`${property.name} - ${property.location.city}, ${property.location.country}`}` instead of a simple `alt={property.name}`.
- Updated the `<Image>` component in [InvestModal.tsx](file:///apps/webapp/src/components/marketplace/InvestModal.tsx) to similarly include the detailed `alt` text.
- This ensures screen readers get descriptive context of the properties being viewed in the marketplace, resolving WCAG 2.1 AA accessibility guidelines.

## How to Test
1. Navigate to the `/marketplace` page.
2. Inspect the property image cards using dev tools and verify they have descriptive alt attributes containing the property's name, city, and country.
3. Click "Invest Now" on a property to open the investment modal.
4. Verify the property thumbnail image inside the modal also has the same descriptive alt text format.

## Checklist
- [x] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation
- [x] No `.env` files or secrets are committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #896