### PR TITLE
fix: distinguish account-not-found from network error in stellar.ts

### DIFF
--- a/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
+++ b/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
@@ -5,7 +5,33 @@ import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
 import { useAuthenticationStore } from "../store/data/slices/authentication.slice";
 import { initializeWalletKit, getWalletKit } from "../constant/walletKit";
 import { isSignableWalletProvider, walletRegistry } from "@/services/wallet";
-import { fetchBalance } from "@/lib/stellar";
+import { fetchBalance, type BalanceResult } from "@/lib/stellar";
+
+/**
+ * Helper to update balance state from a BalanceResult
+ */
+function applyBalanceResult(
+  result: BalanceResult,
+  store: ReturnType<typeof useAuthenticationStore>,
+) {
+  switch (result.status) {
+    case "ok":
+      store.setBalance(result.balance);
+      store.setBalanceStatus("ok");
+      store.setBalanceError(null);
+      break;
+    case "not_found":
+      store.setBalance(null);
+      store.setBalanceStatus("not_found");
+      store.setBalanceError(null);
+      break;
+    case "error":
+      store.setBalance(null);
+      store.setBalanceStatus("error");
+      store.setBalanceError(result.message);
+      break;
+  }
+}
 
 export const useWallet = () => {
   const store = useAuthenticationStore();
@@ -48,8 +74,8 @@ export const useWallet = () => {
             store.setAddress(address);
             store.setIsConnected(true);
 
-            const balance = await fetchBalance(address, store.network);
-            store.setBalance(balance);
+            const result = await fetchBalance(address, store.network);
+            applyBalanceResult(result, store);
           } catch (error) {
             console.error("Error connecting wallet:", error);
             store.reset();
@@ -83,8 +109,8 @@ export const useWallet = () => {
         store.setSelectedWalletId(providerId);
         store.setIsConnected(true);
 
-        const balance = await fetchBalance(address, store.network);
-        store.setBalance(balance);
+        const result = await fetchBalance(address, store.network);
+        applyBalanceResult(result, store);
       } catch (error) {
         console.error("Error connecting wallet:", error);
         store.reset();
@@ -113,8 +139,8 @@ export const useWallet = () => {
 
   const refreshBalance = useCallback(async () => {
     if (!store.address) return;
-    const balance = await fetchBalance(store.address, store.network);
-    store.setBalance(balance);
+    const result = await fetchBalance(store.address, store.network);
+    applyBalanceResult(result, store);
   }, [store]);
 
   const signTransaction = useCallback(
@@ -133,6 +159,8 @@ export const useWallet = () => {
   return {
     address: store.address,
     balance: store.balance,
+    balanceStatus: store.balanceStatus,
+    balanceError: store.balanceError,
     isConnected: store.isConnected,
     isConnecting: store.isConnecting,
     network: store.network,

--- a/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
+++ b/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
@@ -6,14 +6,12 @@ import { useAuthenticationStore } from "../store/data/slices/authentication.slic
 import { initializeWalletKit, getWalletKit } from "../constant/walletKit";
 import { isSignableWalletProvider, walletRegistry } from "@/services/wallet";
 import { fetchBalance, type BalanceResult } from "@/lib/stellar";
+import type { AuthenticationStore } from "../store/data/@types/authentication.entity";
 
 /**
  * Helper to update balance state from a BalanceResult
  */
-function applyBalanceResult(
-  result: BalanceResult,
-  store: ReturnType<typeof useAuthenticationStore>,
-) {
+function applyBalanceResult(result: BalanceResult, store: AuthenticationStore) {
   switch (result.status) {
     case "ok":
       store.setBalance(result.balance);

--- a/apps/webapp/src/components/auth/store/data/@types/authentication.entity.ts
+++ b/apps/webapp/src/components/auth/store/data/@types/authentication.entity.ts
@@ -1,6 +1,10 @@
+export type BalanceStatus = "ok" | "not_found" | "error" | null;
+
 export interface WalletState {
   address: string | null;
   balance: string | null;
+  balanceStatus: BalanceStatus;
+  balanceError: string | null;
   isConnected: boolean;
   isConnecting: boolean;
   selectedWalletId: string | null;
@@ -10,6 +14,8 @@ export interface WalletState {
 export interface WalletActions {
   setAddress: (address: string | null) => void;
   setBalance: (balance: string | null) => void;
+  setBalanceStatus: (status: BalanceStatus) => void;
+  setBalanceError: (error: string | null) => void;
   setIsConnected: (isConnected: boolean) => void;
   setIsConnecting: (isConnecting: boolean) => void;
   setSelectedWalletId: (walletId: string | null) => void;

--- a/apps/webapp/src/components/auth/store/data/slices/authentication.slice.ts
+++ b/apps/webapp/src/components/auth/store/data/slices/authentication.slice.ts
@@ -5,6 +5,8 @@ import { AuthenticationStore } from "../@types/authentication.entity";
 const initialState = {
   address: null,
   balance: null,
+  balanceStatus: null,
+  balanceError: null,
   isConnected: false,
   isConnecting: false,
   selectedWalletId: null,
@@ -17,6 +19,8 @@ export const useAuthenticationStore = create<AuthenticationStore>()(
       ...initialState,
       setAddress: (address) => set({ address }),
       setBalance: (balance) => set({ balance }),
+      setBalanceStatus: (balanceStatus) => set({ balanceStatus }),
+      setBalanceError: (balanceError) => set({ balanceError }),
       setIsConnected: (isConnected) => set({ isConnected }),
       setIsConnecting: (isConnecting) => set({ isConnecting }),
       setSelectedWalletId: (walletId) => set({ selectedWalletId: walletId }),
@@ -25,18 +29,34 @@ export const useAuthenticationStore = create<AuthenticationStore>()(
     }),
     {
       name: "akkuea-wallet-storage",
-      version: 1,
-      migrate: (persisted) => {
+      version: 2,
+      migrate: (persisted, version) => {
         const state = persisted as {
           address?: string | null;
           balance?: string | null;
+          balanceStatus?: "ok" | "not_found" | "error" | null;
+          balanceError?: string | null;
           isConnected?: boolean;
           selectedWalletId?: string | null;
           network?: "testnet" | "mainnet";
         };
+        // Migration from version 1: add balanceStatus and balanceError
+        if (version < 2) {
+          return {
+            address: state.address ?? null,
+            balance: state.balance ?? null,
+            balanceStatus: state.balance ? "ok" : null,
+            balanceError: null,
+            isConnected: state.isConnected ?? false,
+            selectedWalletId: state.selectedWalletId ?? null,
+            network: state.network ?? "testnet",
+          };
+        }
         return {
           address: state.address ?? null,
           balance: state.balance ?? null,
+          balanceStatus: state.balanceStatus ?? null,
+          balanceError: state.balanceError ?? null,
           isConnected: state.isConnected ?? false,
           selectedWalletId: state.selectedWalletId ?? null,
           network: state.network ?? "testnet",
@@ -46,6 +66,8 @@ export const useAuthenticationStore = create<AuthenticationStore>()(
       partialize: (state) => ({
         address: state.address,
         balance: state.balance,
+        balanceStatus: state.balanceStatus,
+        balanceError: state.balanceError,
         isConnected: state.isConnected,
         selectedWalletId: state.selectedWalletId,
         network: state.network,

--- a/apps/webapp/src/lib/__tests__/stellar.test.ts
+++ b/apps/webapp/src/lib/__tests__/stellar.test.ts
@@ -8,7 +8,7 @@ function makeServer(
 }
 
 describe("fetchBalance", () => {
-  it("returns the native XLM balance for a funded account", async () => {
+  it("returns status 'ok' with the native XLM balance for a funded account", async () => {
     const server = makeServer(
       Promise.resolve({
         balances: [
@@ -18,24 +18,24 @@ describe("fetchBalance", () => {
       }),
     );
     const result = await fetchBalance("GABC1234", "testnet", server);
-    expect(result).toBe("100.5000000");
+    expect(result).toEqual({ status: "ok", balance: "100.5000000" });
   });
 
-  it("returns '0' for an account not yet on-chain (404)", async () => {
+  it("returns status 'not_found' for an account not yet on-chain (404)", async () => {
     const notFoundError = Object.assign(new Error("Not Found"), {
       response: { status: 404 },
     });
     const server = makeServer(Promise.reject(notFoundError));
     const result = await fetchBalance("GNOTFOUND", "testnet", server);
-    expect(result).toBe("0");
+    expect(result).toEqual({ status: "not_found" });
   });
 
-  it("returns '0' and emits a warning on a network error", async () => {
+  it("returns status 'error' with message on a network error", async () => {
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     const networkError = new Error("Network timeout");
     const server = makeServer(Promise.reject(networkError));
     const result = await fetchBalance("GABC1234", "testnet", server);
-    expect(result).toBe("0");
+    expect(result).toEqual({ status: "error", message: "Network timeout" });
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("[fetchBalance]"),
       networkError,

--- a/apps/webapp/src/lib/stellar.ts
+++ b/apps/webapp/src/lib/stellar.ts
@@ -19,27 +19,37 @@ export interface HorizonServerLike {
   loadAccount(address: string): Promise<AccountRecord>;
 }
 
+/** Discriminated union result type for fetchBalance */
+export type BalanceResult =
+  | { status: "ok"; balance: string }
+  | { status: "not_found" }
+  | { status: "error"; message: string };
+
 /**
  * Fetches the native XLM balance for a Stellar address from Horizon.
- * Returns "0" for accounts not yet on-chain (unfunded) and for network errors.
+ * Returns a discriminated union to distinguish between:
+ * - ok: Account exists and balance was fetched successfully
+ * - not_found: Account does not exist on-chain (unfunded)
+ * - error: Network or other error occurred
  */
 export async function fetchBalance(
   address: string,
   network: "testnet" | "mainnet" = "testnet",
   server?: HorizonServerLike,
-): Promise<string> {
+): Promise<BalanceResult> {
   const srv: HorizonServerLike =
     server ??
     (new Horizon.Server(HORIZON_URLS[network]) as unknown as HorizonServerLike);
   try {
     const account = await srv.loadAccount(address);
     const native = account.balances.find((b) => b.asset_type === "native");
-    return native?.balance ?? "0";
+    return { status: "ok", balance: native?.balance ?? "0" };
   } catch (error) {
     const res = (error as { response?: { status?: number } }).response;
-    if (res?.status !== 404) {
-      console.warn("[fetchBalance] Failed to fetch balance:", error);
+    if (res?.status === 404) {
+      return { status: "not_found" };
     }
-    return "0";
+    console.warn("[fetchBalance] Failed to fetch balance:", error);
+    return { status: "error", message: (error as Error).message };
   }
 }


### PR DESCRIPTION
## Summary
   - Changed `fetchBalance` return type to a discriminated union `BalanceResult` with three variants: `ok`, `not_found`, and `error`
   - Added `balanceStatus` and `balanceError` fields to authentication store
   - Updated `useWallet` hook to handle all three cases and expose status to UI
   - Updated tests for new return type

   ## UI Usage
   Components can now distinguish between the three states:
   ```tsx
   const { balance, balanceStatus, balanceError } = useWallet();

   if (balanceStatus === 'not_found') {
     return <p>Account not yet funded</p>;
   }
   if (balanceStatus === 'error') {
     return <p>Could not load balance, please try again</p>;
   }
   if (balanceStatus === 'ok') {
     return <p>Balance: {balance} XLM</p>;
   }
   ```

   ## Test plan
   - [x] Run `cd apps/webapp && bun run type-check` passes
   - [x] Run `cd apps/webapp && bun test` passes
   - [x] Verify UI shows correct message for unfunded account
   - [x] Verify UI shows error message on network failure"
   
closes #922