### PR TITLE
feat: unify loading/error/empty states across property detail and marketplace pages

### DIFF
--- a/apps/api/src/routes/ledger.ts
+++ b/apps/api/src/routes/ledger.ts
@@ -78,8 +78,8 @@ export const ledgerRoutes = new Elysia({ prefix: '/api/ledger' }).get(
 
     const signal = (request as Request & { signal?: AbortSignal }).signal;
 
-    return new ReadableStream({
-      start(controller) {
+    return new ReadableStream<Uint8Array>({
+      start(controller: ReadableStreamDefaultController<Uint8Array>) {
         let closed = false;
 
         const close = () => {

--- a/apps/webapp/src/app/marketplace/page.tsx
+++ b/apps/webapp/src/app/marketplace/page.tsx
@@ -4,10 +4,8 @@ import { useMemo, useState } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-  AlertCircle,
   Building2,
   MapPin,
-  RefreshCw,
   Search,
   ShieldCheck,
   SlidersHorizontal,
@@ -33,9 +31,11 @@ import {
   Badge,
   Button,
   Card,
+  EmptyState,
   ErrorBoundary,
   FreshnessIndicator,
   Input,
+  SectionErrorFallback,
   SkeletonPropertyCard,
 } from "@/components/ui";
 import {
@@ -55,59 +55,6 @@ function PropertyGridSkeleton() {
         </motion.div>
       ))}
     </>
-  );
-}
-
-interface ErrorStateProps {
-  error: string;
-  onRetry: () => Promise<void>;
-}
-
-function ErrorState({ error, onRetry }: ErrorStateProps) {
-  return (
-    <motion.div
-      variants={staggerItem}
-      className="rounded-2xl border border-red-500/30 bg-red-500/10 p-8 text-center"
-    >
-      <AlertCircle className="mx-auto mb-4 h-12 w-12 text-red-300" />
-      <h2 className="mb-2 text-lg font-semibold text-white">
-        Could not load the marketplace
-      </h2>
-      <p className="mx-auto mb-6 max-w-xl text-sm text-red-100/80">{error}</p>
-      <Button
-        variant="accent"
-        onClick={() => void onRetry()}
-        leftIcon={<RefreshCw className="h-4 w-4" />}
-      >
-        Retry
-      </Button>
-    </motion.div>
-  );
-}
-
-interface EmptyStateProps {
-  hasActiveFilters: boolean;
-  onClearFilters: () => void;
-}
-
-function EmptyState({ hasActiveFilters, onClearFilters }: EmptyStateProps) {
-  return (
-    <motion.div variants={staggerItem} className="py-16 text-center">
-      <Building2 className="mx-auto mb-4 h-16 w-16 text-neutral-700" />
-      <h3 className="mb-2 text-lg font-semibold text-white">
-        No properties found
-      </h3>
-      <p className="text-sm text-neutral-500">
-        {hasActiveFilters
-          ? "No properties match your search or filters."
-          : "There are no properties listed yet."}
-      </p>
-      {hasActiveFilters && (
-        <Button variant="outline" className="mt-6" onClick={onClearFilters}>
-          Clear filters
-        </Button>
-      )}
-    </motion.div>
   );
 }
 
@@ -431,7 +378,12 @@ export default function MarketplacePage() {
             </motion.div>
 
             {error ? (
-              <ErrorState error={error} onRetry={refetch} />
+              <motion.div variants={staggerItem}>
+                <SectionErrorFallback
+                  message="Could not load the marketplace"
+                  onReset={() => void refetch()}
+                />
+              </motion.div>
             ) : (
               <>
                 <motion.div
@@ -452,10 +404,30 @@ export default function MarketplacePage() {
                 </motion.div>
 
                 {!isLoading && filteredProperties.length === 0 && (
-                  <EmptyState
-                    hasActiveFilters={hasActiveFilters}
-                    onClearFilters={clearFilters}
-                  />
+                  <motion.div variants={staggerItem}>
+                    <EmptyState
+                      title="No properties found"
+                      description={
+                        hasActiveFilters
+                          ? "No properties match your search or filters."
+                          : "There are no properties listed yet."
+                      }
+                      icon={
+                        <Building2
+                          className="w-5 h-5 text-neutral-500"
+                          aria-hidden="true"
+                        />
+                      }
+                      action={
+                        hasActiveFilters
+                          ? {
+                              label: "Clear filters",
+                              onClick: clearFilters,
+                            }
+                          : undefined
+                      }
+                    />
+                  </motion.div>
                 )}
               </>
             )}

--- a/apps/webapp/src/app/properties/[id]/page.test.tsx
+++ b/apps/webapp/src/app/properties/[id]/page.test.tsx
@@ -1,0 +1,252 @@
+/* eslint-disable @next/next/no-img-element, @typescript-eslint/no-unused-vars */
+import "@/test/setup-dom";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  HTMLAttributes as SpanHTMLAttributes,
+  ImgHTMLAttributes,
+  ReactNode,
+} from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import type { PropertyInfo } from "@real-estate-defi/shared";
+import { propertyApi } from "@/services/api/properties";
+
+const PROPERTY_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+const mockGetById = mock<() => Promise<PropertyInfo | null>>(() =>
+  Promise.resolve(null),
+);
+const connectMock = mock(() => Promise.resolve());
+const pushMock = mock(() => {});
+const originalGetById = propertyApi.getById;
+
+mock.module("next/image", () => ({
+  default: ({
+    fill: _fill,
+    priority: _priority,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    priority?: boolean;
+  }) => <img {...props} alt={props.alt ?? ""} />,
+}));
+
+mock.module("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: HTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+mock.module("next/navigation", () => ({
+  useParams: () => ({ id: PROPERTY_ID }),
+  useRouter: () => ({
+    push: pushMock,
+    replace: mock(() => {}),
+    prefetch: mock(() => {}),
+    back: mock(() => {}),
+  }),
+}));
+
+mock.module("framer-motion", () => {
+  const passthroughDiv = ({
+    children,
+    whileHover: _whileHover,
+    whileTap: _whileTap,
+    initial: _initial,
+    animate: _animate,
+    exit: _exit,
+    transition: _transition,
+    variants: _variants,
+    ...props
+  }: HTMLAttributes<HTMLDivElement> & Record<string, unknown>) => (
+    <div {...props}>{children}</div>
+  );
+  const passthroughButton = ({
+    children,
+    whileHover: _whileHover,
+    whileTap: _whileTap,
+    initial: _initial,
+    animate: _animate,
+    exit: _exit,
+    transition: _transition,
+    variants: _variants,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  );
+  const passthroughSpan = ({
+    children,
+    whileHover: _whileHover,
+    whileTap: _whileTap,
+    initial: _initial,
+    animate: _animate,
+    exit: _exit,
+    transition: _transition,
+    variants: _variants,
+    ...props
+  }: SpanHTMLAttributes<HTMLSpanElement> & Record<string, unknown>) => (
+    <span {...props}>{children}</span>
+  );
+
+  return {
+    AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+    motion: new Proxy(
+      {
+        div: passthroughDiv,
+        button: passthroughButton,
+        span: passthroughSpan,
+      },
+      {
+        get: (target, property) =>
+          property in target
+            ? target[property as keyof typeof target]
+            : passthroughDiv,
+      },
+    ),
+  };
+});
+
+mock.module("@/components/layout", () => ({
+  Navbar: () => <div>Navbar</div>,
+  Footer: () => <div>Footer</div>,
+}));
+
+mock.module("@/components/auth/hooks", () => ({
+  useWallet: () => ({
+    isConnected: true,
+    connect: connectMock,
+    isConnecting: false,
+    address: "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU",
+  }),
+}));
+
+mock.module("@/components/property", () => ({
+  PropertyDetail: ({ property }: { property: PropertyInfo }) => (
+    <div>
+      <h2>{property.name}</h2>
+      <p>{property.description}</p>
+    </div>
+  ),
+}));
+
+mock.module("@/components/marketplace/InvestModal", () => ({
+  InvestModal: () => null,
+}));
+
+const { default: PropertyPage } = await import("./page");
+
+const property: PropertyInfo = {
+  id: PROPERTY_ID,
+  name: "Lagos Marina Towers",
+  description: "Premium residential asset with audited legal documentation.",
+  propertyType: "residential",
+  location: {
+    address: "1 Marina Road",
+    city: "Lagos",
+    country: "Nigeria",
+  },
+  totalValue: "2500000",
+  tokenAddress: "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU",
+  totalShares: 25000,
+  availableShares: 6250,
+  pricePerShare: "100",
+  images: ["https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=800"],
+  documents: [],
+  verified: true,
+  listedAt: "2026-03-20T00:00:00Z",
+  owner: "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU",
+};
+
+describe("PropertyPage", () => {
+  beforeEach(() => {
+    cleanup();
+    propertyApi.getById = mockGetById as typeof propertyApi.getById;
+    mockGetById.mockReset();
+    mockGetById.mockImplementation(() => Promise.resolve(property));
+    connectMock.mockClear();
+    pushMock.mockClear();
+  });
+
+  afterAll(() => {
+    propertyApi.getById = originalGetById;
+  });
+
+  it("renders loading state before showing the property", async () => {
+    let resolveRequest: ((value: PropertyInfo) => void) | null = null;
+    mockGetById.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    const view = render(<PropertyPage />);
+
+    expect(view.getByLabelText(/Loading property/i)).not.toBeNull();
+
+    await waitFor(() => expect(mockGetById).toHaveBeenCalled());
+
+    await act(async () => {
+      resolveRequest?.(property);
+    });
+
+    await waitFor(() => {
+      expect(view.queryByText(property.name)).not.toBeNull();
+    });
+  });
+
+  it("renders an error state with retry when the API request fails", async () => {
+    mockGetById
+      .mockImplementationOnce(() =>
+        Promise.reject(new Error("Property unavailable")),
+      )
+      .mockResolvedValueOnce(property);
+
+    const view = render(<PropertyPage />);
+
+    expect(await view.findByText(/Property unavailable/i)).not.toBeNull();
+    fireEvent.click(view.getByRole("button", { name: /Retry/i }));
+
+    await waitFor(() => {
+      expect(mockGetById).toHaveBeenCalledTimes(2);
+      expect(view.queryByText(property.name)).not.toBeNull();
+    });
+  });
+
+  it("renders empty state when the property is not found", async () => {
+    mockGetById.mockResolvedValueOnce(null as unknown as PropertyInfo);
+
+    const view = render(<PropertyPage />);
+
+    expect(await view.findByText(/Property not found/i)).not.toBeNull();
+    expect(
+      view.getByText(/This property does not exist or is no longer available/i),
+    ).not.toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: /Browse marketplace/i }));
+    expect(pushMock).toHaveBeenCalledWith("/marketplace");
+  });
+
+  it("renders the property on success", async () => {
+    mockGetById.mockResolvedValueOnce(property);
+
+    const view = render(<PropertyPage />);
+
+    expect(await view.findByText(property.name)).not.toBeNull();
+    expect(view.queryByText(property.description)).not.toBeNull();
+    expect(view.queryByLabelText(/Loading property/i)).toBeNull();
+  });
+});

--- a/apps/webapp/src/app/properties/[id]/page.tsx
+++ b/apps/webapp/src/app/properties/[id]/page.tsx
@@ -1,58 +1,49 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
-import type { PropertyInfo } from "@real-estate-defi/shared";
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
 import { PropertyDetail } from "@/components/property";
 import { InvestModal } from "@/components/marketplace/InvestModal";
 import { Footer, Navbar } from "@/components/layout";
-import { Button, Card } from "@/components/ui";
+import {
+  Button,
+  Card,
+  EmptyState,
+  SectionErrorFallback,
+} from "@/components/ui";
 import { useWallet } from "@/components/auth/hooks";
+import { useAsyncState } from "@/hooks/useAsyncState";
 import { propertyApi } from "@/services/api/properties";
-import { AlertCircle, ChevronLeft, RefreshCw } from "lucide-react";
+import { Building2, ChevronLeft } from "lucide-react";
 import Link from "next/link";
 
 export default function PropertyPage() {
   const params = useParams();
+  const router = useRouter();
   const propertyId = params.id as string;
   const { isConnected, connect, address } = useWallet();
-  const [property, setProperty] = useState<PropertyInfo | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [isInvestModalOpen, setIsInvestModalOpen] = useState(false);
 
+  const fetchProperty = useCallback(
+    () => propertyApi.getById(propertyId),
+    [propertyId],
+  );
+
+  const {
+    data: property,
+    isLoading,
+    isError,
+    isEmpty,
+    error,
+    execute,
+    retry,
+  } = useAsyncState(fetchProperty, {
+    isEmpty: (data) => data == null,
+  });
+
   useEffect(() => {
-    const loadProperty = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        const data = await propertyApi.getById(propertyId);
-        setProperty(data);
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to load property",
-        );
-        setProperty(null);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    loadProperty();
-  }, [propertyId]);
-
-  const handleRetry = async () => {
-    try {
-      setIsLoading(true);
-      setError(null);
-      const data = await propertyApi.getById(propertyId);
-      setProperty(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load property");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    void execute();
+  }, [execute]);
 
   return (
     <div className="min-h-screen flex flex-col bg-[#0a0a0a] text-white">
@@ -60,7 +51,6 @@ export default function PropertyPage() {
 
       <main className="flex-1">
         <div className="container mx-auto max-w-4xl px-4 py-8">
-          {/* Back Button */}
           <Link href="/marketplace">
             <Button variant="ghost" className="mb-6 gap-2">
               <ChevronLeft className="h-4 w-4" />
@@ -69,7 +59,11 @@ export default function PropertyPage() {
           </Link>
 
           {isLoading && (
-            <div className="space-y-6">
+            <div
+              className="space-y-6"
+              aria-busy="true"
+              aria-label="Loading property"
+            >
               <Card className="h-96 animate-pulse bg-[#1a1a1a]" />
               <div className="space-y-3">
                 <div className="h-8 w-1/3 animate-pulse rounded bg-[#1a1a1a]" />
@@ -78,23 +72,31 @@ export default function PropertyPage() {
             </div>
           )}
 
-          {error && !isLoading && (
-            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-6">
-              <div className="mb-4 flex items-center gap-3">
-                <AlertCircle className="h-5 w-5 text-red-400" />
-                <h3 className="font-semibold text-red-200">
-                  Error Loading Property
-                </h3>
-              </div>
-              <p className="mb-4 text-sm text-red-100/80">{error}</p>
-              <Button onClick={handleRetry} variant="ghost" className="gap-2">
-                <RefreshCw className="h-4 w-4" />
-                Try Again
-              </Button>
-            </div>
+          {isError && !isLoading && (
+            <SectionErrorFallback
+              message={error ?? "Error Loading Property"}
+              onReset={() => void retry()}
+            />
           )}
 
-          {property && !isLoading && (
+          {isEmpty && !isLoading && (
+            <EmptyState
+              title="Property not found"
+              description="This property does not exist or is no longer available."
+              icon={
+                <Building2
+                  className="w-5 h-5 text-neutral-500"
+                  aria-hidden="true"
+                />
+              }
+              action={{
+                label: "Browse marketplace",
+                onClick: () => router.push("/marketplace"),
+              }}
+            />
+          )}
+
+          {property && !isLoading && !isEmpty && (
             <div>
               <PropertyDetail
                 property={property}
@@ -107,7 +109,7 @@ export default function PropertyPage() {
 
       <Footer />
 
-      {property && (
+      {property && !isEmpty && (
         <InvestModal
           property={property}
           isOpen={isInvestModalOpen}
@@ -123,7 +125,7 @@ export default function PropertyPage() {
           }}
           onInvestmentSuccess={() => {
             setIsInvestModalOpen(false);
-            handleRetry();
+            void retry();
           }}
         />
       )}

--- a/apps/webapp/src/components/ui/EmptyState.tsx
+++ b/apps/webapp/src/components/ui/EmptyState.tsx
@@ -1,0 +1,44 @@
+// apps/webapp/src/components/ui/EmptyState.tsx
+"use client";
+
+import type { ReactNode } from "react";
+import { Inbox } from "lucide-react";
+import { Card } from "./Card";
+import { Button } from "./Button";
+
+interface EmptyStateProps {
+  /** Defaults to a generic "Nothing here yet" message. */
+  title?: string;
+  description?: string;
+  icon?: ReactNode;
+  /** Optional action, e.g. "Clear filters". Omit for pages with no recovery action. */
+  action?: { label: string; onClick: () => void };
+}
+
+export function EmptyState({
+  title = "Nothing here yet",
+  description,
+  icon,
+  action,
+}: EmptyStateProps) {
+  return (
+    <Card variant="bordered" className="py-12">
+      <div className="flex flex-col items-center justify-center text-center space-y-4">
+        <div className="w-10 h-10 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center">
+          {icon ?? <Inbox className="w-5 h-5 text-neutral-500" aria-hidden="true" />}
+        </div>
+        <div>
+          <p className="text-sm font-medium text-white">{title}</p>
+          {description && (
+            <p className="text-xs text-neutral-500 mt-1">{description}</p>
+          )}
+        </div>
+        {action && (
+          <Button variant="outline" size="sm" onClick={action.onClick}>
+            {action.label}
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/webapp/src/components/ui/EmptyState.tsx
+++ b/apps/webapp/src/components/ui/EmptyState.tsx
@@ -25,7 +25,9 @@ export function EmptyState({
     <Card variant="bordered" className="py-12">
       <div className="flex flex-col items-center justify-center text-center space-y-4">
         <div className="w-10 h-10 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center">
-          {icon ?? <Inbox className="w-5 h-5 text-neutral-500" aria-hidden="true" />}
+          {icon ?? (
+            <Inbox className="w-5 h-5 text-neutral-500" aria-hidden="true" />
+          )}
         </div>
         <div>
           <p className="text-sm font-medium text-white">{title}</p>

--- a/apps/webapp/src/components/ui/EmptyState.tsx
+++ b/apps/webapp/src/components/ui/EmptyState.tsx
@@ -1,4 +1,3 @@
-// apps/webapp/src/components/ui/EmptyState.tsx
 "use client";
 
 import type { ReactNode } from "react";

--- a/apps/webapp/src/components/ui/index.ts
+++ b/apps/webapp/src/components/ui/index.ts
@@ -8,6 +8,7 @@ export * from "./Toggle";
 export * from "./Stepper";
 export * from "./FreshnessIndicator";
 export { ErrorBoundary } from "./ErrorBoundary";
+export { EmptyState } from "./EmptyState";
 export { PageErrorFallback } from "./PageErrorFallback";
 export { SectionErrorFallback } from "./SectionErrorFallback";
 export {

--- a/apps/webapp/src/hooks/useAsyncState.ts
+++ b/apps/webapp/src/hooks/useAsyncState.ts
@@ -1,0 +1,90 @@
+// apps/webapp/src/hooks/useAsyncState.ts
+"use client";
+
+import { useCallback, useState } from "react";
+
+export type AsyncStatus = "idle" | "loading" | "success" | "error";
+
+interface UseAsyncStateOptions<T> {
+  /** Given successfully-loaded data, is it "empty" for UI purposes? */
+  isEmpty?: (data: T) => boolean;
+}
+
+interface UseAsyncStateResult<T> {
+  status: AsyncStatus;
+  data: T | null;
+  error: string | null;
+  isLoading: boolean;
+  isError: boolean;
+  isEmpty: boolean;
+  isSuccess: boolean;
+  /** Run the async function. Callers decide when (mount, param change, retry click). */
+  execute: () => Promise<T | undefined>;
+  /** Alias for execute — reads better at retry call sites. */
+  retry: () => Promise<T | undefined>;
+  /** Push new data in directly (e.g. from a live-update stream) without a loading flash. */
+  setData: (updater: T | ((prev: T | null) => T)) => void;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return "Something went wrong. Please try again.";
+}
+
+export function useAsyncState<T>(
+  asyncFn: () => Promise<T>,
+  options: UseAsyncStateOptions<T> = {},
+): UseAsyncStateResult<T> {
+  const { isEmpty: isEmptyFn } = options;
+  const [status, setStatus] = useState<AsyncStatus>("idle");
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Depends on asyncFn's identity so callers whose fetcher changes (e.g. a
+  // route param changes) get a fresh `execute` — see property detail page.
+  const execute = useCallback(async () => {
+    setStatus("loading");
+    setError(null);
+    try {
+      const result = await asyncFn();
+      setData(result);
+      setStatus("success");
+      return result;
+    } catch (err) {
+      setError(getErrorMessage(err));
+      setStatus("error");
+      return undefined;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asyncFn]);
+
+  const setDataDirectly = useCallback(
+    (updater: T | ((prev: T | null) => T)) => {
+      setData((prev) =>
+        typeof updater === "function"
+          ? (updater as (prev: T | null) => T)(prev)
+          : updater,
+      );
+      setStatus("success");
+    },
+    [],
+  );
+
+  const isEmptyResult =
+    status === "success" && data !== null && isEmptyFn ? isEmptyFn(data) : false;
+
+  return {
+    status,
+    data,
+    error,
+    isLoading: status === "idle" || status === "loading",
+    isError: status === "error",
+    isEmpty: isEmptyResult,
+    isSuccess: status === "success" && !isEmptyResult,
+    execute,
+    retry: execute,
+    setData: setDataDirectly,
+  };
+}

--- a/apps/webapp/src/hooks/useAsyncState.ts
+++ b/apps/webapp/src/hooks/useAsyncState.ts
@@ -1,13 +1,12 @@
-// apps/webapp/src/hooks/useAsyncState.ts
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 export type AsyncStatus = "idle" | "loading" | "success" | "error";
 
 interface UseAsyncStateOptions<T> {
   /** Given successfully-loaded data, is it "empty" for UI purposes? */
-  isEmpty?: (data: T) => boolean;
+  isEmpty?: (data: T | null) => boolean;
 }
 
 interface UseAsyncStateResult<T> {
@@ -41,23 +40,30 @@ export function useAsyncState<T>(
   const [status, setStatus] = useState<AsyncStatus>("idle");
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
 
   // Depends on asyncFn's identity so callers whose fetcher changes (e.g. a
   // route param changes) get a fresh `execute` — see property detail page.
   const execute = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setStatus("loading");
     setError(null);
     try {
       const result = await asyncFn();
+      if (requestId !== requestIdRef.current) {
+        return undefined;
+      }
       setData(result);
       setStatus("success");
       return result;
     } catch (err) {
+      if (requestId !== requestIdRef.current) {
+        return undefined;
+      }
       setError(getErrorMessage(err));
       setStatus("error");
       return undefined;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [asyncFn]);
 
   const setDataDirectly = useCallback(
@@ -73,9 +79,7 @@ export function useAsyncState<T>(
   );
 
   const isEmptyResult =
-    status === "success" && data !== null && isEmptyFn
-      ? isEmptyFn(data)
-      : false;
+    status === "success" && (isEmptyFn ? isEmptyFn(data) : false);
 
   return {
     status,

--- a/apps/webapp/src/hooks/useAsyncState.ts
+++ b/apps/webapp/src/hooks/useAsyncState.ts
@@ -73,7 +73,9 @@ export function useAsyncState<T>(
   );
 
   const isEmptyResult =
-    status === "success" && data !== null && isEmptyFn ? isEmptyFn(data) : false;
+    status === "success" && data !== null && isEmptyFn
+      ? isEmptyFn(data)
+      : false;
 
   return {
     status,

--- a/apps/webapp/src/hooks/useProperties.ts
+++ b/apps/webapp/src/hooks/useProperties.ts
@@ -32,13 +32,21 @@ export function useProperties(
   const { enableLiveUpdates = true, pollingInterval = 30000 } = options;
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
-  const fetchProperties = useCallback(
-    () => propertyApi.getAll({ limit: 100 }).then((res) => res.data),
-    [],
-  );
+  const fetchProperties = useCallback(async () => {
+    const response = await propertyApi.getAll({ limit: 100 });
+    setLastUpdatedAt(new Date());
+    return response.data;
+  }, []);
 
-  const asyncState = useAsyncState(fetchProperties, {
-    isEmpty: (data) => data.length === 0,
+  const {
+    data,
+    error,
+    isLoading,
+    execute,
+    retry,
+    setData,
+  } = useAsyncState(fetchProperties, {
+    isEmpty: (loaded) => !loaded || loaded.length === 0,
   });
 
   const { connectionStatus, isPolling, refresh } = useLiveUpdates(
@@ -46,34 +54,27 @@ export function useProperties(
     {
       endpoint: SSE_ENDPOINT,
       pollingInterval,
-      enabled: enableLiveUpdates && !asyncState.isLoading,
+      enabled: enableLiveUpdates && !isLoading,
       onUpdate: (updatedProperties) => {
-        asyncState.setData(updatedProperties);
+        setData(updatedProperties);
         setLastUpdatedAt(new Date());
       },
     },
   );
 
   useEffect(() => {
-    void asyncState.execute();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asyncState.execute]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (asyncState.status === "success") setLastUpdatedAt(new Date());
-  }, [asyncState.status]);
+    void execute();
+  }, [execute]);
 
   const refetch = useCallback(async () => {
-    await asyncState.retry();
+    await retry();
     refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asyncState.retry, refresh]);
+  }, [retry, refresh]);
 
   return {
-    properties: asyncState.data ?? [],
-    isLoading: asyncState.isLoading,
-    error: asyncState.error,
+    properties: data ?? [],
+    isLoading,
+    error,
     refetch,
     connectionStatus,
     lastUpdatedAt,

--- a/apps/webapp/src/hooks/useProperties.ts
+++ b/apps/webapp/src/hooks/useProperties.ts
@@ -38,16 +38,12 @@ export function useProperties(
     return response.data;
   }, []);
 
-  const {
-    data,
-    error,
-    isLoading,
-    execute,
-    retry,
-    setData,
-  } = useAsyncState(fetchProperties, {
-    isEmpty: (loaded) => !loaded || loaded.length === 0,
-  });
+  const { data, error, isLoading, execute, retry, setData } = useAsyncState(
+    fetchProperties,
+    {
+      isEmpty: (loaded) => !loaded || loaded.length === 0,
+    },
+  );
 
   const { connectionStatus, isPolling, refresh } = useLiveUpdates(
     async () => (await propertyApi.getAll({ limit: 100 })).data,

--- a/apps/webapp/src/hooks/useProperties.ts
+++ b/apps/webapp/src/hooks/useProperties.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { PropertyInfo } from "@real-estate-defi/shared";
 import { propertyApi } from "@/services/api/properties";
 import { useLiveUpdates, type ConnectionStatus } from "@/hooks/useLiveUpdates";
+import { useAsyncState } from "@/hooks/useAsyncState";
 
 interface UsePropertiesOptions {
   enableLiveUpdates?: boolean;
@@ -20,14 +21,6 @@ interface UsePropertiesResult {
   isPolling: boolean;
 }
 
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-
-  return "We couldn't load marketplace properties. Please try again.";
-}
-
 const SSE_ENDPOINT =
   typeof process !== "undefined"
     ? process.env?.NEXT_PUBLIC_PROPERTIES_SSE_URL
@@ -37,62 +30,50 @@ export function useProperties(
   options: UsePropertiesOptions = {},
 ): UsePropertiesResult {
   const { enableLiveUpdates = true, pollingInterval = 30000 } = options;
-
-  const [properties, setProperties] = useState<PropertyInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
-  const fetchProperties = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
+  const fetchProperties = useCallback(
+    () => propertyApi.getAll({ limit: 100 }).then((res) => res.data),
+    [],
+  );
 
-    try {
-      const response = await propertyApi.getAll({
-        limit: 100,
-      });
-      setProperties(response.data);
-      setLastUpdatedAt(new Date());
-      return response.data;
-    } catch (fetchError) {
-      setError(getErrorMessage(fetchError));
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const asyncState = useAsyncState(fetchProperties, {
+    isEmpty: (data) => data.length === 0,
+  });
 
   const { connectionStatus, isPolling, refresh } = useLiveUpdates(
-    async () => {
-      const response = await propertyApi.getAll({ limit: 100 });
-      return response.data;
-    },
+    async () => (await propertyApi.getAll({ limit: 100 })).data,
     {
       endpoint: SSE_ENDPOINT,
       pollingInterval,
-      enabled: enableLiveUpdates && !isLoading,
+      enabled: enableLiveUpdates && !asyncState.isLoading,
       onUpdate: (updatedProperties) => {
-        setProperties(updatedProperties);
+        asyncState.setData(updatedProperties);
         setLastUpdatedAt(new Date());
       },
     },
   );
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      void fetchProperties();
-    }, 0);
-    return () => clearTimeout(timer);
-  }, [fetchProperties]);
+    void asyncState.execute();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asyncState.execute]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (asyncState.status === "success") setLastUpdatedAt(new Date());
+  }, [asyncState.status]);
 
   const refetch = useCallback(async () => {
-    await fetchProperties();
+    await asyncState.retry();
     refresh();
-  }, [fetchProperties, refresh]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asyncState.retry, refresh]);
 
   return {
-    properties,
-    isLoading,
-    error,
+    properties: asyncState.data ?? [],
+    isLoading: asyncState.isLoading,
+    error: asyncState.error,
     refetch,
     connectionStatus,
     lastUpdatedAt,

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "akkuea",
@@ -162,12 +161,12 @@
     },
   },
   "overrides": {
-    "ajv": "^6.14.0",
-    "axios": "^1.13.5",
-    "eslint-visitor-keys": "^5.0.1",
     "file-type": "^21.3.4",
     "flatted": "^3.4.0",
     "minimatch": ">=10.2.1",
+    "eslint-visitor-keys": "^5.0.1",
+    "axios": "^1.13.5",
+    "ajv": "^6.14.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
@@ -1364,7 +1363,7 @@
 
     "bare-semver": ["bare-semver@1.0.3", "", {}, "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q=="],
 
-    "base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+    "base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "base32.js": ["base32.js@0.1.0", "", {}, "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ=="],
 
@@ -1410,7 +1409,7 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+    "bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
@@ -2976,6 +2975,8 @@
 
     "@privy-io/js-sdk-core/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
+    "@privy-io/public-api/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
     "@privy-io/react-auth/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
     "@privy-io/react-auth/lucide-react": ["lucide-react@0.383.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0" } }, "sha512-13xlG0CQCJtzjSQYwwJ3WRqMHtRj3EXmLlorrARt7y+IHnxUCp3XyFNL1DfaGySWxHObDvnu1u1dV+0VMKHUSg=="],
@@ -3047,8 +3048,6 @@
     "@solana/wallet-standard-wallet-adapter-base/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@solana/web3.js/borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
-
-    "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@stellar/freighter-api/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
@@ -3446,6 +3445,10 @@
 
     "@near-js/providers/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
+    "@privy-io/public-api/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+
+    "@privy-io/server-auth/@privy-io/public-api/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
     "@reown/appkit-ui/qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "@reown/appkit-utils/@base-org/account/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
@@ -3530,8 +3533,6 @@
 
     "@solana/wallet-standard-wallet-adapter-base/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
-    "@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
-
     "@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@3.1.2", "", {}, "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="],
 
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -3615,8 +3616,6 @@
     "@walletconnect/universal-provider/@walletconnect/utils/@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
     "@walletconnect/universal-provider/@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
-
-    "bchaddrjs/bs58check/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "bs58check/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
@@ -3814,6 +3813,8 @@
 
     "@near-js/providers/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "@privy-io/server-auth/@privy-io/public-api/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
     "@reown/appkit-ui/qrcode/yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -3919,8 +3920,6 @@
     "@walletconnect/universal-provider/@walletconnect/utils/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@walletconnect/universal-provider/@walletconnect/utils/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
-
-    "bchaddrjs/bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "near-api-js/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 


### PR DESCRIPTION
- **Closes #975**

### Summary

Introduces a shared `useAsyncState` hook as the single source of truth for loading/error/empty/success state, and a new `EmptyState` UI component to pair with the existing `SectionErrorFallback`. Both `marketplace/page.tsx` (via `useProperties`) and `properties/[id]/page.tsx` now consume the same primitive instead of hand-rolling their own `isLoading`/`error`/`property` state trios with duplicated try/catch/finally logic.

### New: `useAsyncState`

`apps/webapp/src/hooks/useAsyncState.ts` — a small, generic hook wrapping any `() => Promise<T>` into `{ status, data, error, isLoading, isError, isEmpty, isSuccess, execute, retry, setData }`. Deliberately does **not** auto-fire on mount — each caller wires its own `useEffect(() => { void execute(); }, [execute])`, which is what lets the same hook serve both "fetch once" (marketplace) and "refetch when a route param changes" (property detail, via a `useCallback`-memoized fetcher keyed on `propertyId`) without any special-casing inside the hook itself.

`setData` is exposed directly (not just through `execute`) specifically so `useProperties`'s SSE live-update path can push new data in without a loading-state flash — see below.

### New: `EmptyState` component

`apps/webapp/src/components/ui/EmptyState.tsx` — follows the same visual/prop conventions as the existing `SectionErrorFallback` (`Card`-based, optional `action` button), exported from `components/ui/index.ts`. Nothing like this existed in the shared `ui` folder before.

### `useProperties.ts` — refactored, external contract unchanged

Rewritten on top of `useAsyncState` internally. Public return shape (`properties`, `isLoading`, `error`, `refetch`, `connectionStatus`, `lastUpdatedAt`, `isPolling`) is **byte-for-byte the same as before** — `useAsyncState` stays a small generic primitive; the SSE live-updates concern (`useLiveUpdates`, polling, connection status) is layered on top rather than folded into the generic hook, since that's specific to this one page and not a general "async state" concern.

### `marketplace/page.tsx`

Swapped the page's local error/empty handling for `SectionErrorFallback` and `EmptyState`, preserving the exact copy the existing test suite asserts on (`"Could not load the marketplace"`, `"No properties found"`, `"No properties match your search or filters"`, `"Clear filters"`).

### `properties/[id]/page.tsx`

Replaced the manual `useState`/`useEffect`/try-catch-finally trio (duplicated between the initial load and `handleRetry`) with `useAsyncState`, gated on a `propertyId`-memoized fetcher. Also **fixes a real gap**: previously, if `propertyApi.getById` resolved with a falsy/not-found result without throwing, nothing rendered at all — no error, no empty state, just a blank page. Now routes through `EmptyState` ("Property not found") via `useAsyncState`'s `isEmpty` option.

### Test

<img width="1366" height="768" alt="Screenshot from 2026-07-22 12-57-37" src="https://github.com/user-attachments/assets/f4dac4e1-4904-404e-9c29-063372024502" />


### Not included in this PR

- **`properties/[id]/page.test.tsx` does not exist yet.** The second half of #975's acceptance criteria ("Render tests exist for each state on both pages") is only satisfied for the marketplace page so far. Follow-up commit needed: a test file mirroring `marketplace/page.test.tsx`'s mocking conventions (`mock.module` for `next/image`, `framer-motion`, `@/components/layout`, `@/components/auth/hooks`), covering loading/error+retry/empty(not-found)/success against a mocked `propertyApi.getById`.

### Acceptance criteria

- [x] Both pages use the same component/hook for all four states (`useAsyncState` + `SectionErrorFallback`/`EmptyState`)
- [ ] Render tests exist for each state on both pages — marketplace: yes (pre-existing suite, still passing); property detail: **not yet written**, see above