### PR TITLE
feat(webapp): implement wallet reconnection flow and pending action retry (#976)

### DIFF
--- a/apps/webapp/src/components/Providers.tsx
+++ b/apps/webapp/src/components/Providers.tsx
@@ -10,6 +10,7 @@ import {
   pollarProvider,
 } from "@/services/wallet";
 import { PrivyWrapper } from "@/components/auth/PrivyWrapper";
+import { WalletReconnectionPrompt } from "@/components/auth/WalletReconnectionPrompt";
 
 walletRegistry.register(new StellarWalletsKitProvider());
 
@@ -64,7 +65,10 @@ export function Providers({ children }: ProvidersProps) {
           deviceLabel: "Akkuea web",
         }}
       >
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          {children}
+          <WalletReconnectionPrompt />
+        </ThemeProvider>
       </PollarProvider>
     </PrivyWrapper>
   );

--- a/apps/webapp/src/components/auth/WalletReconnectionPrompt.tsx
+++ b/apps/webapp/src/components/auth/WalletReconnectionPrompt.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { WifiOff, X, Loader2 } from "lucide-react";
+import { useWallet } from "@/components/auth/hooks";
+
+/**
+ * Global, non-blocking banner shown when a previously-connected wallet is
+ * found to be unavailable or on the wrong network (see the focus-triggered
+ * check in useWallet.hook.ts). Mounted once in Providers.tsx so it has scope
+ * over every route.
+ */
+export function WalletReconnectionPrompt() {
+  const { isWalletDisconnected, reconnect, dismissReconnectionPrompt } =
+    useWallet();
+  const [isReconnecting, setIsReconnecting] = useState(false);
+
+  const handleReconnect = async () => {
+    setIsReconnecting(true);
+    try {
+      await reconnect();
+    } catch {
+      // Error state is left visible via isWalletDisconnected; the user can retry.
+    } finally {
+      setIsReconnecting(false);
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isWalletDisconnected && (
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 16 }}
+          transition={{ duration: 0.18, ease: [0.25, 0.46, 0.45, 0.94] }}
+          role="alert"
+          aria-live="assertive"
+          className="fixed bottom-4 right-4 z-[60] w-full max-w-sm"
+        >
+          <div className="flex items-start gap-3 rounded-xl border border-[#262626] bg-[#0a0a0a] p-4 shadow-2xl">
+            <span className="shrink-0 flex items-center justify-center w-9 h-9 rounded-lg bg-[#1a1a1a] border border-[#262626] text-amber-400">
+              <WifiOff className="w-4 h-4" />
+            </span>
+
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-white">
+                Wallet disconnected
+              </p>
+              <p className="text-xs text-neutral-500 mt-0.5">
+                Your wallet session ended or switched networks unexpectedly.
+              </p>
+
+              <button
+                onClick={handleReconnect}
+                disabled={isReconnecting}
+                className="inline-flex items-center gap-1.5 mt-3 px-3 py-1.5 rounded-md bg-white text-black text-xs font-medium hover:bg-neutral-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                {isReconnecting && (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                )}
+                {isReconnecting ? "Reconnecting…" : "Reconnect"}
+              </button>
+            </div>
+
+            <button
+              onClick={dismissReconnectionPrompt}
+              disabled={isReconnecting}
+              aria-label="Dismiss"
+              className="p-1.5 rounded-md text-neutral-500 hover:text-white hover:bg-[#1a1a1a] transition-colors cursor-pointer disabled:opacity-40"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/webapp/src/components/auth/hooks/__tests__/useWallet.hook.test.ts
+++ b/apps/webapp/src/components/auth/hooks/__tests__/useWallet.hook.test.ts
@@ -1,0 +1,241 @@
+import "@/test/setup-dom";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+interface MockWalletOption {
+  id: string;
+}
+
+interface MockKit {
+  openModal: (opts: {
+    onWalletSelected: (option: MockWalletOption) => Promise<void> | void;
+    onClosed: () => void;
+  }) => Promise<void>;
+  setWallet: (id: string) => void;
+  getAddress: () => Promise<{ address: string }>;
+  getNetwork: () => Promise<{ networkPassphrase: string }>;
+}
+
+let mockKit: MockKit | null = null;
+
+mock.module("../../constant/walletKit", () => ({
+  initializeWalletKit: () => {},
+  getWalletKit: () => mockKit,
+}));
+
+const fetchBalanceMock = mock(() =>
+  Promise.resolve({ status: "ok" as const, balance: "100" }),
+);
+mock.module("@/lib/stellar", () => ({
+  fetchBalance: fetchBalanceMock,
+}));
+
+const { useWallet } = await import("../useWallet.hook");
+const { useAuthenticationStore } =
+  await import("../../store/data/slices/authentication.slice");
+
+const TEST_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+function resetStore() {
+  useAuthenticationStore.setState({
+    address: null,
+    balance: null,
+    balanceStatus: null,
+    balanceError: null,
+    isConnected: false,
+    isConnecting: false,
+    isWalletDisconnected: false,
+    pendingAction: null,
+    selectedWalletId: null,
+    network: "testnet",
+  });
+}
+
+function makeMockKit(overrides: Partial<MockKit> = {}): MockKit {
+  return {
+    setWallet: () => {},
+    getAddress: async () => ({ address: "GADDRESSRECONNECTED" }),
+    getNetwork: async () => ({ networkPassphrase: TEST_NETWORK_PASSPHRASE }),
+    openModal: async (opts) => {
+      opts.onClosed();
+    },
+    ...overrides,
+  };
+}
+
+describe("useWallet - reconnection flow", () => {
+  beforeEach(() => {
+    resetStore();
+    mockKit = null;
+    fetchBalanceMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the reconnection prompt visible if the wallet-selection modal is cancelled", async () => {
+    useAuthenticationStore.setState({ isWalletDisconnected: true });
+    mockKit = makeMockKit();
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.reconnect();
+    });
+
+    // The legacy connect() path resolves even when the user closes the
+    // modal without picking a wallet — reconnect() must not treat that as
+    // a successful reconnection.
+    expect(useAuthenticationStore.getState().isWalletDisconnected).toBe(true);
+    expect(useAuthenticationStore.getState().isConnected).toBe(false);
+  });
+
+  it("clears the prompt and resumes the pending action once reconnection succeeds", async () => {
+    const pendingAction = mock(() => Promise.resolve("signed-xdr"));
+    useAuthenticationStore.setState({
+      isWalletDisconnected: true,
+      pendingAction,
+    });
+    mockKit = makeMockKit({
+      openModal: async (opts) => {
+        await opts.onWalletSelected({ id: "freighter" });
+      },
+    });
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.reconnect();
+    });
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(false);
+    expect(state.pendingAction).toBeNull();
+    expect(pendingAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms the prompt with the same pending action if resuming it fails again", async () => {
+    const pendingAction = mock(() =>
+      Promise.reject(new Error("still failing")),
+    );
+    useAuthenticationStore.setState({
+      isWalletDisconnected: true,
+      pendingAction,
+    });
+    mockKit = makeMockKit({
+      openModal: async (opts) => {
+        await opts.onWalletSelected({ id: "freighter" });
+      },
+    });
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.reconnect();
+    });
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(true);
+    expect(state.pendingAction).toBe(pendingAction);
+  });
+
+  it("a failed reconnect attempt (resetSession) does not clear isWalletDisconnected", async () => {
+    useAuthenticationStore.setState({ isWalletDisconnected: true });
+    mockKit = makeMockKit({
+      openModal: async (opts) => {
+        // Selection succeeds but the address lookup fails, forcing the
+        // onWalletSelected catch branch (store.resetSession()).
+        await opts.onWalletSelected({ id: "freighter" });
+      },
+      getAddress: async () => {
+        throw new Error("kit unavailable");
+      },
+    });
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.reconnect();
+    });
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(true);
+    expect(state.isConnected).toBe(false);
+    expect(state.address).toBeNull();
+  });
+});
+
+describe("useAuthenticationStore - reconnection state", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("triggerReconnectionPrompt sets the flag and queues the given action", () => {
+    const action = mock(() => Promise.resolve());
+    useAuthenticationStore.getState().triggerReconnectionPrompt(action);
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(true);
+    expect(state.pendingAction).toBe(action);
+  });
+
+  it("triggerReconnectionPrompt called without an action preserves an already-queued one", () => {
+    const action = mock(() => Promise.resolve());
+    useAuthenticationStore.getState().triggerReconnectionPrompt(action);
+
+    // Simulates the passive focus-probe firing after a sign attempt already
+    // queued a pending action — it must not clobber it.
+    useAuthenticationStore.getState().triggerReconnectionPrompt();
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(true);
+    expect(state.pendingAction).toBe(action);
+  });
+
+  it("clearReconnectionPrompt resets both the flag and the pending action", () => {
+    const action = mock(() => Promise.resolve());
+    useAuthenticationStore.getState().triggerReconnectionPrompt(action);
+    useAuthenticationStore.getState().clearReconnectionPrompt();
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(false);
+    expect(state.pendingAction).toBeNull();
+  });
+
+  it("resetSession clears session fields but preserves the reconnection prompt state", () => {
+    const action = mock(() => Promise.resolve());
+    useAuthenticationStore.setState({
+      address: "GADDRESS",
+      isConnected: true,
+      selectedWalletId: "freighter",
+      isWalletDisconnected: true,
+      pendingAction: action,
+    });
+
+    useAuthenticationStore.getState().resetSession();
+
+    const state = useAuthenticationStore.getState();
+    expect(state.address).toBeNull();
+    expect(state.isConnected).toBe(false);
+    expect(state.selectedWalletId).toBeNull();
+    // The whole point of resetSession vs. reset(): the reconnection banner
+    // and its queued action must survive a failed (re)connect attempt.
+    expect(state.isWalletDisconnected).toBe(true);
+    expect(state.pendingAction).toBe(action);
+  });
+
+  it("reset (full disconnect) clears the reconnection prompt state too", () => {
+    const action = mock(() => Promise.resolve());
+    useAuthenticationStore.setState({
+      isWalletDisconnected: true,
+      pendingAction: action,
+    });
+
+    useAuthenticationStore.getState().reset();
+
+    const state = useAuthenticationStore.getState();
+    expect(state.isWalletDisconnected).toBe(false);
+    expect(state.pendingAction).toBeNull();
+  });
+});

