### PR TITLE
[AKKUEA-LAND] Keyboard navigation and a11y in CityMap

### DIFF
--- a/apps/akkuea-land/src/components/game/CityMap.css
+++ b/apps/akkuea-land/src/components/game/CityMap.css
@@ -37,6 +37,12 @@
   justify-content: center;
 }
 
+.city-tile:focus-visible {
+  outline: 2px solid var(--land-accent, #00d4ff);
+  outline-offset: 2px;
+  z-index: 10;
+}
+
 /* ─── Hover ──────────────────────────────────────────────────────────────── */
 
 .city-tile:hover {

--- a/apps/akkuea-land/src/components/game/CityMap.tsx
+++ b/apps/akkuea-land/src/components/game/CityMap.tsx
@@ -28,67 +28,90 @@ const FLASH_DURATION = 700; // ms — matches CSS animation duration
 // ── PropertyTile ─────────────────────────────────────────────────────────────
 
 interface PropertyTileProps {
-    property: GameProperty;
-    isSelected: boolean;
+  property: GameProperty;
+  isSelected: boolean;
+  isFocusable: boolean;
+  onFocus: (propertyId: string) => void;
+}
+
+const GRID_SIZE = 20;
+
+function getTileStatus(property: GameProperty): string {
+  if (!property.owner) return "Unowned";
+  if (property.owner === "GBTREASURY") return "Treasury";
+  return `Owned by ${abbreviateAddress(property.owner)}`;
+}
+
+function getTileAriaLabel(property: GameProperty): string {
+  const { row, col } = getGridCoords(property.id);
+  const status = getTileStatus(property);
+  const saleStatus = property.isListed
+    ? `, listed for ${property.pricePerShare} LAND per share`
+    : ", not listed for sale";
+
+  return `${property.name}, row ${row + 1}, column ${col + 1}, ${status}, ${BUILDING_NAMES[property.buildingLevel]}${saleStatus}`;
 }
 
 const PropertyTile = React.memo(function PropertyTile({
-    property,
-    isSelected,
+  property,
+  isSelected,
+  isFocusable,
+  onFocus,
 }: PropertyTileProps) {
-    const { row, col } = getGridCoords(property.id);
-    const bgColor = addressToHSL(property.owner);
-    const glowColor = addressToGlow(property.owner);
-    const isTreasury = !property.owner || property.owner === "GBTREASURY";
-    const isUnowned = !property.owner;
+  const { row, col } = getGridCoords(property.id);
+  const bgColor = addressToHSL(property.owner);
+  const glowColor = addressToGlow(property.owner);
+  const isTreasury = !property.owner || property.owner === "GBTREASURY";
+  const isUnowned = !property.owner;
 
-    const tooltipLines = [
-        `📍 (${row}, ${col})`,
-        `👤 ${abbreviateAddress(property.owner)}`,
-        `🏗 ${BUILDING_NAMES[property.buildingLevel]}`,
-    ];
-    if (property.isListed) {
-        tooltipLines.push(`💰 ${property.pricePerShare} LAND`);
-    }
-    const tooltip = tooltipLines.join("\n");
+  const tooltipLines = [
+    `📍 (${row}, ${col})`,
+    `👤 ${abbreviateAddress(property.owner)}`,
+    `🏗 ${BUILDING_NAMES[property.buildingLevel]}`,
+  ];
+  if (property.isListed) {
+    tooltipLines.push(`💰 ${property.pricePerShare} LAND`);
+  }
+  const tooltip = tooltipLines.join("\n");
 
-    const tileClasses = ["city-tile", isSelected && "tile-selected"]
-        .filter(Boolean)
-        .join(" ");
+  const tileClasses = ["city-tile", isSelected && "tile-selected"]
+    .filter(Boolean)
+    .join(" ");
 
-    return (
-        <div
-            key={property.id}
-            data-property-id={property.id}
-            data-tooltip={tooltip}
-            className={tileClasses}
-            style={
-                {
-                    backgroundColor: isUnowned ? "var(--tile-empty)" : bgColor,
-                    "--tile-glow-color": glowColor,
-                    opacity: isUnowned ? 0.45 : isTreasury ? 0.7 : 1,
-                } as React.CSSProperties
-            }
-            role="gridcell"
-            aria-label={`Tile ${row},${col} — ${abbreviateAddress(property.owner)} — ${BUILDING_NAMES[property.buildingLevel]}${property.isListed ? " — For Sale" : ""}`}
-        >
-            {property.buildingLevel > 0 && (
-                <span
-                    className={`tile-badge tile-badge-${property.buildingLevel}`}
-                >
-                    {BUILDING_LABELS[property.buildingLevel]}
-                </span>
-            )}
+  return (
+    <div
+      key={property.id}
+      data-property-id={property.id}
+      data-tooltip={tooltip}
+      className={tileClasses}
+      style={
+        {
+          backgroundColor: isUnowned ? "var(--tile-empty)" : bgColor,
+          "--tile-glow-color": glowColor,
+          opacity: isUnowned ? 0.45 : isTreasury ? 0.7 : 1,
+        } as React.CSSProperties
+      }
+      role="gridcell"
+      aria-label={getTileAriaLabel(property)}
+      aria-selected={isSelected}
+      aria-rowindex={row + 1}
+      aria-colindex={col + 1}
+      tabIndex={isFocusable ? 0 : -1}
+      onFocus={() => onFocus(property.id)}
+    >
+      {property.buildingLevel > 0 && (
+        <span className={`tile-badge tile-badge-${property.buildingLevel}`}>
+          {BUILDING_LABELS[property.buildingLevel]}
+        </span>
+      )}
 
-            {property.buildingLevel === 0 && !isUnowned && !isTreasury && (
-                <span className="tile-badge tile-badge-0">
-                    {BUILDING_LABELS[0]}
-                </span>
-            )}
+      {property.buildingLevel === 0 && !isUnowned && !isTreasury && (
+        <span className="tile-badge tile-badge-0">{BUILDING_LABELS[0]}</span>
+      )}
 
-            {property.isListed && <span className="tile-listed-dot" />}
-        </div>
-    );
+      {property.isListed && <span className="tile-listed-dot" />}
+    </div>
+  );
 });
 
 // ── Component ────────────────────────────────────────────────────────────────
@@ -99,6 +122,9 @@ export function CityMap() {
     generateMockGrid(),
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [focusedId, setFocusedId] = useState<string>(
+    () => properties[0]?.id ?? "",
+  );
   const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
 
@@ -164,18 +190,76 @@ export function CityMap() {
     };
   }, []);
 
-  // ── Event delegation click handler ───────────────────────────────────────
-  const handleGridClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const target = (e.target as HTMLElement).closest<HTMLElement>(
-      "[data-property-id]",
-    );
-    if (!target) return;
-
-    const propertyId = target.dataset.propertyId!;
-
-    // Toggle selection: clicking same tile deselects
+  const selectTile = useCallback((propertyId: string) => {
+    // Toggle selection: activating same tile deselects
     setSelectedId((prev) => (prev === propertyId ? null : propertyId));
   }, []);
+
+  const focusTile = useCallback((propertyId: string) => {
+    setFocusedId(propertyId);
+    gridRef.current
+      ?.querySelector<HTMLElement>(`[data-property-id="${propertyId}"]`)
+      ?.focus();
+  }, []);
+
+  // ── Event delegation click handler ───────────────────────────────────────
+  const handleGridClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const target = (e.target as HTMLElement).closest<HTMLElement>(
+        "[data-property-id]",
+      );
+      if (!target) return;
+
+      const propertyId = target.dataset.propertyId!;
+      setFocusedId(propertyId);
+      selectTile(propertyId);
+    },
+    [selectTile],
+  );
+
+  // ── Keyboard navigation handler ──────────────────────────────────────────
+  const handleGridKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const target = (e.target as HTMLElement).closest<HTMLElement>(
+        "[data-property-id]",
+      );
+      if (!target) return;
+
+      const propertyId = target.dataset.propertyId!;
+      const currentIndex = properties.findIndex((p) => p.id === propertyId);
+      if (currentIndex === -1) return;
+
+      const keyOffsets: Record<string, number> = {
+        ArrowUp: -GRID_SIZE,
+        ArrowDown: GRID_SIZE,
+        ArrowLeft: -1,
+        ArrowRight: 1,
+      };
+
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        selectTile(propertyId);
+        return;
+      }
+
+      const offset = keyOffsets[e.key];
+      if (!offset) return;
+
+      e.preventDefault();
+      const { row, col } = getGridCoords(propertyId);
+      const isBlockedHorizontal =
+        (e.key === "ArrowLeft" && col === 0) ||
+        (e.key === "ArrowRight" && col === GRID_SIZE - 1);
+      const isBlockedVertical =
+        (e.key === "ArrowUp" && row === 0) ||
+        (e.key === "ArrowDown" && row === GRID_SIZE - 1);
+      if (isBlockedHorizontal || isBlockedVertical) return;
+
+      const nextProperty = properties[currentIndex + offset];
+      if (nextProperty) focusTile(nextProperty.id);
+    },
+    [focusTile, properties, selectTile],
+  );
 
   // ── Close panel ──────────────────────────────────────────────────────────
   const handleClosePanel = useCallback(() => {
@@ -239,69 +323,19 @@ export function CityMap() {
           ref={gridRef}
           className="city-grid"
           onClick={handleGridClick}
+          onKeyDown={handleGridKeyDown}
           role="grid"
           aria-label="Akkuea City property grid"
         >
-          {properties.map((prop) => {
-            const { row, col } = getGridCoords(prop.id);
-            const bgColor = addressToHSL(prop.owner);
-            const glowColor = addressToGlow(prop.owner);
-            const isSelected = prop.id === selectedId;
-            const isTreasury = !prop.owner || prop.owner === "GBTREASURY";
-            const isUnowned = !prop.owner;
-
-            // Build tooltip text
-            const tooltipLines = [
-              `📍 (${row}, ${col})`,
-              `👤 ${abbreviateAddress(prop.owner)}`,
-              `🏗 ${BUILDING_NAMES[prop.buildingLevel]}`,
-            ];
-            if (prop.isListed) {
-              tooltipLines.push(`💰 ${prop.pricePerShare} LAND`);
-            }
-            const tooltip = tooltipLines.join("\n");
-
-            const tileClasses = ["city-tile", isSelected && "tile-selected"]
-              .filter(Boolean)
-              .join(" ");
-
-            return (
-              <div
-                key={prop.id}
-                data-property-id={prop.id}
-                data-tooltip={tooltip}
-                className={tileClasses}
-                style={
-                  {
-                    backgroundColor: isUnowned ? "var(--tile-empty)" : bgColor,
-                    "--tile-glow-color": glowColor,
-                    opacity: isUnowned ? 0.45 : isTreasury ? 0.7 : 1,
-                  } as React.CSSProperties
-                }
-                role="gridcell"
-                aria-label={`Tile ${row},${col} — ${abbreviateAddress(prop.owner)} — ${BUILDING_NAMES[prop.buildingLevel]}${prop.isListed ? " — For Sale" : ""}`}
-              >
-                {/* Building Level Badge */}
-                {prop.buildingLevel > 0 && (
-                  <span
-                    className={`tile-badge tile-badge-${prop.buildingLevel}`}
-                  >
-                    {BUILDING_LABELS[prop.buildingLevel]}
-                  </span>
-                )}
-
-                {/* Vacant label for level 0 — only on non-empty tiles to reduce clutter */}
-                {prop.buildingLevel === 0 && !isUnowned && !isTreasury && (
-                  <span className="tile-badge tile-badge-0">
-                    {BUILDING_LABELS[0]}
-                  </span>
-                )}
-
-                {/* Listed-for-sale amber dot */}
-                {prop.isListed && <span className="tile-listed-dot" />}
-              </div>
-            );
-          })}
+          {properties.map((prop) => (
+            <PropertyTile
+              key={prop.id}
+              property={prop}
+              isSelected={prop.id === selectedId}
+              isFocusable={prop.id === focusedId}
+              onFocus={setFocusedId}
+            />
+          ))}
         </div>
       </div>
 

--- a/apps/akkuea-land/src/components/game/__tests__/CityMap.test.tsx
+++ b/apps/akkuea-land/src/components/game/__tests__/CityMap.test.tsx
@@ -1,0 +1,90 @@
+// @ts-expect-error: jsdom types not fully compatible with bun runtime
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+(dom.window as any).fetch = fetch;
+globalThis.window = dom.window as any;
+globalThis.document = dom.window.document as any;
+globalThis.navigator = dom.window.navigator as any;
+globalThis.HTMLElement = dom.window.HTMLElement as any;
+globalThis.MutationObserver = dom.window.MutationObserver as any;
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+mock.module("../PropertyPanel", () => ({
+  PropertyPanel: ({ property }: any) => (
+    <aside aria-label="Selected property panel">{property.name}</aside>
+  ),
+}));
+
+import { CityMap } from "../CityMap";
+
+describe("CityMap keyboard accessibility", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("allows tiles to be navigated and activated entirely with the keyboard", () => {
+    const view = render(<CityMap />);
+    const grid = view.getByRole("grid", {
+      name: "Akkuea City property grid",
+    });
+    const firstTile = view.getByRole("gridcell", {
+      name: /Tile A1, row 1, column 1,/,
+    });
+
+    expect(firstTile.getAttribute("tabindex")).toBe("0");
+    expect(firstTile.getAttribute("aria-selected")).toBe("false");
+    expect(firstTile.getAttribute("aria-label")).toContain(
+      "not listed for sale",
+    );
+
+    firstTile.focus();
+    expect(document.activeElement).toBe(firstTile);
+
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    const secondTile = view.getByRole("gridcell", {
+      name: /Tile B1, row 1, column 2,/,
+    });
+    expect(document.activeElement).toBe(secondTile);
+    expect(secondTile.getAttribute("tabindex")).toBe("0");
+    expect(firstTile.getAttribute("tabindex")).toBe("-1");
+
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    const lowerTile = view.getByRole("gridcell", {
+      name: /Tile B2, row 2, column 2,/,
+    });
+    expect(document.activeElement).toBe(lowerTile);
+
+    fireEvent.keyDown(grid, { key: "Enter" });
+    expect(lowerTile.getAttribute("aria-selected")).toBe("true");
+    expect(view.getByLabelText("Selected property panel")).not.toBeNull();
+  });
+
+  it("supports tab focus and space activation on a tile", () => {
+    const view = render(<CityMap />);
+    const grid = view.getByRole("grid", {
+      name: "Akkuea City property grid",
+    });
+    const firstTile = view.getByRole("gridcell", {
+      name: /Tile A1, row 1, column 1,/,
+    });
+
+    firstTile.focus();
+    fireEvent.keyDown(grid, { key: " " });
+
+    expect(firstTile.getAttribute("aria-selected")).toBe("true");
+    expect(view.getByLabelText("Selected property panel")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implemented full keyboard accessibility support for the CityMap grid. Property tiles can now be navigated and activated without a mouse using roving focus, arrow-key navigation, and accessible grid semantics.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

Added keyboard navigation and screen-reader support to the CityMap component to improve accessibility for users relying on keyboards and assistive technologies.

Changes include:

- Added a focused `PropertyTile` render with new props:
  - `isFocusable`
  - `onFocus`

- Added helper functions:
  - `getTileAriaLabel()` for descriptive accessibility labels
  - `getTileStatus()` for readable tile status information

- Improved ARIA metadata by including:
  - Property name
  - 1-based row and column position
  - Ownership information
  - Building information
  - Sale status

- Implemented roving focus management:
  - Added `focusedId` state
  - Added `focusTile()` and `selectTile()` handlers
  - Added `handleGridKeyDown()` support for:
    - ArrowUp
    - ArrowDown
    - ArrowLeft
    - ArrowRight
    - Enter
    - Space

- Added grid accessibility semantics:
  - `role="gridcell"`
  - `aria-selected`
  - `aria-rowindex`
  - `aria-colindex`
  - Dynamic `tabIndex` management

- Added visible keyboard focus styling using:
  - `.city-tile:focus-visible`

- Added `CityMap.test.tsx` coverage for:
  - Roving tab index behavior
  - Arrow-key movement between tiles
  - Enter/Space activation
  - Property panel rendering after tile activation

These changes ensure CityMap tiles are fully navigable and usable by keyboard users and assistive technologies.

## How to Test

1. Install dependencies:

```bash
bun install

## Related Issues

<!-- Closes #<issue_number> -->
close #985 