### PR TITLE
cleanup: remove deprecated WalletContext completely

### DIFF
--- a/apps/webapp/src/context/WalletContext.tsx
+++ b/apps/webapp/src/context/WalletContext.tsx
@@ -1,8 +1,0 @@
-/**
- * @deprecated This file is maintained for backward compatibility only.
- * Please use @/components/auth/hooks instead.
- *
- * This file now re-exports the new Stellar Wallets Kit implementation.
- */
-
-export { useWallet } from "@/components/auth/hooks";


### PR DESCRIPTION
Removed the deprecated `WalletContext.tsx` file to clean up the codebase.

I verified that all existing imports have already been successfully migrated to the new hooks implementation, making this file completely obsolete. Deleting it now should prevent any confusion for future contributors.

Closes #902