--- a/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
+++ b/apps/webapp/src/components/auth/hooks/useWallet.hook.ts
@@ -52,6 +52,56 @@ export const useWallet = () => {
   }, []);
 
   /**
+   * Passive reconnection check: the Stellar Wallets Kit (v1.9.5) exposes no
+   * onAccountChange/onNetworkChange subscription, so the only way to notice an
+   * extension lock, revoked session, or out-of-band network switch is to probe
+   * it. We probe on window focus rather than on an interval — cheap, and it
+   * naturally fires exactly when a user comes back from the extension popup.
+   */
+  useEffect(() => {
+    const verifyConnection = async () => {
+      if (!store.isConnected) return;
+
+      // Only the raw kit lacks connection events. A registered provider
+      // (privy, smart-account-kit) manages its own session state, so skip it.
+      const registered = store.selectedWalletId
+        ? walletRegistry.get(store.selectedWalletId)
+        : undefined;
+      const usesStellarWalletsKit =
+        !registered || registered.id === "stellar-wallets-kit";
+      if (!usesStellarWalletsKit) return;
+
+      const kit = getWalletKit();
+      if (!kit) return;
+
+      try {
+        const [{ address }, { networkPassphrase }] = await Promise.all([
+          kit.getAddress(),
+          kit.getNetwork(),
+        ]);
+
+        const expectedPassphrase =
+          store.network === "mainnet"
+            ? WalletNetwork.PUBLIC
+            : WalletNetwork.TESTNET;
+
+        if (
+          address !== store.address ||
+          networkPassphrase !== expectedPassphrase
+        ) {
+          store.triggerReconnectionPrompt();
+        }
+      } catch {
+        store.triggerReconnectionPrompt();
+      }
+    };
+
+    window.addEventListener("focus", verifyConnection);
+    return () => window.removeEventListener("focus", verifyConnection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store.isConnected, store.selectedWalletId, store.address, store.network]);
+
+  /**
    * Legacy connect: opens the StellarWalletsKit modal.
    * Kept for backward compatibility with existing onClick={connect} usages.
    */
@@ -76,7 +126,10 @@ export const useWallet = () => {
             applyBalanceResult(result, store);
           } catch (error) {
             console.error("Error connecting wallet:", error);
-            store.reset();
+            // Same reasoning as connectWith(): don't wipe the reconnection
+            // banner via a full reset() when the (re)connect attempt itself
+            // is what failed.
+            store.resetSession();
           } finally {
             store.setIsConnecting(false);
           }
@@ -111,7 +164,10 @@ export const useWallet = () => {
         applyBalanceResult(result, store);
       } catch (error) {
         console.error("Error connecting wallet:", error);
-        store.reset();
+        // A partial reset only: a failed (re)connect attempt must not wipe
+        // isWalletDisconnected/pendingAction, or the reconnection banner the
+        // user is trying to act on would vanish along with the session.
+        store.resetSession();
         throw error;
       } finally {
         store.setIsConnecting(false);
@@ -149,10 +205,61 @@ export const useWallet = () => {
           "Connected wallet does not support transaction signing",
         );
       }
-      return provider.signTransaction(xdr, networkPassphrase);
+
+      const attempt = () => provider.signTransaction(xdr, networkPassphrase);
+
+      try {
+        return await attempt();
+      } catch (error) {
+        // The kit doesn't distinguish "user rejected" from "wallet gone" in
+        // its error shape, but either way the session can no longer sign, so
+        // surface the reconnection prompt instead of letting this fail silently
+        // on the next unrelated action. Queue the same call as the pending
+        // action so a successful reconnect can resume it automatically.
+        store.triggerReconnectionPrompt(attempt);
+        throw error;
+      }
     },
     [store],
   );
