### PR TITLE
refactor: replace unwrap/expect with Result in shares and positions

### DIFF
--- a/apps/contracts/contracts/defi-rwa/src/access/admin.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/admin.rs
@@ -12,6 +12,9 @@ pub enum ContractError {
     Unauthorized = 4,
     ContractPaused = 5,
     ContractNotPaused = 6,
+    BalanceOverflow = 7,
+    InsufficientBalance = 8,
+    InsufficientAllowance = 9,
 }
 
 pub struct AdminControl;

--- a/apps/contracts/contracts/defi-rwa/src/lending/positions.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lending/positions.rs
@@ -121,9 +121,10 @@ impl PositionStorage {
         let mut new_list: Vec<String> = Vec::new(env);
 
         for i in 0..list.len() {
-            let id = list.get(i).unwrap();
-            if id != pool_id.clone() {
-                new_list.push_back(id);
+            if let Some(id) = list.get(i) {
+                if id != pool_id.clone() {
+                    new_list.push_back(id);
+                }
             }
         }
 
@@ -248,9 +249,11 @@ impl PositionStorage {
 
         let mut exists = false;
         for i in 0..list.len() {
-            if list.get(i).unwrap() == pool_id.clone() {
-                exists = true;
-                break;
+            if let Some(id) = list.get(i) {
+                if id == pool_id.clone() {
+                    exists = true;
+                    break;
+                }
             }
         }
 
@@ -267,9 +270,10 @@ impl PositionStorage {
         let mut new_list: Vec<String> = Vec::new(env);
 
         for i in 0..list.len() {
-            let id = list.get(i).unwrap();
-            if id != pool_id.clone() {
-                new_list.push_back(id);
+            if let Some(id) = list.get(i) {
+                if id != pool_id.clone() {
+                    new_list.push_back(id);
+                }
             }
         }
 

--- a/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -155,7 +155,8 @@ impl PropertyTokenContract {
         let total = get_total_shares(&env, property_id);
         let new_total = total.checked_add(amount).expect("Total shares overflow");
         set_total_shares(&env, property_id, new_total);
-        increase_balance(&env, property_id, &recipient, amount);
+        increase_balance(&env, property_id, &recipient, amount)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
 
         let prop_str = u64_to_string(&env, property_id);
         PropertyEvents::share_transfer(&env, prop_str, admin, recipient, amount as i128);
@@ -166,7 +167,8 @@ impl PropertyTokenContract {
         if amount == 0 {
             panic!("Amount must be greater than zero");
         }
-        decrease_balance(&env, property_id, &owner, amount);
+        decrease_balance(&env, property_id, &owner, amount)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
         let total = get_total_shares(&env, property_id);
         let new_total = total.checked_sub(amount).expect("Total shares underflow");
         set_total_shares(&env, property_id, new_total);
@@ -182,7 +184,8 @@ impl PropertyTokenContract {
         if amount == 0 {
             panic!("Amount must be greater than zero");
         }
-        transfer_shares(&env, property_id, &from, &to, amount);
+        transfer_shares(&env, property_id, &from, &to, amount)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
 
         let prop_str = u64_to_string(&env, property_id);
         PropertyEvents::share_transfer(&env, prop_str, from, to, amount as i128);
@@ -205,8 +208,10 @@ impl PropertyTokenContract {
         if amount == 0 {
             panic!("Amount must be greater than zero");
         }
-        spend_allowance(&env, property_id, &from, &spender, amount);
-        transfer_shares(&env, property_id, &from, &to, amount);
+        spend_allowance(&env, property_id, &from, &spender, amount)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
+        transfer_shares(&env, property_id, &from, &to, amount)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
 
         let prop_str = u64_to_string(&env, property_id);
         PropertyEvents::share_transfer(&env, prop_str, from, to, amount as i128);
@@ -245,7 +250,8 @@ impl PropertyTokenContract {
         let token_client = token::Client::new(&env, &payment_token);
         token_client.transfer(&buyer, &property.owner, &total_cost);
 
-        storage::shares::increase_balance(&env, property_id, &buyer, amount);
+        storage::shares::increase_balance(&env, property_id, &buyer, amount)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
         storage::property::decrease_available_shares(&env, property_id, amount);
 
         let mut buffer = itoa::Buffer::new();

--- a/apps/contracts/contracts/defi-rwa/src/storage/shares.rs
+++ b/apps/contracts/contracts/defi-rwa/src/storage/shares.rs
@@ -1,3 +1,4 @@
+use crate::access::ContractError;
 use soroban_sdk::{Address, Env};
 
 use super::keys::StorageKey;
@@ -52,13 +53,21 @@ pub fn set_balance(env: &Env, property_id: u64, owner: &Address, balance: u64) {
 /// * `owner` - Address of the share owner
 /// * `amount` - Number of shares to add
 ///
-/// # Panics
-/// Panics if the addition would overflow u64
+/// # Errors
+/// Returns `ContractError::BalanceOverflow` if the addition would overflow u64
 #[allow(dead_code)]
-pub fn increase_balance(env: &Env, property_id: u64, owner: &Address, amount: u64) {
+pub fn increase_balance(
+    env: &Env,
+    property_id: u64,
+    owner: &Address,
+    amount: u64,
+) -> Result<(), ContractError> {
     let current = get_balance(env, property_id, owner);
-    let new_balance = current.checked_add(amount).expect("Share balance overflow");
+    let new_balance = current
+        .checked_add(amount)
+        .ok_or(ContractError::BalanceOverflow)?;
     set_balance(env, property_id, owner, new_balance);
+    Ok(())
 }
 
 /// Decreases the share balance for an owner
@@ -69,15 +78,21 @@ pub fn increase_balance(env: &Env, property_id: u64, owner: &Address, amount: u6
 /// * `owner` - Address of the share owner
 /// * `amount` - Number of shares to subtract
 ///
-/// # Panics
-/// Panics if the subtraction would underflow (insufficient balance)
+/// # Errors
+/// Returns `ContractError::InsufficientBalance` if the balance is insufficient
 #[allow(dead_code)]
-pub fn decrease_balance(env: &Env, property_id: u64, owner: &Address, amount: u64) {
+pub fn decrease_balance(
+    env: &Env,
+    property_id: u64,
+    owner: &Address,
+    amount: u64,
+) -> Result<(), ContractError> {
     let current = get_balance(env, property_id, owner);
     let new_balance = current
         .checked_sub(amount)
-        .expect("Insufficient share balance");
+        .ok_or(ContractError::InsufficientBalance)?;
     set_balance(env, property_id, owner, new_balance);
+    Ok(())
 }
 
 /// Gets the total shares issued for a property
@@ -115,12 +130,20 @@ pub fn set_total_shares(env: &Env, property_id: u64, total: u64) {
 /// * `to` - Address of the recipient
 /// * `amount` - Number of shares to transfer
 ///
-/// # Panics
-/// Panics if sender has insufficient balance
+/// # Errors
+/// Returns `ContractError::InsufficientBalance` if sender has insufficient balance
+/// Returns `ContractError::BalanceOverflow` if recipient balance would overflow
 #[allow(dead_code)]
-pub fn transfer_shares(env: &Env, property_id: u64, from: &Address, to: &Address, amount: u64) {
-    decrease_balance(env, property_id, from, amount);
-    increase_balance(env, property_id, to, amount);
+pub fn transfer_shares(
+    env: &Env,
+    property_id: u64,
+    from: &Address,
+    to: &Address,
+    amount: u64,
+) -> Result<(), ContractError> {
+    decrease_balance(env, property_id, from, amount)?;
+    increase_balance(env, property_id, to, amount)?;
+    Ok(())
 }
 
 /// Helper to get approved allowance
@@ -142,6 +165,9 @@ pub fn set_allowance(env: &Env, property_id: u64, owner: &Address, spender: &Add
 }
 
 /// Helper to consume approved allowance
+///
+/// # Errors
+/// Returns `ContractError::InsufficientAllowance` if allowance is insufficient
 #[allow(dead_code)]
 pub fn spend_allowance(
     env: &Env,
@@ -149,10 +175,11 @@ pub fn spend_allowance(
     owner: &Address,
     spender: &Address,
     amount: u64,
-) {
+) -> Result<(), ContractError> {
     let current_allowance = get_allowance(env, property_id, owner, spender);
     let new_allowance = current_allowance
         .checked_sub(amount)
-        .expect("Insufficient allowance");
+        .ok_or(ContractError::InsufficientAllowance)?;
     set_allowance(env, property_id, owner, spender, new_allowance);
+    Ok(())
 }

--- a/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -2037,13 +2037,42 @@ fn test_burn_shares() {
 }
 
 #[test]
-#[should_panic(expected = "Insufficient share balance")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_burn_more_than_balance_panics() {
     let (env, client, admin) = setup_token_test();
     let owner = Address::generate(&env);
 
     client.mint_shares(&admin, &1, &owner, &500);
     client.burn_shares(&owner, &1, &600); // Exceeds balance
+}
+
+// Transfer more shares than owned should produce InsufficientBalance error (#8)
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_transfer_insufficient_balance() {
+    let (env, client, admin) = setup_token_test();
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let property_id = 1;
+
+    client.mint_shares(&admin, &property_id, &from, &500);
+    client.transfer_shares(&from, &to, &property_id, &600);
+}
+
+// TransferFrom with insufficient allowance should produce InsufficientAllowance error (#9)
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_transfer_from_insufficient_allowance() {
+    let (env, client, admin) = setup_token_test();
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let property_id = 1;
+
+    client.mint_shares(&admin, &property_id, &owner, &1000);
+    client.approve(&owner, &spender, &property_id, &100);
+    // Try to spend more than the approved allowance
+    client.transfer_from(&spender, &owner, &recipient, &property_id, &200);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Refactor `unwrap()` / `expect()` in `storage/shares.rs` and `lending/positions.rs` to return `Result` with specific `ContractError` variants instead of panicking.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

Replaced all `unwrap()` and `expect()` calls in the share balance and
position tracking modules with proper error propagation. Previously,
insufficient balance, insufficient allowance, or arithmetic overflow
would abort the contract. Now they return dedicated error variants
(`InsufficientBalance`, `InsufficientAllowance`, `BalanceOverflow`)
that callers can handle gracefully. This matches the pattern already
used in other modules (issue #31) and makes the contract more robust.

Key changes:
- Added three new variants to `ContractError`.
- Updated `increase_balance`, `decrease_balance`, `transfer_shares`,
  and `spend_allowance` to return `Result<(), ContractError>`.
- Refactored list lookups in `lending/positions.rs` to avoid
  `.unwrap()`.
- Updated all callers in `lib.rs` to propagate errors via
  `panic_with_error!` (the existing pattern).
- Added tests for insufficient balance and allowance scenarios.
- Fixed one existing test that expected the old panic string.

## How to Test

1. Run `cargo test -p rwa-defi-contract` – all 101 tests pass,
   including new tests for error conditions.
2. Run `cargo clippy -p rwa-defi-contract` – zero warnings.
3. Verify that existing transactions (transfer, mint, burn,
   purchase) still succeed with valid inputs and fail with specific
   contract error codes when inputs are invalid (e.g., transfer
   more than balance → `Error(Contract, #8)`).

## Checklist

- [x] All CI workflows pass (monorepo, API, webapp, shared, contracts) – contracts tests pass locally.
- [x] I have added or updated tests where applicable – added two new tests, updated one.
- [x] I have updated relevant documentation – N/A.
- [x] No `.env` files or secrets are committed.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Closes #1012