### PR TITLE
remove debug console.log statements and use structured logger in / Closes #898

### DIFF
--- a/apps/akkuea-land/src/hooks/useGameWallet.ts
+++ b/apps/akkuea-land/src/hooks/useGameWallet.ts
@@ -32,7 +32,6 @@ export function useGameWallet() {
   const signAndSubmitTx = async (xdr: string) => {
     // Simulate transaction submission delay
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log("Simulating transaction submission for XDR:", xdr);
   };
 
   return {

--- a/apps/api/src/controllers/NotificationController.ts
+++ b/apps/api/src/controllers/NotificationController.ts
@@ -1,6 +1,7 @@
 import type { AuthContext } from '../middleware/auth';
 import { NotificationService } from '../services/NotificationService';
 import { ApiError } from '../errors/ApiError';
+import { logger } from '../services/logger';
 
 type NotificationBody = {
   email?: string;
@@ -52,7 +53,7 @@ export class NotificationController {
         pagination: { limit, offset },
       });
     } catch (error) {
-      console.error(error);
+      logger.error('Failed to retrieve notifications', error);
 
       throw new ApiError(500, 'INTERNAL_ERROR', 'Failed to retrieve notifications');
     }
@@ -68,7 +69,7 @@ export class NotificationController {
       const count = await this.notificationService.getUnreadCount(userId);
       return this.jsonResponse({ unreadCount: count });
     } catch (error) {
-      console.error(error);
+      logger.error('Failed to retrieve unread count', error);
 
       throw new ApiError(500, 'INTERNAL_ERROR', 'Failed to retrieve unread count');
     }
@@ -197,7 +198,7 @@ export class NotificationController {
         count,
       });
     } catch (error) {
-      console.error(error);
+      logger.error('Failed to update notifications', error);
 
       throw new ApiError(500, 'INTERNAL_ERROR', 'Failed to update notifications');
     }

--- a/apps/api/src/middleware/validation.ts
+++ b/apps/api/src/middleware/validation.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import { z, ZodSchema, ZodError } from 'zod';
+import { logger } from '../services/logger';
 
 /**
  * Format Zod errors into a structured response
@@ -212,7 +213,7 @@ export function validate<
 
             result.validatedBody = bodyResult.data;
           } catch (e) {
-            console.error('[validation.ts] Error parsing JSON body:', e);
+            logger.error('Error parsing JSON body', e);
             result.validationError = {
               status: 400,
               code: 'INVALID_JSON',

--- a/apps/webapp/src/components/kyc/KYCForm.tsx
+++ b/apps/webapp/src/components/kyc/KYCForm.tsx
@@ -114,8 +114,6 @@ export default function KYCForm() {
     try {
       setIsSubmitting(true);
 
-      console.log("Submitting data:", data);
-
       //send to API
       const formData = new FormData();
 


### PR DESCRIPTION
# Tittle: remove debug console.log statements and use structured logger in API


## Description

This PR addresses the cleanup of debug logging statements across the workspaces. It completely removes verbose `console.log` statements in production-bound frontend code that could expose user or session data. In the API server, it replaces bare `console.error` calls with the structured `LoggerService` already implemented in the project.

## Changes Made

### Frontend Code Cleanup
- **`apps/webapp`**: Removed debug form submission logger in `KYCForm.tsx` (line 117) to prevent sensitive user form data leak.
- **`apps/akkuea-land`**: Removed the transaction simulation logging in `useGameWallet.ts` (line 35).

### API logging updates
- **`apps/api`**: Imported `logger` from `../services/logger` and replaced bare `console.error(error)` calls in `NotificationController.ts` (getUserNotifications, getUnreadCount, markAllAsRead) and `validation.ts` (JSON body parsing catch block).

---

## Verification & Screenshots

- [x] Linter passing: ran `bun run lint` successfully across all workspaces.
- [x] Tests passing: ran `bun test --workspaces` (verified tests pass successfully).

### Evidence / Screenshots
<img width="1030" height="279" alt="image" src="https://github.com/user-attachments/assets/73c14f45-3847-4eae-bab6-491198684fbb" />

---

## Closes

Closes #898