+
+  /**
+   * Re-invokes whichever connect path established the current session
+   * (registry provider vs. legacy raw-kit connect) using the id already saved
+   * in the store. Note: for the Stellar Wallets Kit this still opens its
+   * selection modal — the kit has no headless "resume session" API.
+   */
+  const reconnect = useCallback(async () => {
+    const provider = store.selectedWalletId
+      ? walletRegistry.get(store.selectedWalletId)
+      : undefined;
+
+    if (provider) {
+      await connectWith(provider.id);
+    } else {
+      await connect();
+    }
+
+    // The legacy connect() path resolves even when the user closes the
+    // wallet-selection modal without picking a wallet (onClosed doesn't
+    // reject). Read fresh state rather than the stale `store` closure to
+    // confirm a session actually came back before dismissing the prompt —
+    // otherwise a cancelled reconnect would silently hide its own banner.
+    const { isConnected, address, pendingAction } =
+      useAuthenticationStore.getState();
+    if (!isConnected || !address) return;
+
+    store.clearReconnectionPrompt();
+
+    if (pendingAction) {
+      try {
+        await pendingAction();
+      } catch (error) {
+        console.error("Error resuming pending action after reconnect:", error);
+        store.triggerReconnectionPrompt(pendingAction);
+      }
+    }
+  }, [store, connect, connectWith]);
 
   return {
     address: store.address,
@@ -161,12 +268,15 @@ export const useWallet = () => {
     balanceError: store.balanceError,
     isConnected: store.isConnected,
     isConnecting: store.isConnecting,
+    isWalletDisconnected: store.isWalletDisconnected,
     network: store.network,
     selectedWalletId: store.selectedWalletId,
     providers: walletRegistry.getAll(),
     connect,
     connectWith,
     disconnect,
+    reconnect,
+    dismissReconnectionPrompt: store.clearReconnectionPrompt,
     switchNetwork,
     refreshBalance,
     signTransaction,

--- a/apps/webapp/src/components/auth/store/data/@types/authentication.entity.ts
+++ b/apps/webapp/src/components/auth/store/data/@types/authentication.entity.ts
@@ -7,6 +7,10 @@ export interface WalletState {
   balanceError: string | null;
   isConnected: boolean;
   isConnecting: boolean;
+  /** True when a previously-connected wallet is found to be unavailable or on the wrong network (e.g. extension locked, session expired, network switched outside the app). */
+  isWalletDisconnected: boolean;
+  /** The wallet-dependent action that was in flight when the disconnection was detected, if any. Not persisted (functions aren't serializable). */
+  pendingAction: (() => Promise<unknown>) | null;
   selectedWalletId: string | null;
   network: "testnet" | "mainnet";
 }
@@ -20,6 +24,17 @@ export interface WalletActions {
   setIsConnecting: (isConnecting: boolean) => void;
   setSelectedWalletId: (walletId: string | null) => void;
   setNetwork: (network: "testnet" | "mainnet") => void;
+  setPendingAction: (action: (() => Promise<unknown>) | null) => void;
+  /**
+   * Marks the wallet as disconnected. When `action` is provided it is queued
+   * as the pending action to resume on a successful reconnect; when omitted,
+   * any already-queued pending action is left untouched (a passive focus-probe
+   * detection should never clobber an action queued by a failed sign attempt).
+   */
+  triggerReconnectionPrompt: (action?: () => Promise<unknown>) => void;
+  clearReconnectionPrompt: () => void;
+  /** Clears the current session (address/balance/connection identity) without touching the reconnection-prompt or pending-action state. Use this on a failed reconnect attempt instead of `reset()`. */
+  resetSession: () => void;
   reset: () => void;
 }
 

--- a/apps/webapp/src/components/auth/store/data/slices/authentication.slice.ts
+++ b/apps/webapp/src/components/auth/store/data/slices/authentication.slice.ts
@@ -9,6 +9,8 @@ const initialState = {
   balanceError: null,
   isConnected: false,
   isConnecting: false,
+  isWalletDisconnected: false,
+  pendingAction: null,
   selectedWalletId: null,
   network: "testnet" as const,
 };
@@ -25,6 +27,23 @@ export const useAuthenticationStore = create<AuthenticationStore>()(
       setIsConnecting: (isConnecting) => set({ isConnecting }),
       setSelectedWalletId: (walletId) => set({ selectedWalletId: walletId }),
       setNetwork: (network) => set({ network }),
+      setPendingAction: (action) => set({ pendingAction: action }),
+      triggerReconnectionPrompt: (action) =>
+        set((state) => ({
+          isWalletDisconnected: true,
+          pendingAction: action ?? state.pendingAction,
+        })),
+      clearReconnectionPrompt: () =>
+        set({ isWalletDisconnected: false, pendingAction: null }),
+      resetSession: () =>
+        set({
+          address: null,
+          balance: null,
+          balanceStatus: null,
+          balanceError: null,
+          isConnected: false,
+          selectedWalletId: null,
+        }),
       reset: () => set(initialState),
     }),
     {
@@ -74,6 +93,7 @@ export const useAuthenticationStore = create<AuthenticationStore>()(
       }),
       onRehydrateStorage: () => (state) => {
         state?.setIsConnecting(false);
+        state?.clearReconnectionPrompt();
       },
     },
   ),


