### PR TITLE
fix: avoid setState in effect in PropertyViewer3D

### DIFF
--- a/apps/webapp/src/components/forms/FormSelect.tsx
+++ b/apps/webapp/src/components/forms/FormSelect.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import React from "react";
-import type { FieldError, FieldErrors, FieldValues, Path } from "react-hook-form";
+import type {
+  FieldError,
+  FieldErrors,
+  FieldValues,
+  Path,
+} from "react-hook-form";
 import { useFormContext } from "react-hook-form";
 import { cn } from "@/lib/utils";
 

--- a/apps/webapp/src/components/property/PropertyViewer3D.tsx
+++ b/apps/webapp/src/components/property/PropertyViewer3D.tsx
@@ -39,6 +39,17 @@ export function PropertyViewer3D({
 
   const [retryTrigger, setRetryTrigger] = useState(0);
 
+  const [prevResetKey, setPrevResetKey] = useState([retryTrigger, splatUrl]);
+  if (prevResetKey[0] !== retryTrigger || prevResetKey[1] !== splatUrl) {
+    setPrevResetKey([retryTrigger, splatUrl]);
+    setState((prev) => ({
+      ...prev,
+      hasError: false,
+      isLoading: true,
+      errorMessage: "",
+    }));
+  }
+
   const checkWebGLSupport = useCallback((): boolean => {
     try {
       const canvas = document.createElement("canvas");
@@ -50,15 +61,6 @@ export function PropertyViewer3D({
       return false;
     }
   }, []);
-
-  useEffect(() => {
-    setState((prev) => ({
-      ...prev,
-      hasError: false,
-      isLoading: true,
-      errorMessage: "",
-    }));
-  }, [retryTrigger, splatUrl]);
 
   useEffect(() => {
     if (!state.isLoading || state.hasError) return;

--- a/apps/webapp/src/components/property/PropertyViewer3D.tsx
+++ b/apps/webapp/src/components/property/PropertyViewer3D.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { AlertCircle, Maximize2, RotateCcw, Copy, RefreshCw } from "lucide-react";
+import {
+  AlertCircle,
+  Maximize2,
+  RotateCcw,
+  Copy,
+  RefreshCw,
+} from "lucide-react";
 import { Button } from "@/components/ui";
 import { TIMEOUTS } from "@/lib/constants";
 


### PR DESCRIPTION
## Summary

Fixes a failing ESLint check in the WebApp CI on `develop` caused by a `react-hooks/set-state-in-effect` violation in `PropertyViewer3D`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

`PropertyViewer3D` had a `useEffect` that synchronously called `setState` to reset `isLoading`/`hasError` whenever `splatUrl` or `retryTrigger` changed. This pattern triggers the `react-hooks/set-state-in-effect` ESLint rule, since calling `setState` directly inside an effect body can cause cascading renders.

The reset logic was moved to render time, following React's recommended pattern for "adjusting state when a prop changes": the previous `splatUrl`/`retryTrigger` values are tracked in state, and if they differ from the current render, the state is reset directly during render instead of via an effect. Behavior is unchanged — only the mechanism moved out of `useEffect`.

## How to Test

1. Run `bunx eslint apps/webapp/src/components/property/PropertyViewer3D.tsx` — no errors.
2. Run `bunx tsc --noEmit` in `apps/webapp` — no errors.
3. In the app, open a property with a 3D viewer, trigger an error (e.g. invalid `splatUrl`), click "R loading state resets correctly and the viewer re-attempts loading.

## Checklist

- [x] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [x] No `.env` files or secrets are committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Closes #964