### PR TITLE
ci: add apps/akkuea-land to webapp-ci path filters

### DIFF
--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -5,11 +5,13 @@ on:
     branches: [main, develop]
     paths:
       - "apps/webapp/**"
+      - "apps/akkuea-land/**"
       - ".github/workflows/webapp-ci.yml"
   pull_request:
     branches: [main, develop]
     paths:
       - "apps/webapp/**"
+      - "apps/akkuea-land/**"
       - ".github/workflows/webapp-ci.yml"
 
 env:


### PR DESCRIPTION
The webapp-ci.yml workflow was not triggering for PRs that only touched `apps/akkuea-land/**`. Added the path filter so the CI gap is covered.