### PR DESCRIPTION
Summary

Adds a global, non-blocking reconnection prompt that detects when a previously-connected Stellar wallet becomes unavailable or switches network mid-session, and automatically resumes the wallet action that was interrupted once the user reconnects.

Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

What Changed and Why

Detection
- `useWallet.hook.ts` probes the Stellar Wallets Kit on window focus (the kit exposes no `onAccountChange`/`onNetworkChange` subscription in the version we use), comparing the kit's live address/network against the store. A mismatch or a failed probe marks the wallet as disconnected.

UI
- New `WalletReconnectionPrompt.tsx`: a fixed bottom-right banner (`role="alert"`, `aria-live="assertive"`), mounted once in `Providers.tsx` so it has scope over every route. Shows a "Reconnect" action and a dismiss button; fully decoupled from `WalletProviderModal` and `useAuthenticationStore`'s internals — it only talks to the `useWallet()` hook.

State
- `authentication.entity.ts` / `authentication.slice.ts`: added `isWalletDisconnected` and `pendingAction` to the store, plus `triggerReconnectionPrompt(action?)`, `clearReconnectionPrompt()`, and `resetSession()`. Both new fields are excluded from persistence (`partialize`), so a stale disconnected flag or an unserializable function never survives a page reload.

Pending-action resume
- `signTransaction` now queues the failed sign attempt as `pendingAction` when it triggers the prompt. On a successful `reconnect()`, the queued action is replayed automatically; if it fails again, the prompt re-arms with the same action instead of losing it.

