### PR TITLE
feat(api): implement audit logging and admin audit log endpoint

### DIFF
--- a/apps/api/drizzle/migrations/0006_add_audit_log.sql
+++ b/apps/api/drizzle/migrations/0006_add_audit_log.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "audit_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"actor" varchar(56) NOT NULL,
+	"action" varchar(100) NOT NULL,
+	"entity_type" varchar(50) NOT NULL,
+	"entity_id" uuid NOT NULL,
+	"before_value" jsonb,
+	"after_value" jsonb,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_log_actor_idx" ON "audit_log" ("actor");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_log_action_idx" ON "audit_log" ("action");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_log_entity_idx" ON "audit_log" ("entity_type", "entity_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_log_created_at_idx" ON "audit_log" ("created_at");

--- a/apps/api/drizzle/migrations/meta/_journal.json
+++ b/apps/api/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777449700000,
       "tag": "0005_expand_valuation_confidence",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777449700001,
+      "tag": "0006_add_audit_log",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/__tests__/AuditService.test.ts
+++ b/apps/api/src/__tests__/AuditService.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { AuditService } from '../services/AuditService';
+import type { AuditLogRepository } from '../repositories/AuditLogRepository';
+
+function createMockRepository(): AuditLogRepository {
+  return {
+    create: mock(() => Promise.resolve({ id: 'mock-id' } as any)),
+    findPaginated: mock(() =>
+      Promise.resolve({
+        data: [],
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+      }),
+    ),
+  } as unknown as AuditLogRepository;
+}
+
+describe('AuditService', () => {
+  describe('logAction', () => {
+    it('should call repository.create with correct values', async () => {
+      const repo = createMockRepository();
+      const service = new AuditService(repo);
+
+      await service.logAction({
+        actor: 'GActorWallet1234567890123456789012345678901234567890',
+        action: 'kyc.approve',
+        entityType: 'kyc_document',
+        entityId: '550e8400-e29b-41d4-a716-446655440000',
+        beforeValue: { status: 'pending' },
+        afterValue: { status: 'approved' },
+        metadata: { userId: 'user-123' },
+      });
+
+      expect(repo.create).toHaveBeenCalledTimes(1);
+      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0][0];
+      expect(callArg).toEqual({
+        actor: 'GActorWallet1234567890123456789012345678901234567890',
+        action: 'kyc.approve',
+        entityType: 'kyc_document',
+        entityId: '550e8400-e29b-41d4-a716-446655440000',
+        beforeValue: { status: 'pending' },
+        afterValue: { status: 'approved' },
+        metadata: { userId: 'user-123' },
+      });
+    });
+
+    it('should store null for undefined before/after/metadata', async () => {
+      const repo = createMockRepository();
+      const service = new AuditService(repo);
+
+      await service.logAction({
+        actor: 'GActor123',
+        action: 'test.action',
+        entityType: 'test',
+        entityId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0][0];
+      expect(callArg.beforeValue).toBeNull();
+      expect(callArg.afterValue).toBeNull();
+      expect(callArg.metadata).toBeNull();
+    });
+
+    it('should serialize before/after values correctly', async () => {
+      const repo = createMockRepository();
+      const service = new AuditService(repo);
+
+      const beforeValue = {
+        status: 'pending',
+        verified: false,
+        reviewStatus: 'pending_review',
+        lastReviewNote: null,
+        lastReviewedAt: null,
+        lastReviewerWallet: null,
+      };
+
+      const afterValue = {
+        status: 'approved',
+        verified: true,
+        reviewStatus: 'approved',
+        lastReviewNote: 'Approved after review',
+        lastReviewedAt: new Date('2025-07-24T12:00:00.000Z'),
+        lastReviewerWallet: 'GReviewer123',
+      };
+
+      await service.logAction({
+        actor: 'GAdmin123',
+        action: 'property.approve',
+        entityType: 'property',
+        entityId: '550e8400-e29b-41d4-a716-446655440000',
+        beforeValue: beforeValue as unknown as Record<string, unknown>,
+        afterValue: afterValue as unknown as Record<string, unknown>,
+      });
+
+      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0][0];
+      expect(callArg.beforeValue).toEqual(beforeValue);
+      expect(callArg.afterValue).toEqual(afterValue);
+    });
+  });
+
+  describe('getAuditLogs', () => {
+    it('should call repository.findPaginated with provided filters', async () => {
+      const repo = createMockRepository();
+      const service = new AuditService(repo);
+
+      await service.getAuditLogs({
+        actor: 'GActor123',
+        action: 'kyc.approve',
+        startDate: '2025-01-01T00:00:00.000Z',
+        endDate: '2025-12-31T23:59:59.000Z',
+        page: 2,
+        limit: 10,
+      });
+
+      expect(repo.findPaginated).toHaveBeenCalledTimes(1);
+      const callArg = (repo.findPaginated as ReturnType<typeof mock>).mock.calls[0][0];
+      expect(callArg).toEqual({
+        actor: 'GActor123',
+        action: 'kyc.approve',
+        startDate: '2025-01-01T00:00:00.000Z',
+        endDate: '2025-12-31T23:59:59.000Z',
+        page: 2,
+        limit: 10,
+      });
+    });
+
+    it('should return paginated results', async () => {
+      const repo = createMockRepository();
+      const mockData = Array.from({ length: 3 }, (_, i) => ({
+        id: `id-${i}`,
+        actor: 'GActor123',
+        action: 'kyc.approve',
+        entityType: 'kyc_document',
+        entityId: `doc-${i}`,
+        beforeValue: null,
+        afterValue: null,
+        metadata: null,
+        createdAt: new Date(),
+      }));
+      (repo.findPaginated as ReturnType<typeof mock>).mockResolvedValue({
+        data: mockData,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      const service = new AuditService(repo);
+      const result = await service.getAuditLogs({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(3);
+      expect(result.pagination.total).toBe(3);
+      expect(result.pagination.totalPages).toBe(1);
+    });
+
+    it('should handle empty results', async () => {
+      const repo = createMockRepository();
+      const service = new AuditService(repo);
+      const result = await service.getAuditLogs({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/__tests__/AuditService.test.ts
+++ b/apps/api/src/__tests__/AuditService.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { AuditService } from '../services/AuditService';
 import type { AuditLogRepository } from '../repositories/AuditLogRepository';
+import type { AuditLog } from '../db/schema/auditLog';
 
 function createMockRepository(): AuditLogRepository {
   return {
-    create: mock(() => Promise.resolve({ id: 'mock-id' } as any)),
+    create: mock(() => Promise.resolve({ id: 'mock-id' } as AuditLog)),
     findPaginated: mock(() =>
       Promise.resolve({
         data: [],

--- a/apps/api/src/__tests__/AuditService.test.ts
+++ b/apps/api/src/__tests__/AuditService.test.ts
@@ -31,7 +31,7 @@ describe('AuditService', () => {
       });
 
       expect(repo.create).toHaveBeenCalledTimes(1);
-      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0][0];
+      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0]![0];
       expect(callArg).toEqual({
         actor: 'GActorWallet1234567890123456789012345678901234567890',
         action: 'kyc.approve',
@@ -54,7 +54,7 @@ describe('AuditService', () => {
         entityId: '550e8400-e29b-41d4-a716-446655440000',
       });
 
-      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0][0];
+      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0]![0];
       expect(callArg.beforeValue).toBeNull();
       expect(callArg.afterValue).toBeNull();
       expect(callArg.metadata).toBeNull();
@@ -91,7 +91,7 @@ describe('AuditService', () => {
         afterValue: afterValue as unknown as Record<string, unknown>,
       });
 
-      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0][0];
+      const callArg = (repo.create as ReturnType<typeof mock>).mock.calls[0]![0];
       expect(callArg.beforeValue).toEqual(beforeValue);
       expect(callArg.afterValue).toEqual(afterValue);
     });
@@ -112,7 +112,7 @@ describe('AuditService', () => {
       });
 
       expect(repo.findPaginated).toHaveBeenCalledTimes(1);
-      const callArg = (repo.findPaginated as ReturnType<typeof mock>).mock.calls[0][0];
+      const callArg = (repo.findPaginated as ReturnType<typeof mock>).mock.calls[0]![0];
       expect(callArg).toEqual({
         actor: 'GActor123',
         action: 'kyc.approve',

--- a/apps/api/src/__tests__/audit.test.ts
+++ b/apps/api/src/__tests__/audit.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, beforeAll } from 'bun:test';
+import { Elysia } from 'elysia';
+import { kycRoutes } from '../routes/kyc';
+import { adminRoutes } from '../routes/admin';
+import { errorHandler } from '../middleware/errorHandler';
+import { VALID_UUID } from '@real-estate-defi/shared';
+import { userRepository } from '../repositories/UserRepository';
+import jwt from 'jsonwebtoken';
+
+const skipIfNoDatabase = !process.env.DATABASE_URL;
+const TEST_WALLET = 'GAUDITTESTWALLETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const JWT_SECRET = process.env.JWT_SECRET || 'super-secret-default-key-for-dev';
+const INTERNAL_KEY = process.env.INTERNAL_API_KEY || 'test-internal-api-key';
+const OPS_CREDENTIAL = process.env.OPERATIONS_BACKEND_CREDENTIAL || 'test-ops-credential';
+process.env.INTERNAL_API_KEY = INTERNAL_KEY;
+process.env.OPERATIONS_BACKEND_CREDENTIAL = OPS_CREDENTIAL;
+
+function createKycApp() {
+  return new Elysia().use(errorHandler).use(kycRoutes);
+}
+
+function createAdminApp() {
+  return new Elysia().use(errorHandler).use(adminRoutes);
+}
+
+describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
+  let testUserId = VALID_UUID;
+  let testToken = '';
+
+  beforeAll(async () => {
+    if (!skipIfNoDatabase) {
+      const user = await userRepository.getOrCreateByWallet(TEST_WALLET);
+      testUserId = user.id;
+      testToken = jwt.sign({ id: testUserId, walletAddress: TEST_WALLET }, JWT_SECRET);
+    }
+  });
+
+  async function uploadDocument(app: Elysia): Promise<string> {
+    const formData = new FormData();
+    formData.set('userId', testUserId);
+    formData.set('documentType', 'passport');
+    const pdfContent = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+    formData.set('file', new File([pdfContent], 'id.pdf', { type: 'application/pdf' }));
+    const uploadRes = await app.handle(
+      new Request('http://localhost/kyc/upload', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${testToken}` },
+        body: formData,
+      }),
+    );
+    if (uploadRes.status !== 200) {
+      throw new Error(`Upload failed: ${uploadRes.status} ${await uploadRes.text()}`);
+    }
+    const body = (await uploadRes.json()) as { documentId?: string };
+    return body.documentId!;
+  }
+
+  describe('KYC verify creates audit row', () => {
+    it('should create an audit row when approving a KYC document', async () => {
+      const app = createKycApp();
+      const documentId = await uploadDocument(app);
+
+      const response = await app.handle(
+        new Request(`http://localhost/kyc/verify/${documentId}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'internal-api-key': INTERNAL_KEY,
+          },
+          body: JSON.stringify({ verified: true, actorWallet: TEST_WALLET }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const adminApp = createAdminApp();
+      const auditRes = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?action=kyc.approve', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(auditRes.status).toBe(200);
+      const auditBody = (await auditRes.json()) as {
+        success?: boolean;
+        data?: Array<Record<string, unknown>>;
+        pagination?: Record<string, unknown>;
+      };
+      expect(auditBody.success).toBe(true);
+      expect(auditBody.data?.length).toBeGreaterThanOrEqual(1);
+      expect(auditBody.data![0].action).toBe('kyc.approve');
+      expect(auditBody.data![0].entityId).toBe(documentId);
+      expect(auditBody.data![0].actor).toBe(TEST_WALLET);
+    });
+
+    it('should create an audit row when rejecting a KYC document', async () => {
+      const app = createKycApp();
+      const documentId = await uploadDocument(app);
+
+      const response = await app.handle(
+        new Request(`http://localhost/kyc/verify/${documentId}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'internal-api-key': INTERNAL_KEY,
+          },
+          body: JSON.stringify({ verified: false, notes: 'Document invalid', actorWallet: TEST_WALLET }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const adminApp = createAdminApp();
+      const auditRes = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?action=kyc.reject', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(auditRes.status).toBe(200);
+      const auditBody = (await auditRes.json()) as {
+        success?: boolean;
+        data?: Array<Record<string, unknown>>;
+      };
+      expect(auditBody.success).toBe(true);
+      expect(auditBody.data?.length).toBeGreaterThanOrEqual(1);
+      expect(auditBody.data![0].action).toBe('kyc.reject');
+      expect(auditBody.data![0].entityId).toBe(documentId);
+    });
+  });
+
+  describe('GET /api/v1/admin/audit-log filtering', () => {
+    it('should filter by actor', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request(`http://localhost/api/v1/admin/audit-log?actor=${TEST_WALLET}`, {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        success?: boolean;
+        data?: Array<{ actor?: string }>;
+        pagination?: { total?: number };
+      };
+      expect(body.success).toBe(true);
+      if (body.data && body.data.length > 0) {
+        for (const entry of body.data) {
+          expect(entry.actor).toBe(TEST_WALLET);
+        }
+      }
+    });
+
+    it('should filter by action', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?action=kyc.approve', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        success?: boolean;
+        data?: Array<{ action?: string }>;
+      };
+      expect(body.success).toBe(true);
+      if (body.data && body.data.length > 0) {
+        for (const entry of body.data) {
+          expect(entry.action).toBe('kyc.approve');
+        }
+      }
+    });
+
+    it('should filter by date range', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request(
+          'http://localhost/api/v1/admin/audit-log?startDate=2025-01-01T00:00:00.000Z&endDate=2030-12-31T23:59:59.000Z',
+          {
+            headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+          },
+        ),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { success?: boolean };
+      expect(body.success).toBe(true);
+    });
+
+    it('should return validation error for invalid date', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?startDate=invalid-date', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('pagination', () => {
+    it('should paginate results', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?page=1&limit=2', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        success?: boolean;
+        data?: Array<unknown>;
+        pagination?: { page?: number; limit?: number; total?: number; totalPages?: number };
+      };
+      expect(body.success).toBe(true);
+      expect(body.pagination?.page).toBe(1);
+      expect(body.pagination?.limit).toBe(2);
+      expect(typeof body.pagination?.total).toBe('number');
+      expect(typeof body.pagination?.totalPages).toBe('number');
+    });
+
+    it('should limit to 100 max', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?limit=999', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('empty results', () => {
+    it('should return empty data for non-existent actor filter', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log?actor=GNONEXISTENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', {
+          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        success?: boolean;
+        data?: Array<unknown>;
+        pagination?: { total?: number };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data).toHaveLength(0);
+      expect(body.pagination?.total).toBe(0);
+    });
+  });
+
+  describe('authentication', () => {
+    it('should return 403 without internal api key', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log'),
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('should return 403 with wrong internal api key', async () => {
+      const adminApp = createAdminApp();
+      const res = await adminApp.handle(
+        new Request('http://localhost/api/v1/admin/audit-log', {
+          headers: { 'x-internal-api-key': 'wrong-key' },
+        }),
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/api/src/__tests__/audit.test.ts
+++ b/apps/api/src/__tests__/audit.test.ts
@@ -102,7 +102,11 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
             'Content-Type': 'application/json',
             'internal-api-key': INTERNAL_KEY,
           },
-          body: JSON.stringify({ verified: false, notes: 'Document invalid', actorWallet: TEST_WALLET }),
+          body: JSON.stringify({
+            verified: false,
+            notes: 'Document invalid',
+            actorWallet: TEST_WALLET,
+          }),
         }),
       );
       expect(response.status).toBe(200);
@@ -233,9 +237,12 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
     it('should return empty data for non-existent actor filter', async () => {
       const adminApp = createAdminApp();
       const res = await adminApp.handle(
-        new Request('http://localhost/api/v1/admin/audit-log?actor=GNONEXISTENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', {
-          headers: { 'x-internal-api-key': OPS_CREDENTIAL },
-        }),
+        new Request(
+          'http://localhost/api/v1/admin/audit-log?actor=GNONEXISTENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          {
+            headers: { 'x-internal-api-key': OPS_CREDENTIAL },
+          },
+        ),
       );
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
@@ -252,9 +259,7 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
   describe('authentication', () => {
     it('should return 403 without internal api key', async () => {
       const adminApp = createAdminApp();
-      const res = await adminApp.handle(
-        new Request('http://localhost/api/v1/admin/audit-log'),
-      );
+      const res = await adminApp.handle(new Request('http://localhost/api/v1/admin/audit-log'));
       expect(res.status).toBe(403);
     });
 

--- a/apps/api/src/__tests__/audit.test.ts
+++ b/apps/api/src/__tests__/audit.test.ts
@@ -35,7 +35,7 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
     }
   });
 
-  async function uploadDocument(app: Elysia): Promise<string> {
+  async function uploadDocument(app: ReturnType<typeof createKycApp>): Promise<string> {
     const formData = new FormData();
     formData.set('userId', testUserId);
     formData.set('documentType', 'passport');
@@ -86,9 +86,9 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
       };
       expect(auditBody.success).toBe(true);
       expect(auditBody.data?.length).toBeGreaterThanOrEqual(1);
-      expect(auditBody.data![0].action).toBe('kyc.approve');
-      expect(auditBody.data![0].entityId).toBe(documentId);
-      expect(auditBody.data![0].actor).toBe(TEST_WALLET);
+      expect(auditBody.data![0]!.action).toBe('kyc.approve');
+      expect(auditBody.data![0]!.entityId).toBe(documentId);
+      expect(auditBody.data![0]!.actor).toBe(TEST_WALLET);
     });
 
     it('should create an audit row when rejecting a KYC document', async () => {
@@ -120,8 +120,8 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
       };
       expect(auditBody.success).toBe(true);
       expect(auditBody.data?.length).toBeGreaterThanOrEqual(1);
-      expect(auditBody.data![0].action).toBe('kyc.reject');
-      expect(auditBody.data![0].entityId).toBe(documentId);
+      expect(auditBody.data![0]!.action).toBe('kyc.reject');
+      expect(auditBody.data![0]!.entityId).toBe(documentId);
     });
   });
 
@@ -210,10 +210,10 @@ describe.skipIf(skipIfNoDatabase)('Audit Log Integration', () => {
         pagination?: { page?: number; limit?: number; total?: number; totalPages?: number };
       };
       expect(body.success).toBe(true);
-      expect(body.pagination?.page).toBe(1);
-      expect(body.pagination?.limit).toBe(2);
-      expect(typeof body.pagination?.total).toBe('number');
-      expect(typeof body.pagination?.totalPages).toBe('number');
+      expect(body.pagination!.page).toBe(1);
+      expect(body.pagination!.limit).toBe(2);
+      expect(typeof body.pagination!.total).toBe('number');
+      expect(typeof body.pagination!.totalPages).toBe('number');
     });
 
     it('should limit to 100 max', async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { webhookRoutes } from './routes/webhooks';
 import { internalOperationsRoutes } from './routes/internalOperations';
 import { notificationDlqRoutes } from './routes/notificationDlq';
 import { authRoutes } from './routes/auth';
+import { adminRoutes } from './routes/admin';
 import { ledgerRoutes } from './routes/ledger';
 import { errorHandler } from './middleware/errorHandler';
 import { requestLogger } from './middleware';
@@ -28,6 +29,7 @@ const app = new Elysia()
   .use(webhookRoutes)
   .use(internalOperationsRoutes)
   .use(notificationDlqRoutes)
+  .use(adminRoutes)
   .use(ledgerRoutes);
 
 export default app;

--- a/apps/api/src/controllers/KYCController.ts
+++ b/apps/api/src/controllers/KYCController.ts
@@ -4,6 +4,7 @@ import { kycRepository } from '../repositories/KYCRepository';
 import { userRepository } from '../repositories/UserRepository';
 import { storageService, StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
+import { auditService } from '../services/AuditService';
 
 const DOCUMENT_TYPE_MAP = {
   passport: 'passport' as const,
@@ -178,6 +179,7 @@ export class KYCController {
   static async verifyDocument(
     documentId: string,
     data: { verified: boolean; notes?: string },
+    actorWallet?: string,
   ): Promise<{ success: boolean }> {
     try {
       const doc = await kycRepository.findById(documentId);
@@ -185,17 +187,26 @@ export class KYCController {
         throw ApiError.notFound('Document not found');
       }
 
+      const beforeDoc = { status: doc.status, rejectionReason: doc.rejectionReason, reviewedAt: doc.reviewedAt };
       const status = data.verified ? 'approved' : 'rejected';
+
       await kycRepository.updateStatus(documentId, status, data.notes);
 
       const allDocs = await kycRepository.findByUserId(doc.userId);
       const anyRejected = allDocs.some((d) => d.status === 'rejected');
       const allApproved = allDocs.every((d) => d.status === 'approved');
 
+      const afterDoc = { status, rejectionReason: status === 'rejected' ? (data.notes ?? null) : null, reviewedAt: new Date() };
+
+      let userBeforeStatus: string | undefined;
+      let userAfterStatus: string | undefined;
+
       // Initialize notification service
       const notificationService = new NotificationService();
 
       if (anyRejected) {
+        userBeforeStatus = 'pending';
+        userAfterStatus = 'rejected';
         await kycRepository.updateUserKycStatus(doc.userId, 'rejected');
         // Send verification rejected notification
         await notificationService.notifyVerificationRejected(
@@ -205,10 +216,29 @@ export class KYCController {
           'IN_APP',
         );
       } else if (allApproved) {
+        userBeforeStatus = 'pending';
+        userAfterStatus = 'approved';
         await kycRepository.updateUserKycStatus(doc.userId, 'approved');
         // Send verification approved notification
         await notificationService.notifyVerificationApproved(doc.userId, 'IN_APP');
       }
+
+      const actor = actorWallet || 'system';
+      const actionName = data.verified ? 'kyc.approve' : 'kyc.reject';
+
+      await auditService.logAction({
+        actor,
+        action: actionName,
+        entityType: 'kyc_document',
+        entityId: documentId,
+        beforeValue: beforeDoc as unknown as Record<string, unknown>,
+        afterValue: afterDoc as unknown as Record<string, unknown>,
+        metadata: {
+          userId: doc.userId,
+          notes: data.notes || null,
+          ...(userBeforeStatus && userAfterStatus ? { userKycStatusBefore: userBeforeStatus, userKycStatusAfter: userAfterStatus } : {}),
+        },
+      });
 
       return { success: true };
     } catch (e) {

--- a/apps/api/src/controllers/KYCController.ts
+++ b/apps/api/src/controllers/KYCController.ts
@@ -187,7 +187,11 @@ export class KYCController {
         throw ApiError.notFound('Document not found');
       }
 
-      const beforeDoc = { status: doc.status, rejectionReason: doc.rejectionReason, reviewedAt: doc.reviewedAt };
+      const beforeDoc = {
+        status: doc.status,
+        rejectionReason: doc.rejectionReason,
+        reviewedAt: doc.reviewedAt,
+      };
       const status = data.verified ? 'approved' : 'rejected';
 
       await kycRepository.updateStatus(documentId, status, data.notes);
@@ -196,7 +200,11 @@ export class KYCController {
       const anyRejected = allDocs.some((d) => d.status === 'rejected');
       const allApproved = allDocs.every((d) => d.status === 'approved');
 
-      const afterDoc = { status, rejectionReason: status === 'rejected' ? (data.notes ?? null) : null, reviewedAt: new Date() };
+      const afterDoc = {
+        status,
+        rejectionReason: status === 'rejected' ? (data.notes ?? null) : null,
+        reviewedAt: new Date(),
+      };
 
       let userBeforeStatus: string | undefined;
       let userAfterStatus: string | undefined;
@@ -236,7 +244,9 @@ export class KYCController {
         metadata: {
           userId: doc.userId,
           notes: data.notes || null,
-          ...(userBeforeStatus && userAfterStatus ? { userKycStatusBefore: userBeforeStatus, userKycStatusAfter: userAfterStatus } : {}),
+          ...(userBeforeStatus && userAfterStatus
+            ? { userKycStatusBefore: userBeforeStatus, userKycStatusAfter: userAfterStatus }
+            : {}),
         },
       });
 

--- a/apps/api/src/controllers/OperationalPropertyController.ts
+++ b/apps/api/src/controllers/OperationalPropertyController.ts
@@ -4,6 +4,7 @@ import { PropertyController } from './PropertyController';
 import { propertyRepository, type PropertyReviewStatus } from '../repositories/PropertyRepository';
 import { userRepository } from '../repositories/UserRepository';
 import { OracleService } from '../services/OracleService';
+import { auditService } from '../services/AuditService';
 import type { Property } from '../db/schema';
 
 export type OperationsQueue = 'pending' | 'approved' | 'rejected' | 'hold' | 'changes' | 'all';
@@ -201,6 +202,14 @@ export class OperationalPropertyController {
       throw new NotFoundError('Property', propertyId);
     }
 
+    const beforeValue = {
+      reviewStatus: property.reviewStatus,
+      verified: property.verified,
+      lastReviewNote: property.lastReviewNote,
+      lastReviewedAt: property.lastReviewedAt,
+      lastReviewerWallet: property.lastReviewerWallet,
+    };
+
     let reviewStatus: PropertyReviewStatus;
     let verified: boolean;
 
@@ -238,6 +247,24 @@ export class OperationalPropertyController {
     if (!updated) {
       throw new NotFoundError('Property', propertyId);
     }
+
+    const afterValue = {
+      reviewStatus: updated.reviewStatus,
+      verified: updated.verified,
+      lastReviewNote: updated.lastReviewNote,
+      lastReviewedAt: updated.lastReviewedAt,
+      lastReviewerWallet: updated.lastReviewerWallet,
+    };
+
+    await auditService.logAction({
+      actor: actorWallet,
+      action: `property.${action}`,
+      entityType: 'property',
+      entityId: propertyId,
+      beforeValue: beforeValue as unknown as Record<string, unknown>,
+      afterValue: afterValue as unknown as Record<string, unknown>,
+      metadata: note?.trim() ? { note: note.trim() } : null,
+    });
 
     return OperationalPropertyController.getPropertyDetail(propertyId);
   }

--- a/apps/api/src/db/schema/auditLog.ts
+++ b/apps/api/src/db/schema/auditLog.ts
@@ -1,0 +1,16 @@
+import { pgTable, uuid, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
+
+export const auditLog = pgTable('audit_log', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  actor: varchar('actor', { length: 56 }).notNull(),
+  action: varchar('action', { length: 100 }).notNull(),
+  entityType: varchar('entity_type', { length: 50 }).notNull(),
+  entityId: uuid('entity_id').notNull(),
+  beforeValue: jsonb('before_value'),
+  afterValue: jsonb('after_value'),
+  metadata: jsonb('metadata'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type AuditLog = typeof auditLog.$inferSelect;
+export type NewAuditLog = typeof auditLog.$inferInsert;

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -5,3 +5,4 @@ export * from './transactions';
 export * from './notifications';
 export * from './valuations';
 export * from './notificationDlq';
+export * from './auditLog';

--- a/apps/api/src/repositories/AuditLogRepository.ts
+++ b/apps/api/src/repositories/AuditLogRepository.ts
@@ -24,7 +24,7 @@ export interface PaginatedAuditLogs {
 export class AuditLogRepository {
   async create(data: NewAuditLog): Promise<AuditLog> {
     const results = await db.insert(auditLog).values(data).returning();
-    return results[0];
+    return results[0]!;
   }
 
   async findPaginated(filter: AuditLogFilter): Promise<PaginatedAuditLogs> {

--- a/apps/api/src/repositories/AuditLogRepository.ts
+++ b/apps/api/src/repositories/AuditLogRepository.ts
@@ -1,0 +1,85 @@
+import { and, desc, gte, lte, eq, sql, type SQL } from 'drizzle-orm';
+import { db } from '../db';
+import { auditLog, type AuditLog, type NewAuditLog } from '../db/schema';
+
+export interface AuditLogFilter {
+  actor?: string;
+  action?: string;
+  startDate?: string;
+  endDate?: string;
+  page: number;
+  limit: number;
+}
+
+export interface PaginatedAuditLogs {
+  data: AuditLog[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export class AuditLogRepository {
+  async create(data: NewAuditLog): Promise<AuditLog> {
+    const results = await db.insert(auditLog).values(data).returning();
+    return results[0];
+  }
+
+  async findPaginated(filter: AuditLogFilter): Promise<PaginatedAuditLogs> {
+    const { page, limit } = filter;
+    const offset = (page - 1) * limit;
+
+    const conditions = this.buildFilterConditions(filter);
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const countResult = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(auditLog)
+      .where(whereClause);
+    const total = countResult[0]?.count ?? 0;
+
+    const data = await db
+      .select()
+      .from(auditLog)
+      .where(whereClause)
+      .orderBy(desc(auditLog.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return {
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  private buildFilterConditions(filter: AuditLogFilter): SQL[] {
+    const conditions: SQL[] = [];
+
+    if (filter.actor) {
+      conditions.push(eq(auditLog.actor, filter.actor));
+    }
+
+    if (filter.action) {
+      conditions.push(eq(auditLog.action, filter.action));
+    }
+
+    if (filter.startDate) {
+      conditions.push(gte(auditLog.createdAt, new Date(filter.startDate)));
+    }
+
+    if (filter.endDate) {
+      conditions.push(lte(auditLog.createdAt, new Date(filter.endDate)));
+    }
+
+    return conditions;
+  }
+}
+
+export const auditLogRepository = new AuditLogRepository();

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -14,19 +14,17 @@ const auditLogQuerySchema = z.object({
   limit: z.coerce.number().int().positive().max(100).default(20),
 });
 
-const adminAuth = new Elysia({ name: 'admin-auth' }).onBeforeHandle(
-  ({ headers, set }) => {
-    if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
-      set.status = 403;
-      return {
-        success: false,
-        error: 'FORBIDDEN',
-        message: 'Admin access denied',
-        timestamp: new Date().toISOString(),
-      };
-    }
-  },
-);
+const adminAuth = new Elysia({ name: 'admin-auth' }).onBeforeHandle(({ headers, set }) => {
+  if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
+    set.status = 403;
+    return {
+      success: false,
+      error: 'FORBIDDEN',
+      message: 'Admin access denied',
+      timestamp: new Date().toISOString(),
+    };
+  }
+});
 
 const getAuditLogRoute = new Elysia()
   .use(adminAuth)
@@ -49,5 +47,4 @@ const getAuditLogRoute = new Elysia()
     }
   });
 
-export const adminRoutes = new Elysia({ prefix: '/api/v1/admin' })
-  .use(getAuditLogRoute);
+export const adminRoutes = new Elysia({ prefix: '/api/v1/admin' }).use(getAuditLogRoute);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -14,20 +14,7 @@ const auditLogQuerySchema = z.object({
   limit: z.coerce.number().int().positive().max(100).default(20),
 });
 
-const adminAuth = new Elysia({ name: 'admin-auth' }).onBeforeHandle(({ headers, set }) => {
-  if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
-    set.status = 403;
-    return {
-      success: false,
-      error: 'FORBIDDEN',
-      message: 'Admin access denied',
-      timestamp: new Date().toISOString(),
-    };
-  }
-});
-
 const getAuditLogRoute = new Elysia()
-  .use(adminAuth)
   .use(validateQuery(auditLogQuerySchema))
   .get('/audit-log', async ({ validatedQuery, set }) => {
     try {
@@ -47,4 +34,16 @@ const getAuditLogRoute = new Elysia()
     }
   });
 
-export const adminRoutes = new Elysia({ prefix: '/api/v1/admin' }).use(getAuditLogRoute);
+export const adminRoutes = new Elysia({ prefix: '/api/v1/admin' })
+  .onBeforeHandle(({ headers, set }) => {
+    if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
+      set.status = 403;
+      return {
+        success: false,
+        error: 'FORBIDDEN',
+        message: 'Admin access denied',
+        timestamp: new Date().toISOString(),
+      };
+    }
+  })
+  .use(getAuditLogRoute);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,53 @@
+import { Elysia } from 'elysia';
+import { z } from 'zod';
+import { validateQuery } from '../middleware/validation';
+import { auditService } from '../services/AuditService';
+import { handleError } from '../utils/errors';
+import { isInternalOperationsAuthorized } from '../utils/internalOperationsAuth';
+
+const auditLogQuerySchema = z.object({
+  actor: z.string().min(1).max(56).optional(),
+  action: z.string().min(1).max(100).optional(),
+  startDate: z.string().datetime({ offset: true }).optional(),
+  endDate: z.string().datetime({ offset: true }).optional(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+const adminAuth = new Elysia({ name: 'admin-auth' }).onBeforeHandle(
+  ({ headers, set }) => {
+    if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
+      set.status = 403;
+      return {
+        success: false,
+        error: 'FORBIDDEN',
+        message: 'Admin access denied',
+        timestamp: new Date().toISOString(),
+      };
+    }
+  },
+);
+
+const getAuditLogRoute = new Elysia()
+  .use(adminAuth)
+  .use(validateQuery(auditLogQuerySchema))
+  .get('/audit-log', async ({ validatedQuery, set }) => {
+    try {
+      const result = await auditService.getAuditLogs({
+        actor: validatedQuery!.actor,
+        action: validatedQuery!.action,
+        startDate: validatedQuery!.startDate,
+        endDate: validatedQuery!.endDate,
+        page: validatedQuery!.page,
+        limit: validatedQuery!.limit,
+      });
+      return { success: true, ...result };
+    } catch (error) {
+      const errorResponse = handleError(error);
+      set.status = errorResponse.statusCode;
+      return errorResponse;
+    }
+  });
+
+export const adminRoutes = new Elysia({ prefix: '/api/v1/admin' })
+  .use(getAuditLogRoute);

--- a/apps/api/src/routes/kyc.ts
+++ b/apps/api/src/routes/kyc.ts
@@ -188,9 +188,11 @@ const internalScoped = new Elysia().post(
         throw new ApiError(401, 'UNAUTHORIZED', 'Internal key required');
       }
 
+      const verifyBody = body as { verified: boolean; notes?: string; actorWallet?: string };
       return await KYCController.verifyDocument(
         documentId,
-        body as { verified: boolean; notes?: string },
+        verifyBody,
+        verifyBody.actorWallet,
       );
     } catch (error) {
       return handleKycError(error, set);

--- a/apps/api/src/routes/kyc.ts
+++ b/apps/api/src/routes/kyc.ts
@@ -189,11 +189,7 @@ const internalScoped = new Elysia().post(
       }
 
       const verifyBody = body as { verified: boolean; notes?: string; actorWallet?: string };
-      return await KYCController.verifyDocument(
-        documentId,
-        verifyBody,
-        verifyBody.actorWallet,
-      );
+      return await KYCController.verifyDocument(documentId, verifyBody, verifyBody.actorWallet);
     } catch (error) {
       return handleKycError(error, set);
     }

--- a/apps/api/src/services/AuditService.ts
+++ b/apps/api/src/services/AuditService.ts
@@ -1,4 +1,8 @@
-import { AuditLogRepository, type AuditLogFilter, type PaginatedAuditLogs } from '../repositories/AuditLogRepository';
+import {
+  AuditLogRepository,
+  type AuditLogFilter,
+  type PaginatedAuditLogs,
+} from '../repositories/AuditLogRepository';
 import { auditLogRepository as defaultRepository } from '../repositories/AuditLogRepository';
 
 export interface AuditLogActionInput {

--- a/apps/api/src/services/AuditService.ts
+++ b/apps/api/src/services/AuditService.ts
@@ -1,0 +1,34 @@
+import { AuditLogRepository, type AuditLogFilter, type PaginatedAuditLogs } from '../repositories/AuditLogRepository';
+import { auditLogRepository as defaultRepository } from '../repositories/AuditLogRepository';
+
+export interface AuditLogActionInput {
+  actor: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  beforeValue?: Record<string, unknown> | null;
+  afterValue?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export class AuditService {
+  constructor(private repository: AuditLogRepository = defaultRepository) {}
+
+  async logAction(input: AuditLogActionInput): Promise<void> {
+    await this.repository.create({
+      actor: input.actor,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      beforeValue: input.beforeValue ?? null,
+      afterValue: input.afterValue ?? null,
+      metadata: input.metadata ?? null,
+    });
+  }
+
+  async getAuditLogs(filters: AuditLogFilter): Promise<PaginatedAuditLogs> {
+    return this.repository.findPaginated(filters);
+  }
+}
+
+export const auditService = new AuditService();


### PR DESCRIPTION
##closes #967 

## Summary

This PR introduces a persistent audit logging system for sensitive administrative operations.

## Changes

- Added a new `audit_log` table via Drizzle migration.
- Implemented a reusable `AuditService` for recording audit events.
- Integrated audit logging into:
  - KYC approvals
  - KYC rejections
  - Admin override actions
  - Property status updates
- Added `GET /api/v1/admin/audit-log` with:
  - actor filtering
  - action filtering
  - date range filtering
  - pagination
  - newest-first sorting
- Added unit tests for the audit service.
- Added integration tests for audit log creation and retrieval.

## Why

Sensitive administrative actions previously had no persistent, queryable audit trail. This implementation improves traceability, accountability, and operational visibility while providing administrators with a searchable audit history.

## Testing

- ✅ Unit tests for `AuditService`
- ✅ Integration tests for audit log creation
- ✅ Endpoint filtering tests
- ✅ Pagination tests
- ✅ Existing test suite passes

## Acceptance Criteria

- [x] Every KYC approval/rejection generates an audit record.
- [x] Audit log endpoint supports filtering and pagination.
- [x] Unit and integration tests added.
- [x] No unrelated functionality changed.