### PR TITLE
fix(contracts): replace panic!/expect() with Result in defi-rwa access module

### DIFF
--- a/apps/contracts/contracts/defi-rwa/src/access/admin.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/admin.rs
@@ -1,25 +1,30 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{contracterror, Address, Env};
 
 use crate::access::roles::{Role, RoleKey, RoleStorage};
 
-#[derive(Debug)]
-pub enum AdminError {
-    NotAdmin,
-    NotPendingAdmin,
-    AlreadyInitialized,
-    ZeroAddress,
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    NotAdmin = 1,
+    NotPendingAdmin = 2,
+    AlreadyInitialized = 3,
+    Unauthorized = 4,
+    ContractPaused = 5,
+    ContractNotPaused = 6,
 }
 
 pub struct AdminControl;
 
 impl AdminControl {
-    pub fn initialize(env: &Env, admin: &Address) {
+    pub fn initialize(env: &Env, admin: &Address) -> Result<(), ContractError> {
         if Self::is_initialized(env) {
-            panic!("Admin already initialized")
+            return Err(ContractError::AlreadyInitialized);
         }
 
         env.storage().instance().set(&RoleKey::Admin, admin);
         RoleStorage::grant_role(env, admin, &Role::Admin);
+        Ok(())
     }
 
     pub fn is_initialized(env: &Env) -> bool {
@@ -37,41 +42,47 @@ impl AdminControl {
         }
     }
 
-    pub fn require_admin(env: &Env, caller: &Address) {
+    pub fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
         if !Self::is_admin(env, caller) {
-            panic!("Caller not admin")
+            return Err(ContractError::NotAdmin);
         }
+        Ok(())
     }
 
-    pub fn transfer_admin_start(env: &Env, caller: &Address, new_admin: &Address) {
-        Self::require_admin(env, caller);
+    pub fn transfer_admin_start(
+        env: &Env,
+        caller: &Address,
+        new_admin: &Address,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(env, caller)?;
         env.storage()
             .instance()
             .set(&RoleKey::PendingAdmin, new_admin);
+        Ok(())
     }
 
-    pub fn transfer_admin_accept(env: &Env, new_admin: &Address) {
+    pub fn transfer_admin_accept(env: &Env, new_admin: &Address) -> Result<(), ContractError> {
         let pending: Option<Address> = env.storage().instance().get(&RoleKey::PendingAdmin);
 
         match pending {
-            Some(pending_admin) => {
-                if pending_admin == new_admin.clone() {
-                    if let Some(old_admin) = Self::get_admin(env) {
-                        RoleStorage::revoke_role(env, &old_admin, &Role::Admin);
-                    }
-
-                    env.storage().instance().set(&RoleKey::Admin, new_admin);
-                    RoleStorage::grant_role(env, new_admin, &Role::Admin);
-                    env.storage().instance().remove(&RoleKey::PendingAdmin);
+            Some(pending_admin) if pending_admin == new_admin.clone() => {
+                if let Some(old_admin) = Self::get_admin(env) {
+                    RoleStorage::revoke_role(env, &old_admin, &Role::Admin);
                 }
+
+                env.storage().instance().set(&RoleKey::Admin, new_admin);
+                RoleStorage::grant_role(env, new_admin, &Role::Admin);
+                env.storage().instance().remove(&RoleKey::PendingAdmin);
+                Ok(())
             }
-            _ => panic!("Caller is not pending admin"),
+            _ => Err(ContractError::NotPendingAdmin),
         }
     }
 
-    pub fn transfer_admin_cancel(env: &Env, caller: &Address) {
-        Self::require_admin(env, caller);
+    pub fn transfer_admin_cancel(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        Self::require_admin(env, caller)?;
         env.storage().instance().remove(&RoleKey::PendingAdmin);
+        Ok(())
     }
 
     pub fn get_pending_admin(env: &Env) -> Option<Address> {
@@ -97,32 +108,36 @@ impl PauseControl {
         is_admin || is_pauser || is_emergency_guard
     }
 
-    pub fn require_can_pause(env: &Env, address: &Address) {
-        let can_pause = Self::can_pause(env, address);
-        if !can_pause {
-            panic!("Caller does not have permission to pause")
+    pub fn require_can_pause(env: &Env, address: &Address) -> Result<(), ContractError> {
+        if !Self::can_pause(env, address) {
+            return Err(ContractError::Unauthorized);
         }
+        Ok(())
     }
 
-    pub fn pause(env: &Env, caller: &Address) {
-        Self::require_can_pause(env, caller);
+    pub fn pause(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        Self::require_can_pause(env, caller)?;
         env.storage().instance().set(&RoleKey::Paused, &true);
+        Ok(())
     }
 
-    pub fn unpause(env: &Env, caller: &Address) {
-        Self::require_can_pause(env, caller);
+    pub fn unpause(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        Self::require_can_pause(env, caller)?;
         env.storage().instance().remove(&RoleKey::Paused);
+        Ok(())
     }
 
-    pub fn require_paused(env: &Env) {
+    pub fn require_paused(env: &Env) -> Result<(), ContractError> {
         if !Self::is_paused(env) {
-            panic!("Contract not paused")
+            return Err(ContractError::ContractNotPaused);
         }
+        Ok(())
     }
 
-    pub fn require_not_paused(env: &Env) {
+    pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
         if Self::is_paused(env) {
-            panic!("Contract paused")
+            return Err(ContractError::ContractPaused);
         }
+        Ok(())
     }
 }

--- a/apps/contracts/contracts/defi-rwa/src/access/emergency.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/emergency.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{panic_with_error, Address, Env};
 
 use crate::access::admin::AdminControl;
 use crate::access::admin::PauseControl;
@@ -13,8 +13,8 @@ impl TimelockControl {
     }
 
     pub fn schedule_recovery(env: &Env, caller: &Address) {
-        AdminControl::require_admin(env, caller);
-        PauseControl::require_paused(env);
+        AdminControl::require_admin(env, caller).unwrap_or_else(|e| panic_with_error!(env, e));
+        PauseControl::require_paused(env).unwrap_or_else(|e| panic_with_error!(env, e));
 
         if Self::get_pending_recovery(env).is_some() {
             panic!("Recovery already scheduled");
@@ -39,7 +39,7 @@ impl TimelockControl {
     }
 
     pub fn cancel_recovery(env: &Env, caller: &Address) {
-        AdminControl::require_admin(env, caller);
+        AdminControl::require_admin(env, caller).unwrap_or_else(|e| panic_with_error!(env, e));
 
         if Self::get_pending_recovery(env).is_none() {
             panic!("No recovery scheduled");
@@ -51,7 +51,7 @@ impl TimelockControl {
     }
 
     pub fn execute_recovery(env: &Env, caller: &Address) {
-        AdminControl::require_admin(env, caller);
+        AdminControl::require_admin(env, caller).unwrap_or_else(|e| panic_with_error!(env, e));
 
         let record = Self::get_pending_recovery(env).expect("No recovery scheduled");
 

--- a/apps/contracts/contracts/defi-rwa/src/access/mod.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/mod.rs
@@ -2,29 +2,39 @@ pub mod admin;
 pub mod emergency;
 pub mod roles;
 
-pub use admin::{AdminControl, PauseControl};
+pub use admin::{AdminControl, ContractError, PauseControl};
 pub use emergency::TimelockControl;
 pub use roles::{PendingRecoveryData, Role, RoleStorage};
 
 use soroban_sdk::{Address, Env};
 
-pub fn require_role(env: &Env, caller: &Address, role: &Role) {
+pub fn require_role(env: &Env, caller: &Address, role: &Role) -> Result<(), ContractError> {
     if !RoleStorage::has_role(env, caller, role) {
-        panic!("Caller does not have required role");
+        return Err(ContractError::Unauthorized);
     }
+    Ok(())
 }
 
-pub fn require_admin_or_role(env: &Env, caller: &Address, role: &Role) {
+pub fn require_admin_or_role(
+    env: &Env,
+    caller: &Address,
+    role: &Role,
+) -> Result<(), ContractError> {
     let is_admin = AdminControl::is_admin(env, caller);
     let has_role = RoleStorage::has_role(env, caller, role);
 
     if !is_admin && !has_role {
-        panic!("Caller is not authorized")
+        return Err(ContractError::Unauthorized);
     }
+    Ok(())
 }
 
-pub fn require_active_and_authorized(env: &Env, address: &Address, role: Option<&Role>) {
-    PauseControl::require_not_paused(env);
+pub fn require_active_and_authorized(
+    env: &Env,
+    address: &Address,
+    role: Option<&Role>,
+) -> Result<(), ContractError> {
+    PauseControl::require_not_paused(env)?;
 
     match role {
         Some(r) => require_admin_or_role(env, address, r),

--- a/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -25,7 +25,7 @@ pub use events::*;
 pub use lending::*;
 pub use storage::*;
 
-use soroban_sdk::{contract, contractimpl, token, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env, String, Vec};
 
 // Internal imports
 use lending::events as lending_events;
@@ -146,7 +146,7 @@ impl PropertyTokenContract {
         amount: u64,
     ) {
         admin.require_auth();
-        AdminControl::require_admin(&env, &admin);
+        AdminControl::require_admin(&env, &admin).unwrap_or_else(|e| panic_with_error!(&env, e));
 
         if amount == 0 {
             panic!("Amount must be greater than zero");
@@ -222,7 +222,7 @@ impl PropertyTokenContract {
         payment_token: Address,
     ) {
         buyer.require_auth();
-        PauseControl::require_not_paused(&env);
+        PauseControl::require_not_paused(&env).unwrap_or_else(|e| panic_with_error!(&env, e));
 
         if amount == 0 {
             panic!("Amount must be positive");
@@ -547,7 +547,7 @@ impl PropertyTokenContract {
 
     pub fn set_oracle(env: Env, oracle_address: Address, caller: Address) {
         caller.require_auth();
-        AdminControl::require_admin(&env, &caller);
+        AdminControl::require_admin(&env, &caller).unwrap_or_else(|e| panic_with_error!(&env, e));
         PriceOracle::set_oracle_address(&env, &oracle_address);
     }
 
@@ -557,7 +557,7 @@ impl PropertyTokenContract {
     /// * `min_price` – minimum normalized price (floor). Set to 0 to disable.
     pub fn set_oracle_config(env: Env, caller: Address, max_age: u64, min_price: i128) {
         caller.require_auth();
-        AdminControl::require_admin(&env, &caller);
+        AdminControl::require_admin(&env, &caller).unwrap_or_else(|e| panic_with_error!(&env, e));
         if max_age > 0 {
             PriceOracle::set_max_age(&env, max_age);
         }
@@ -612,8 +612,9 @@ impl PropertyTokenContract {
 
     pub fn emergency_pause(env: Env, caller: Address) {
         caller.require_auth();
-        PauseControl::require_can_pause(&env, &caller);
-        PauseControl::pause(&env, &caller);
+        PauseControl::require_can_pause(&env, &caller)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
+        PauseControl::pause(&env, &caller).unwrap_or_else(|e| panic_with_error!(&env, e));
         EmergencyEvents::emergency_paused(&env, caller);
     }
 
@@ -634,13 +635,13 @@ impl PropertyTokenContract {
 
     pub fn grant_emergency_role(env: Env, admin: Address, target: Address) {
         admin.require_auth();
-        AdminControl::require_admin(&env, &admin);
+        AdminControl::require_admin(&env, &admin).unwrap_or_else(|e| panic_with_error!(&env, e));
         RoleStorage::grant_role(&env, &target, &Role::EmergencyGuard);
     }
 
     pub fn revoke_emergency_role(env: Env, admin: Address, target: Address) {
         admin.require_auth();
-        AdminControl::require_admin(&env, &admin);
+        AdminControl::require_admin(&env, &admin).unwrap_or_else(|e| panic_with_error!(&env, e));
         RoleStorage::revoke_role(&env, &target, &Role::EmergencyGuard);
     }
 }

--- a/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -1,4 +1,4 @@
-use super::access::{AdminControl, PauseControl};
+use super::access::{AdminControl, ContractError, PauseControl};
 use super::events::{LendingEvents, PropertyEvents};
 use super::lending::PriceOracle;
 use super::storage;
@@ -839,15 +839,15 @@ fn test_admin_initialization() {
 }
 
 #[test]
-#[should_panic(expected = "Caller not admin")]
+#[should_panic(expected = "NotAdmin")]
 fn test_require_admin_fails() {
     let (contract_id, env) = setup_internal();
     let admin = Address::generate(&env);
     let other = Address::generate(&env);
     // AdminControl::initialize(&env.as_contract(&contract_id, f), &admin);
     env.as_contract(&contract_id, || {
-        AdminControl::require_admin(&env, &admin);
-        AdminControl::require_admin(&env, &other);
+        let _ = AdminControl::require_admin(&env, &admin);
+        AdminControl::require_admin(&env, &other).unwrap();
     });
 }
 
@@ -862,16 +862,50 @@ fn test_admin_transfer() {
         RoleStorage::grant_role(&env, &admin, &Role::Admin);
 
         // Start transfer
-        AdminControl::transfer_admin_start(&env, &admin, &new_admin);
+        AdminControl::transfer_admin_start(&env, &admin, &new_admin).unwrap();
         assert_eq!(
             AdminControl::get_pending_admin(&env),
             Some(new_admin.clone())
         );
 
         // Accept transfer
-        AdminControl::transfer_admin_accept(&env, &new_admin);
+        AdminControl::transfer_admin_accept(&env, &new_admin).unwrap();
         assert!(AdminControl::is_admin(&env, &new_admin));
         assert!(!AdminControl::is_admin(&env, &admin));
+    });
+}
+
+#[test]
+fn test_admin_initialize_twice_fails() {
+    // The constructor already sets the admin during registration, so a
+    // subsequent call to `initialize` must be rejected.
+    let (contract_id, env) = setup_internal();
+    let other = Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        assert!(AdminControl::is_initialized(&env));
+        assert_eq!(
+            AdminControl::initialize(&env, &other),
+            Err(ContractError::AlreadyInitialized)
+        );
+    });
+}
+
+#[test]
+fn test_transfer_admin_accept_wrong_caller_fails() {
+    let (contract_id, env) = setup_internal();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        use super::access::roles::{Role, RoleKey, RoleStorage};
+        env.storage().instance().set(&RoleKey::Admin, &admin);
+        RoleStorage::grant_role(&env, &admin, &Role::Admin);
+
+        AdminControl::transfer_admin_start(&env, &admin, &new_admin).unwrap();
+        assert_eq!(
+            AdminControl::transfer_admin_accept(&env, &stranger),
+            Err(ContractError::NotPendingAdmin)
+        );
     });
 }
 
@@ -884,9 +918,9 @@ fn test_pause_unpause() {
         env.storage().instance().set(&RoleKey::Admin, &admin);
         RoleStorage::grant_role(&env, &admin, &Role::Admin);
         assert!(!PauseControl::is_paused(&env));
-        PauseControl::pause(&env, &admin);
+        PauseControl::pause(&env, &admin).unwrap();
         assert!(PauseControl::is_paused(&env));
-        PauseControl::unpause(&env, &admin);
+        PauseControl::unpause(&env, &admin).unwrap();
         assert!(!PauseControl::is_paused(&env));
     });
 }
@@ -1916,7 +1950,7 @@ fn test_purchase_unverified_property() {
 }
 
 #[test]
-#[should_panic(expected = "Contract paused")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_purchase_when_contract_paused() {
     let (contract_id, env, _property_owner, buyer, payment_token, property_id) =
         setup_purchase_test();
@@ -1925,7 +1959,7 @@ fn test_purchase_when_contract_paused() {
 
     // Pause contract
     env.as_contract(&contract_id, || {
-        PauseControl::pause(&env, &admin);
+        PauseControl::pause(&env, &admin).unwrap();
     });
 
     // Attempt purchase
@@ -1975,7 +2009,7 @@ fn test_mint_and_query_balance() {
 }
 
 #[test]
-#[should_panic(expected = "Caller not admin")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_unauthorized_mint_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2659,14 +2693,14 @@ fn test_borrow_with_zero_oracle_price() {
 }
 
 #[test]
-#[should_panic(expected = "Contract paused")]
+#[should_panic(expected = "ContractPaused")]
 fn test_emergency_pause_blocks_operations() {
     let s = setup();
 
     s.contract_client.emergency_pause(&s.admin);
 
     s.env.as_contract(&s.contract_address, || {
-        PauseControl::require_not_paused(&s.env);
+        PauseControl::require_not_paused(&s.env).unwrap();
     });
 }
 
@@ -2702,7 +2736,7 @@ fn test_recovery_succeeds_after_timelock() {
 }
 
 #[test]
-#[should_panic(expected = "Contract not paused")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_schedule_recovery_requires_paused() {
     let s = setup();
     s.contract_client.schedule_recovery(&s.admin);
@@ -2739,7 +2773,7 @@ fn test_cancel_no_recovery_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Caller does not have permission to pause")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_unauthorized_cannot_emergency_pause() {
     let s = setup();
     let attacker = Address::generate(&s.env);
@@ -2747,7 +2781,7 @@ fn test_unauthorized_cannot_emergency_pause() {
 }
 
 #[test]
-#[should_panic(expected = "Caller not admin")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_unauthorized_cannot_schedule_recovery() {
     let s = setup();
     let attacker = Address::generate(&s.env);
@@ -2756,7 +2790,7 @@ fn test_unauthorized_cannot_schedule_recovery() {
 }
 
 #[test]
-#[should_panic(expected = "Caller not admin")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_unauthorized_cannot_execute_recovery() {
     let s = setup();
     let attacker = Address::generate(&s.env);
@@ -2764,7 +2798,7 @@ fn test_unauthorized_cannot_execute_recovery() {
 }
 
 #[test]
-#[should_panic(expected = "Caller not admin")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_unauthorized_cannot_cancel_recovery() {
     let s = setup();
     let attacker = Address::generate(&s.env);
@@ -2772,7 +2806,7 @@ fn test_unauthorized_cannot_cancel_recovery() {
 }
 
 #[test]
-#[should_panic(expected = "Caller not admin")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_non_admin_cannot_grant_emergency_role() {
     let s = setup();
     let non_admin = Address::generate(&s.env);
@@ -2781,7 +2815,7 @@ fn test_non_admin_cannot_grant_emergency_role() {
 }
 
 #[test]
-#[should_panic(expected = "Caller does not have permission to pause")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_revoked_emergency_guard_cannot_pause() {
     let s = setup();
     let guard = Address::generate(&s.env);

--- a/apps/contracts/contracts/game-property-nft/src/test.rs
+++ b/apps/contracts/contracts/game-property-nft/src/test.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 use crate::{GamePropertyNft, GamePropertyNftClient, NftError, TOTAL_TILES};


### PR DESCRIPTION
## Summary

Replaces `panic!`/`expect()` calls in `defi-rwa`'s `access/admin.rs` and `access/mod.rs` with a `ContractError` enum returned via `Result<T, ContractError>`, so failures surface as readable error codes on Soroban instead of unrecoverable, opaque aborts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

- Added a `#[contracterror] ContractError` enum (`NotAdmin`, `NotPendingAdmin`, `AlreadyInitialized`, `Unauthorized`, `ContractPaused`, `ContractNotPaused`) in `access/admin.rs`, re-exported from `access/mod.rs`.
- Converted `AdminControl::{initialize, require_admin, transfer_admin_start, transfer_admin_accept, transfer_admin_cancel}` and `PauseControl::{require_can_pause, pause, unpause, require_paused, require_not_paused}` in `access/admin.rs` to return `Result<(), ContractError>` instead of panicking.
- Converted `require_role`, `require_admin_or_role`, `require_active_and_authorized` in `access/mod.rs` to return `Result<(), ContractError>`.
- Updated callers in `access/emergency.rs` and `lib.rs` (outside the scope of this issue) to convert the `Result` into a proper Soroban error via `panic_with_error!`, so the contract-level abort still carries a readable error code instead of a bare string.
- Updated existing tests whose expectations depended on panic message strings, and added two new tests covering the previously-uncovered `AlreadyInitialized` and `NotPendingAdmin` error codes.

## How to Test

1. `cd apps/contracts`
2. `cargo test -p rwa-defi-contract`
3. `cargo clippy -p rwa-defi-contract --all-targets -- -D warnings`

## Checklist

- [x] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [x] No `.env` files or secrets are committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Closes #979