### PR TITLE
feat: add marketplace price/yield sort and clearer empty state with c…

### DIFF
--- a/apps/shared/src/schemas/property.schema.ts
+++ b/apps/shared/src/schemas/property.schema.ts
@@ -3,6 +3,7 @@ import {
   stellarAddressSchema,
   positiveAmountSchema,
   isoDateSchema,
+  percentageSchema,
 } from "./common.schema";
 
 /**
@@ -53,6 +54,7 @@ export const propertyInfoSchema = z.object({
   totalShares: z.number().int().positive(),
   availableShares: z.number().int().min(0),
   pricePerShare: positiveAmountSchema,
+  expectedYield: percentageSchema.optional(),
   images: z.array(z.string().url()).min(1, "At least one image required"),
   splatUrl: z
     .string()

--- a/apps/webapp/src/app/marketplace/page.test.tsx
+++ b/apps/webapp/src/app/marketplace/page.test.tsx
@@ -230,7 +230,9 @@ describe("MarketplacePage", () => {
 
   it("renders an error state with retry when the API request fails", async () => {
     mockGetAll
-      .mockRejectedValueOnce(new Error("Marketplace unavailable"))
+      .mockImplementationOnce(() =>
+        Promise.reject(new Error("Marketplace unavailable")),
+      )
       .mockResolvedValueOnce({
         data: [property],
         pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
@@ -321,9 +323,7 @@ describe("MarketplacePage", () => {
 
     await waitFor(() => {
       expect(view.queryByText(property.name)).not.toBeNull();
-      expect(
-        view.queryByText(commercialPropertyInMexico.name),
-      ).not.toBeNull();
+      expect(view.queryByText(commercialPropertyInMexico.name)).not.toBeNull();
     });
   });
 });

--- a/apps/webapp/src/app/marketplace/page.test.tsx
+++ b/apps/webapp/src/app/marketplace/page.test.tsx
@@ -169,7 +169,7 @@ describe("MarketplacePage", () => {
     cleanup();
     propertyApi.getAll = mockGetAll;
     propertyApi.buyShares = mockBuyShares;
-    mockGetAll.mockClear();
+    mockGetAll.mockReset();
     mockGetAll.mockImplementation(() =>
       Promise.resolve({
         data: [property],
@@ -246,6 +246,84 @@ describe("MarketplacePage", () => {
     await waitFor(() => {
       expect(mockGetAll).toHaveBeenCalledTimes(2);
       expect(view.queryByText(property.name)).not.toBeNull();
+    });
+  });
+
+  it("reorders the list when the sort option changes, without refetching", async () => {
+    const cheapProperty: PropertyInfo = {
+      ...property,
+      id: "550e8400-e29b-41d4-a716-446655440002",
+      name: "Cheap Property",
+      pricePerShare: "10",
+    };
+    const expensiveProperty: PropertyInfo = {
+      ...property,
+      id: "550e8400-e29b-41d4-a716-446655440003",
+      name: "Expensive Property",
+      pricePerShare: "900",
+    };
+    mockGetAll.mockResolvedValueOnce({
+      data: [expensiveProperty, cheapProperty],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 1 },
+    });
+
+    const view = render(<MarketplacePage />);
+    await view.findByText(expensiveProperty.name);
+
+    fireEvent.click(view.getByRole("button", { name: /Filters/i }));
+
+    const sortSelect = view.getByLabelText(/Sort By/i);
+    fireEvent.change(sortSelect, {
+      target: { value: "Price: Low to High" },
+    });
+
+    const names = view
+      .getAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent);
+    expect(names).toEqual([cheapProperty.name, expensiveProperty.name]);
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the empty state with a clear-filters action when filters exclude every property", async () => {
+    const commercialPropertyInMexico: PropertyInfo = {
+      ...property,
+      id: "550e8400-e29b-41d4-a716-446655440004",
+      name: "Mexico City Office Tower",
+      propertyType: "commercial",
+      location: { address: "Reforma 100", city: "CDMX", country: "Mexico" },
+    };
+    mockGetAll.mockResolvedValueOnce({
+      data: [property, commercialPropertyInMexico],
+      pagination: { page: 1, limit: 100, total: 2, totalPages: 1 },
+    });
+
+    const view = render(<MarketplacePage />);
+    await view.findByText(property.name);
+    await view.findByText(commercialPropertyInMexico.name);
+
+    fireEvent.click(view.getByRole("button", { name: /Filters/i }));
+
+    // property is Africa/Residential, the other is Latin America/Commercial —
+    // this combination matches neither, so it excludes every property.
+    fireEvent.change(view.getByLabelText(/Region/i), {
+      target: { value: "Africa" },
+    });
+    fireEvent.change(view.getByLabelText(/Property Type/i), {
+      target: { value: "Commercial" },
+    });
+
+    expect(await view.findByText(/No properties found/i)).not.toBeNull();
+    expect(
+      view.getByText(/No properties match your search or filters/i),
+    ).not.toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: /Clear filters/i }));
+
+    await waitFor(() => {
+      expect(view.queryByText(property.name)).not.toBeNull();
+      expect(
+        view.queryByText(commercialPropertyInMexico.name),
+      ).not.toBeNull();
     });
   });
 });

--- a/apps/webapp/src/app/marketplace/page.tsx
+++ b/apps/webapp/src/app/marketplace/page.tsx
@@ -85,7 +85,12 @@ function ErrorState({ error, onRetry }: ErrorStateProps) {
   );
 }
 
-function EmptyState() {
+interface EmptyStateProps {
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+}
+
+function EmptyState({ hasActiveFilters, onClearFilters }: EmptyStateProps) {
   return (
     <motion.div variants={staggerItem} className="py-16 text-center">
       <Building2 className="mx-auto mb-4 h-16 w-16 text-neutral-700" />
@@ -93,8 +98,15 @@ function EmptyState() {
         No properties found
       </h3>
       <p className="text-sm text-neutral-500">
-        Try adjusting your filters or search query
+        {hasActiveFilters
+          ? "No properties match your search or filters."
+          : "There are no properties listed yet."}
       </p>
+      {hasActiveFilters && (
+        <Button variant="outline" className="mt-6" onClick={onClearFilters}>
+          Clear filters
+        </Button>
+      )}
     </motion.div>
   );
 }
@@ -257,6 +269,19 @@ export default function MarketplacePage() {
     [properties],
   );
 
+  const hasActiveFilters =
+    searchQuery.trim().length > 0 ||
+    selectedRegion !== MARKETPLACE_ALL_REGIONS ||
+    selectedType !== MARKETPLACE_ALL_TYPES ||
+    sortBy !== "Recently Added";
+
+  const clearFilters = () => {
+    setSearchQuery("");
+    setSelectedRegion(MARKETPLACE_ALL_REGIONS);
+    setSelectedType(MARKETPLACE_ALL_TYPES);
+    setSortBy("Recently Added");
+  };
+
   return (
     <motion.div
       variants={pageTransition}
@@ -309,10 +334,14 @@ export default function MarketplacePage() {
                     className="grid gap-4 rounded-lg border border-[#262626] bg-[#0a0a0a] p-4 sm:grid-cols-3"
                   >
                     <div>
-                      <label className="mb-2 block text-xs uppercase tracking-wider text-neutral-500">
+                      <label
+                        htmlFor="marketplace-region"
+                        className="mb-2 block text-xs uppercase tracking-wider text-neutral-500"
+                      >
                         Region
                       </label>
                       <select
+                        id="marketplace-region"
                         value={selectedRegion}
                         onChange={(event) =>
                           setSelectedRegion(event.target.value)
@@ -327,10 +356,14 @@ export default function MarketplacePage() {
                       </select>
                     </div>
                     <div>
-                      <label className="mb-2 block text-xs uppercase tracking-wider text-neutral-500">
+                      <label
+                        htmlFor="marketplace-property-type"
+                        className="mb-2 block text-xs uppercase tracking-wider text-neutral-500"
+                      >
                         Property Type
                       </label>
                       <select
+                        id="marketplace-property-type"
                         value={selectedType}
                         onChange={(event) =>
                           setSelectedType(event.target.value)
@@ -345,10 +378,14 @@ export default function MarketplacePage() {
                       </select>
                     </div>
                     <div>
-                      <label className="mb-2 block text-xs uppercase tracking-wider text-neutral-500">
+                      <label
+                        htmlFor="marketplace-sort"
+                        className="mb-2 block text-xs uppercase tracking-wider text-neutral-500"
+                      >
                         Sort By
                       </label>
                       <select
+                        id="marketplace-sort"
                         value={sortBy}
                         onChange={(event) =>
                           setSortBy(event.target.value as MarketplaceSortOption)
@@ -415,7 +452,10 @@ export default function MarketplacePage() {
                 </motion.div>
 
                 {!isLoading && filteredProperties.length === 0 && (
-                  <EmptyState />
+                  <EmptyState
+                    hasActiveFilters={hasActiveFilters}
+                    onClearFilters={clearFilters}
+                  />
                 )}
               </>
             )}

--- a/apps/webapp/src/components/marketplace/__tests__/marketplace.utils.test.ts
+++ b/apps/webapp/src/components/marketplace/__tests__/marketplace.utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import type { PropertyInfo } from "@real-estate-defi/shared";
+import {
+  filterAndSortProperties,
+  MARKETPLACE_ALL_REGIONS,
+  MARKETPLACE_ALL_TYPES,
+} from "@/components/marketplace/marketplace.utils";
+
+function buildProperty(overrides: Partial<PropertyInfo>): PropertyInfo {
+  return {
+    id: "00000000-0000-0000-0000-000000000000",
+    name: "Test Property",
+    description: "A property used for unit tests.",
+    propertyType: "residential",
+    location: {
+      address: "1 Test Street",
+      city: "Testville",
+      country: "Nigeria",
+    },
+    totalValue: "1000000",
+    totalShares: 1000,
+    availableShares: 500,
+    pricePerShare: "100",
+    images: ["https://example.com/image.jpg"],
+    documents: [],
+    verified: true,
+    listedAt: "2024-01-01T00:00:00.000Z",
+    owner: "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU",
+    ...overrides,
+  };
+}
+
+const baseFilters = {
+  searchQuery: "",
+  selectedRegion: MARKETPLACE_ALL_REGIONS,
+  selectedType: MARKETPLACE_ALL_TYPES,
+};
+
+describe("filterAndSortProperties", () => {
+  const cheap = buildProperty({
+    id: "1",
+    name: "Cheap",
+    pricePerShare: "10",
+    expectedYield: 5,
+  });
+  const expensive = buildProperty({
+    id: "2",
+    name: "Expensive",
+    pricePerShare: "500",
+    expectedYield: 12,
+  });
+  const noYield = buildProperty({
+    id: "3",
+    name: "NoYield",
+    pricePerShare: "250",
+    expectedYield: undefined,
+  });
+
+  const properties = [cheap, expensive, noYield];
+
+  it("sorts by price ascending", () => {
+    const result = filterAndSortProperties(properties, {
+      ...baseFilters,
+      sortBy: "Price: Low to High",
+    });
+    expect(result.map((p) => p.id)).toEqual(["1", "3", "2"]);
+  });
+
+  it("sorts by price descending", () => {
+    const result = filterAndSortProperties(properties, {
+      ...baseFilters,
+      sortBy: "Price: High to Low",
+    });
+    expect(result.map((p) => p.id)).toEqual(["2", "3", "1"]);
+  });
+
+  it("sorts by yield ascending, treating missing yield as 0", () => {
+    const result = filterAndSortProperties(properties, {
+      ...baseFilters,
+      sortBy: "Yield: Low to High",
+    });
+    expect(result.map((p) => p.id)).toEqual(["3", "1", "2"]);
+  });
+
+  it("sorts by yield descending, treating missing yield as 0", () => {
+    const result = filterAndSortProperties(properties, {
+      ...baseFilters,
+      sortBy: "Yield: High to Low",
+    });
+    expect(result.map((p) => p.id)).toEqual(["2", "1", "3"]);
+  });
+
+  it("returns an empty list when no property matches the search query", () => {
+    const result = filterAndSortProperties(properties, {
+      ...baseFilters,
+      searchQuery: "no-such-property-xyz",
+      sortBy: "Recently Added",
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/webapp/src/components/marketplace/marketplace.utils.ts
+++ b/apps/webapp/src/components/marketplace/marketplace.utils.ts
@@ -5,7 +5,10 @@ export const MARKETPLACE_ALL_TYPES = "All Types";
 
 export const sortOptions = [
   "Recently Added",
-  "Lowest Price",
+  "Price: Low to High",
+  "Price: High to Low",
+  "Yield: Low to High",
+  "Yield: High to Low",
   "Most Funded",
   "Highest Value",
 ] as const;
@@ -76,6 +79,26 @@ interface FilterOptions {
   sortBy: MarketplaceSortOption;
 }
 
+const sortComparators: Record<
+  MarketplaceSortOption,
+  (left: PropertyInfo, right: PropertyInfo) => number
+> = {
+  "Recently Added": (left, right) =>
+    Date.parse(right.listedAt) - Date.parse(left.listedAt),
+  "Price: Low to High": (left, right) =>
+    parseFloat(left.pricePerShare) - parseFloat(right.pricePerShare),
+  "Price: High to Low": (left, right) =>
+    parseFloat(right.pricePerShare) - parseFloat(left.pricePerShare),
+  "Yield: Low to High": (left, right) =>
+    (left.expectedYield ?? 0) - (right.expectedYield ?? 0),
+  "Yield: High to Low": (left, right) =>
+    (right.expectedYield ?? 0) - (left.expectedYield ?? 0),
+  "Most Funded": (left, right) =>
+    getFundingProgress(right) - getFundingProgress(left),
+  "Highest Value": (left, right) =>
+    parseFloat(right.totalValue) - parseFloat(left.totalValue),
+};
+
 export function filterAndSortProperties(
   properties: PropertyInfo[],
   { searchQuery, selectedRegion, selectedType, sortBy }: FilterOptions,
@@ -100,22 +123,7 @@ export function filterAndSortProperties(
 
       return matchesSearch && matchesRegion && matchesType;
     })
-    .sort((left, right) => {
-      switch (sortBy) {
-        case "Recently Added":
-          return Date.parse(right.listedAt) - Date.parse(left.listedAt);
-        case "Lowest Price":
-          return (
-            parseFloat(left.pricePerShare) - parseFloat(right.pricePerShare)
-          );
-        case "Most Funded":
-          return getFundingProgress(right) - getFundingProgress(left);
-        case "Highest Value":
-          return parseFloat(right.totalValue) - parseFloat(left.totalValue);
-        default:
-          return 0;
-      }
-    });
+    .sort(sortComparators[sortBy]);
 }
 
 export function getPropertyImage(property: PropertyInfo): string {

--- a/apps/webapp/src/mocks/fixtures/properties.ts
+++ b/apps/webapp/src/mocks/fixtures/properties.ts
@@ -23,6 +23,7 @@ export const mockProperties: PropertyInfo[] = [
     totalShares: 10000,
     availableShares: 3250,
     pricePerShare: "85.00",
+    expectedYield: 8.2,
     images: [
       "https://images.unsplash.com/photo-1613977257592-4871e5fcd7c4?w=800",
       "https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=800",
@@ -68,6 +69,7 @@ export const mockProperties: PropertyInfo[] = [
     totalShares: 24000,
     availableShares: 8800,
     pricePerShare: "100.00",
+    expectedYield: 10.5,
     images: [
       "https://images.unsplash.com/photo-1486325212027-8081e485255e?w=800",
       "https://images.unsplash.com/photo-1497366216548-37526070297c?w=800",
@@ -112,6 +114,7 @@ export const mockProperties: PropertyInfo[] = [
     totalShares: 12000,
     availableShares: 9600,
     pricePerShare: "100.00",
+    expectedYield: 12.4,
     images: [
       "https://images.unsplash.com/photo-1586528116311-ad8dd3c8310d?w=800",
       "https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=800",
@@ -148,6 +151,7 @@ export const mockProperties: PropertyInfo[] = [
     totalShares: 16500,
     availableShares: 2100,
     pricePerShare: "100.00",
+    expectedYield: 9.1,
     images: [
       "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?w=800",
       "https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?w=800",
@@ -192,6 +196,7 @@ export const mockProperties: PropertyInfo[] = [
     totalShares: 9800,
     availableShares: 7200,
     pricePerShare: "100.00",
+    expectedYield: 7.6,
     images: [
       "https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=800",
       "https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=800",
@@ -226,6 +231,7 @@ export const mockProperties: PropertyInfo[] = [
     totalShares: 32000,
     availableShares: 29500,
     pricePerShare: "100.00",
+    expectedYield: 6.5,
     images: [
       "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=800",
       "https://images.unsplash.com/photo-1519046904884-53103b34b206?w=800",


### PR DESCRIPTION
## Summary

Closes #978 

Adds a sort selector (price/yield, asc/desc) and a clearer empty state to the marketplace listing, so filters that return no results are communicated instead of showing a silent empty grid.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

- Added `expectedYield` (optional percentage) to the shared `PropertyInfo` schema (`apps/shared/src/schemas/property.schema.ts`), reusing the existing `percentageSchema`. It's optional so it doesn't break real API responses that don't send it yet.
- Backfilled realistic `expectedYield` values into the mock properties (`apps/webapp/src/mocks/fixtures/properties.ts`) so the new sort options are exercised in dev.
- Replaced the single-direction sort dropdown with directional pairs (`Price: Low to High/High to Low`, `Yield: Low to High/High to Low`, plus the existing `Recently Added`/`Most Funded`/`Highest Value`) and refactored the sort logic into a typed comparator map in `marketplace.utils.ts`. Sorting stays fully client-side (`useMemo`), so changing the order reorders the list with no page reload.
- Enhanced the empty state (`page.tsx`) with a contextual message and a "Clear filters" button that resets search/region/type/sort, shown only when a filter is active.
- Added proper `htmlFor`/`id` associations between filter labels and their `<select>`s (missing before, an a11y gap).
- Added unit tests for the sort comparators and two new component tests (reorder-without-refetch, empty state + clear filters).
- Fixed a pre-existing test-isolation bug in `page.test.tsx` (`mockClear()` → `mockReset()`) that let queued mock values leak between tests.

## How to Test

1. `docker compose -f docker-compose.dev.yml up -d && bun install && bun run dev`
2. Open the marketplace page, click **Filters**, and switch **Sort By** through the Price/Yield options — the grid should reorder instantly with no navigation.
3. Pick a Region + Property Type combination that matches nothing (e.g. Africa + Commercial, if no property satisfies both) — the empty state with "Clear filters" should appear; clicking it should restore the full list.
4. `cd apps/webapp && bun test src/app/marketplace/page.test.tsx src/components/marketplace/__tests__/marketplace.utils.test.ts`

## Checklist

- [ ] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [x] No `.env` files or secrets are committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