Correctness fixes found during review
- `reconnect()` no longer clears the banner unconditionally — it now checks fresh store state (`isConnected && address`) before dismissing, so cancelling the wallet-selection modal keeps the banner visible instead of silently hiding it.
- Added `resetSession()` (partial reset: session identity only) and use it instead of the full `reset()` on failed (re)connect attempts in both `connect()` and `connectWith()`. Previously a failed reconnect wiped `isWalletDisconnected` via `reset()`, hiding the error banner right when the user needed it most.

How to Test

1. Connect a wallet via the Stellar Wallets Kit (Freighter/Albedo) on testnet.
2. Lock the wallet extension or switch its network outside the app, then refocus the browser tab — the "Wallet disconnected" banner should appear bottom-right instead of the app failing silently on the next action.
3. Click Reconnect:
  - If you cancel the wallet-selection modal, the banner must stay visible.
  - If you complete reconnection, the banner should dismiss and any queued pending action should retry automatically.
4. Run the unit tests: `bun test src/components/auth/hooks/__tests__/useWallet.hook.test.ts` (covers both the hook's reconnect flow and the store's reconnection-state transitions).
5. `npx tsc --noEmit` and `npx eslint` on the changed files should be clean.

<img width="1920" height="1080" alt="AKKUEA-TESTPASS" src="https://github.com/user-attachments/assets/5aa2c205-6837-48b7-82bd-e8b715098077" />
<img width="1920" height="1080" alt="AKKUEA-banner" src="https://github.com/user-attachments/assets/e9f1d139-d181-47b7-b623-ae2a5642947e" />


Checklist

- [ ] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [x] No .env files or secrets are committed
- [x] Commit messages follow Conventional Commits (https://www.conventionalcommits.org/)

Related Issues

Closes #976