### PR TITLE
feat(akkuea-land): wire full game flow to real deployed contracts

### DIFF
--- a/apps/akkuea-land/src/components/game/PropertyPanel/index.tsx
+++ b/apps/akkuea-land/src/components/game/PropertyPanel/index.tsx
@@ -8,6 +8,7 @@ import {
   BuildingLevel,
   PropertyOwnershipState,
 } from "../../../types/game.types";
+import { TREASURY_ADDRESS } from "@/lib/soroban-tx";
 
 import { EmptyPanel } from "./EmptyPanel";
 import { NotConnectedPanel } from "./NotConnectedPanel";
@@ -44,7 +45,7 @@ export const getOwnershipState = (
   }
   const isTreasury =
     !property.owner ||
-    property.owner === "GBTREASURY" ||
+    property.owner === TREASURY_ADDRESS ||
     property.owner.toLowerCase() === "treasury" ||
     property.owner.toLowerCase() === "system";
   if (isTreasury) {

--- a/apps/akkuea-land/src/components/game/__tests__/PropertyPanel.test.tsx
+++ b/apps/akkuea-land/src/components/game/__tests__/PropertyPanel.test.tsx
@@ -42,7 +42,28 @@ vi.mock("@/lib/walletKit", () => ({
   initializeWalletKit: vi.fn(),
 }));
 
+// Mock the Soroban XDR builders + RPC calls so clicking an action button
+// never makes a real network call to testnet — this test only cares about
+// PropertyPanel wiring the right ownership state to the right sub-panel.
+const TEST_TREASURY_ADDRESS =
+  "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
+
+vi.mock("@/lib/soroban-tx", () => ({
+  buildBuyFromTreasuryXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  buildBuyFromPlayerXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  buildImprovePropertyXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  buildApproveMarketplaceXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  buildListForSaleXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  buildClaimIncomeXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  submitSorobanTx: vi.fn().mockResolvedValue("mock-tx-hash"),
+  waitForSorobanTx: vi.fn().mockResolvedValue("success"),
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  TREASURY_ADDRESS: TEST_TREASURY_ADDRESS,
+}));
+
 import { PropertyPanel } from "../PropertyPanel";
+import { TREASURY_ADDRESS } from "@/lib/soroban-tx";
 
 const baseProperty: GameProperty = {
   id: "550e8400-e29b-41d4-a716-446655440001",
@@ -67,7 +88,7 @@ const baseProperty: GameProperty = {
   documents: [],
   verified: true,
   listedAt: "2026-05-27T00:00:00Z",
-  owner: "GBTREASURY",
+  owner: TREASURY_ADDRESS,
   buildingLevel: 0,
   improveCost: 100,
   earnedIncome: 0,
@@ -87,7 +108,7 @@ describe("PropertyPanel Tests", () => {
 
     const view = render(
       <PropertyPanel
-        property={{ ...baseProperty, owner: "GBTREASURY" }}
+        property={{ ...baseProperty, owner: TREASURY_ADDRESS }}
         onPropertyUpdate={onUpdate}
         viewerAddress={null}
         isConnected={false}
@@ -111,7 +132,7 @@ describe("PropertyPanel Tests", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  // State 2: unowned (viewer connected, owner is GBTREASURY)
+  // State 2: unowned (viewer connected, owner is the treasury)
   it("renders state 2: unowned (Treasury owned) tile and allows purchase", async () => {
     const onUpdate = mock(() => {});
     const viewerAddress =
@@ -119,7 +140,7 @@ describe("PropertyPanel Tests", () => {
 
     const view = render(
       <PropertyPanel
-        property={{ ...baseProperty, owner: "GBTREASURY" }}
+        property={{ ...baseProperty, owner: TREASURY_ADDRESS }}
         onPropertyUpdate={onUpdate}
         viewerAddress={viewerAddress}
         isConnected={true}

--- a/apps/akkuea-land/src/components/game/onboarding/ClaimLandStep.tsx
+++ b/apps/akkuea-land/src/components/game/onboarding/ClaimLandStep.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useGameWallet } from "@/hooks/useGameWallet";
+import { buildFaucetClaimXdr } from "@/lib/soroban-tx";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Sparkles,
@@ -27,16 +28,20 @@ export function ClaimLandStep({
   onNext: () => void;
   onSkip: () => void;
 }) {
-  const { signAndSubmitTx } = useGameWallet();
+  const { address, signAndSubmitTx } = useGameWallet();
   const [status, setStatus] = useState<Status>("idle");
 
   const handleClaim = async () => {
+    if (!address) {
+      setStatus("error");
+      return;
+    }
     setStatus("pending");
     try {
-      // Simulate/call transaction
-      await signAndSubmitTx("placeholder-faucet-xdr");
+      const xdr = await buildFaucetClaimXdr(address);
+      await signAndSubmitTx(xdr);
       setStatus("done");
-    } catch (err) {
+    } catch {
       setStatus("error");
     }
   };

--- a/apps/akkuea-land/src/components/game/onboarding/ClaimPropertyStep.tsx
+++ b/apps/akkuea-land/src/components/game/onboarding/ClaimPropertyStep.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useGameWallet } from "@/hooks/useGameWallet";
+import { buildBuyFromTreasuryXdr, TREASURY_ADDRESS } from "@/lib/soroban-tx";
 import { motion, AnimatePresence } from "framer-motion";
 import { Sparkles, MapPin, CheckCircle, RefreshCw } from "lucide-react";
 
@@ -25,17 +26,22 @@ export function ClaimPropertyStep({
   onComplete: () => void;
   onSkip: () => void;
 }) {
-  const { signAndSubmitTx } = useGameWallet();
+  const { address, signAndSubmitTx } = useGameWallet();
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [status, setStatus] = useState<"idle" | "pending" | "celebrating">(
     "idle",
   );
 
   const handleClaim = async () => {
-    if (selectedId === null) return;
+    if (selectedId === null || !address) return;
     setStatus("pending");
     try {
-      await signAndSubmitTx("placeholder-starter-claim-xdr");
+      const xdr = await buildBuyFromTreasuryXdr(
+        address,
+        String(selectedId),
+        TREASURY_ADDRESS,
+      );
+      await signAndSubmitTx(xdr);
       setStatus("celebrating");
       // Stay on celebration for 3 seconds, then navigate
       setTimeout(onComplete, 3000);

--- a/apps/akkuea-land/src/components/game/onboarding/__tests__/ClaimLandStep.test.tsx
+++ b/apps/akkuea-land/src/components/game/onboarding/__tests__/ClaimLandStep.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ClaimLandStep — unit tests
+ *
+ * Verifies the onboarding "Claim your starter LAND" step builds a real
+ * GameLandToken.faucet XDR for the connected wallet address and signs it
+ * through useGameWallet, instead of the old code path that handed a literal
+ * "placeholder-faucet-xdr" string straight to a stubbed signAndSubmitTx.
+ */
+
+// @ts-expect-error: jsdom types not fully compatible with bun runtime
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+globalThis.window = dom.window as any;
+globalThis.document = dom.window.document as any;
+globalThis.navigator = dom.window.navigator as any;
+globalThis.HTMLElement = dom.window.HTMLElement as any;
+globalThis.MutationObserver = dom.window.MutationObserver as any;
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
+import React from "react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+mock.module("framer-motion", () => {
+  const passthrough = new Proxy(
+    {},
+    {
+      get:
+        (_target, tagName: string) =>
+        ({ children, ...props }: any) =>
+          React.createElement(tagName, props, children),
+    },
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: passthrough,
+  };
+});
+
+const CONNECTED_ADDRESS =
+  "GDVIEWER1234567890123456789012345678901234567890123456";
+const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
+
+const mockBuildFaucetClaimXdr = vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR);
+vi.mock("@/lib/soroban-tx", () => ({
+  buildFaucetClaimXdr: mockBuildFaucetClaimXdr,
+}));
+
+const mockSignAndSubmitTx = vi.fn().mockResolvedValue(undefined);
+const mockUseGameWallet = vi.fn(
+  (): {
+    address: string | null;
+    signAndSubmitTx: typeof mockSignAndSubmitTx;
+  } => ({
+    address: CONNECTED_ADDRESS,
+    signAndSubmitTx: mockSignAndSubmitTx,
+  }),
+);
+vi.mock("@/hooks/useGameWallet", () => ({
+  useGameWallet: mockUseGameWallet,
+}));
+
+import { ClaimLandStep } from "../ClaimLandStep";
+
+beforeEach(() => {
+  cleanup();
+  mockBuildFaucetClaimXdr.mockClear();
+  mockBuildFaucetClaimXdr.mockResolvedValue(MOCK_UNSIGNED_XDR);
+  mockSignAndSubmitTx.mockClear();
+  mockSignAndSubmitTx.mockResolvedValue(undefined);
+  mockUseGameWallet.mockReturnValue({
+    address: CONNECTED_ADDRESS,
+    signAndSubmitTx: mockSignAndSubmitTx,
+  });
+});
+
+describe("ClaimLandStep", () => {
+  it("builds a real faucet XDR for the connected address and signs it", async () => {
+    const onNext = () => {};
+    const onSkip = () => {};
+
+    const view = render(<ClaimLandStep onNext={onNext} onSkip={onSkip} />);
+
+    fireEvent.click(view.getByRole("button", { name: /Claim 1,000 LAND/i }));
+
+    await waitFor(() => {
+      expect(mockBuildFaucetClaimXdr).toHaveBeenCalledWith(CONNECTED_ADDRESS);
+    });
+    expect(mockSignAndSubmitTx).toHaveBeenCalledWith(MOCK_UNSIGNED_XDR);
+
+    await waitFor(() => {
+      expect(
+        view.queryByText("Transaction successfully recorded on-chain"),
+      ).not.toBeNull();
+    });
+  });
+
+  it("does not call the faucet builder with a hardcoded placeholder string", async () => {
+    const view = render(<ClaimLandStep onNext={() => {}} onSkip={() => {}} />);
+
+    fireEvent.click(view.getByRole("button", { name: /Claim 1,000 LAND/i }));
+
+    await waitFor(() => {
+      expect(mockBuildFaucetClaimXdr).toHaveBeenCalled();
+    });
+
+    expect(mockSignAndSubmitTx).not.toHaveBeenCalledWith(
+      "placeholder-faucet-xdr",
+    );
+  });
+
+  it("shows the error state when the transaction fails", async () => {
+    mockSignAndSubmitTx.mockRejectedValueOnce(new Error("User rejected"));
+
+    const view = render(<ClaimLandStep onNext={() => {}} onSkip={() => {}} />);
+
+    fireEvent.click(view.getByRole("button", { name: /Claim 1,000 LAND/i }));
+
+    await waitFor(() => {
+      expect(view.queryByText("Claim failed. Try again.")).not.toBeNull();
+    });
+  });
+
+  it("does not attempt to claim when no wallet address is connected", async () => {
+    mockUseGameWallet.mockReturnValue({
+      address: null,
+      signAndSubmitTx: mockSignAndSubmitTx,
+    });
+
+    const view = render(<ClaimLandStep onNext={() => {}} onSkip={() => {}} />);
+
+    fireEvent.click(view.getByRole("button", { name: /Claim 1,000 LAND/i }));
+
+    expect(mockBuildFaucetClaimXdr).not.toHaveBeenCalled();
+    expect(mockSignAndSubmitTx).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akkuea-land/src/components/game/onboarding/__tests__/ClaimPropertyStep.test.tsx
+++ b/apps/akkuea-land/src/components/game/onboarding/__tests__/ClaimPropertyStep.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * ClaimPropertyStep — unit tests
+ *
+ * Verifies the onboarding "Claim your first property" step builds a real
+ * PropertyNft.transfer (treasury → viewer) XDR for the selected starter tile
+ * and the connected wallet address, instead of the old code path that handed
+ * a literal "placeholder-starter-claim-xdr" string straight to a stubbed
+ * signAndSubmitTx.
+ */
+
+// @ts-expect-error: jsdom types not fully compatible with bun runtime
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+globalThis.window = dom.window as any;
+globalThis.document = dom.window.document as any;
+globalThis.navigator = dom.window.navigator as any;
+globalThis.HTMLElement = dom.window.HTMLElement as any;
+globalThis.MutationObserver = dom.window.MutationObserver as any;
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
+import React from "react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+mock.module("framer-motion", () => {
+  const passthrough = new Proxy(
+    {},
+    {
+      get:
+        (_target, tagName: string) =>
+        ({ children, ...props }: any) =>
+          React.createElement(tagName, props, children),
+    },
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: passthrough,
+  };
+});
+
+const CONNECTED_ADDRESS =
+  "GDVIEWER1234567890123456789012345678901234567890123456";
+const TEST_TREASURY_ADDRESS =
+  "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
+
+const mockBuildBuyFromTreasuryXdr = vi
+  .fn()
+  .mockResolvedValue(MOCK_UNSIGNED_XDR);
+vi.mock("@/lib/soroban-tx", () => ({
+  buildBuyFromTreasuryXdr: mockBuildBuyFromTreasuryXdr,
+  TREASURY_ADDRESS: TEST_TREASURY_ADDRESS,
+}));
+
+const mockSignAndSubmitTx = vi.fn().mockResolvedValue(undefined);
+const mockUseGameWallet = vi.fn(
+  (): {
+    address: string | null;
+    signAndSubmitTx: typeof mockSignAndSubmitTx;
+  } => ({
+    address: CONNECTED_ADDRESS,
+    signAndSubmitTx: mockSignAndSubmitTx,
+  }),
+);
+vi.mock("@/hooks/useGameWallet", () => ({
+  useGameWallet: mockUseGameWallet,
+}));
+
+import { ClaimPropertyStep } from "../ClaimPropertyStep";
+
+beforeEach(() => {
+  cleanup();
+  mockBuildBuyFromTreasuryXdr.mockClear();
+  mockBuildBuyFromTreasuryXdr.mockResolvedValue(MOCK_UNSIGNED_XDR);
+  mockSignAndSubmitTx.mockClear();
+  mockSignAndSubmitTx.mockResolvedValue(undefined);
+  mockUseGameWallet.mockReturnValue({
+    address: CONNECTED_ADDRESS,
+    signAndSubmitTx: mockSignAndSubmitTx,
+  });
+});
+
+/** Selects the first tile marked claimable ("(i * 7 + 3) % 2 === 0"). */
+function selectFirstClaimableTile(
+  view: ReturnType<typeof render>,
+): HTMLElement {
+  const buttons = view.container.querySelectorAll("button[type='button']");
+  const enabled = Array.from(buttons).find(
+    (btn) => !(btn as HTMLButtonElement).disabled,
+  ) as HTMLElement | undefined;
+  if (!enabled) throw new Error("No claimable starter tile found in grid");
+  return enabled;
+}
+
+describe("ClaimPropertyStep", () => {
+  it("builds a real treasury-transfer XDR for the selected tile and signs it", async () => {
+    const view = render(
+      <ClaimPropertyStep onComplete={() => {}} onSkip={() => {}} />,
+    );
+
+    fireEvent.click(selectFirstClaimableTile(view));
+    fireEvent.click(view.getByRole("button", { name: /Claim Free Property/i }));
+
+    await waitFor(() => {
+      expect(mockBuildBuyFromTreasuryXdr).toHaveBeenCalled();
+    });
+
+    const [buyer, propertyId, treasury] =
+      mockBuildBuyFromTreasuryXdr.mock.calls[0];
+    expect(buyer).toBe(CONNECTED_ADDRESS);
+    expect(treasury).toBe(TEST_TREASURY_ADDRESS);
+    expect(typeof propertyId).toBe("string");
+
+    expect(mockSignAndSubmitTx).toHaveBeenCalledWith(MOCK_UNSIGNED_XDR);
+  });
+
+  it("does not sign a hardcoded placeholder string", async () => {
+    const view = render(
+      <ClaimPropertyStep onComplete={() => {}} onSkip={() => {}} />,
+    );
+
+    fireEvent.click(selectFirstClaimableTile(view));
+    fireEvent.click(view.getByRole("button", { name: /Claim Free Property/i }));
+
+    await waitFor(() => {
+      expect(mockSignAndSubmitTx).toHaveBeenCalled();
+    });
+
+    expect(mockSignAndSubmitTx).not.toHaveBeenCalledWith(
+      "placeholder-starter-claim-xdr",
+    );
+  });
+
+  it("does not attempt to claim when no wallet address is connected", () => {
+    mockUseGameWallet.mockReturnValue({
+      address: null,
+      signAndSubmitTx: mockSignAndSubmitTx,
+    });
+
+    const view = render(
+      <ClaimPropertyStep onComplete={() => {}} onSkip={() => {}} />,
+    );
+
+    fireEvent.click(selectFirstClaimableTile(view));
+    fireEvent.click(view.getByRole("button", { name: /Claim Free Property/i }));
+
+    expect(mockBuildBuyFromTreasuryXdr).not.toHaveBeenCalled();
+    expect(mockSignAndSubmitTx).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akkuea-land/src/hooks/__tests__/useGameWallet.test.ts
+++ b/apps/akkuea-land/src/hooks/__tests__/useGameWallet.test.ts
@@ -1,0 +1,217 @@
+/**
+ * useGameWallet — unit tests
+ *
+ * Verifies that login/logout/signAndSubmitTx delegate to the real Stellar
+ * wallet kit + Soroban RPC helpers instead of the old hardcoded/simulated
+ * behaviour (fixed default address, fake setTimeout "signature").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "bun:test";
+
+// ── Shared mock data ─────────────────────────────────────────────────────────
+
+const CONNECTED_ADDRESS =
+  "GDVIEWER1234567890123456789012345678901234567890123456";
+const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
+const MOCK_SIGNED_XDR = "AAAA_SIGNED_XDR_BASE64==";
+const MOCK_TX_HASH =
+  "abc123def456abc123def456abc123def456abc123def456abc123def456abc1";
+const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+// ── Module mocks — must be declared before importing the module under test ──
+
+const mockSignTransaction = vi
+  .fn()
+  .mockResolvedValue({ signedTxXdr: MOCK_SIGNED_XDR });
+const mockKit = { signTransaction: mockSignTransaction };
+
+const mockConnectWalletKit = vi.fn();
+const mockGetWalletKit = vi.fn(() => mockKit);
+const mockResetWalletKit = vi.fn();
+
+vi.mock("@/lib/walletKit", () => ({
+  connectWalletKit: mockConnectWalletKit,
+  getWalletKit: mockGetWalletKit,
+  resetWalletKit: mockResetWalletKit,
+}));
+
+vi.mock("@/lib/soroban-tx", () => ({
+  submitSorobanTx: vi.fn().mockResolvedValue(MOCK_TX_HASH),
+  waitForSorobanTx: vi.fn().mockResolvedValue("success"),
+  NETWORK_PASSPHRASE,
+}));
+
+// ── Import after mocks are set up ────────────────────────────────────────────
+
+import { submitSorobanTx, waitForSorobanTx } from "@/lib/soroban-tx";
+import { useGameWallet, useWalletStore } from "../useGameWallet";
+
+const submitMock = submitSorobanTx as ReturnType<typeof vi.fn>;
+const waitMock = waitForSorobanTx as ReturnType<typeof vi.fn>;
+
+// ── jsdom setup for renderHook ───────────────────────────────────────────────
+
+// @ts-expect-error: jsdom types not fully compatible with bun runtime
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+globalThis.window = dom.window as any;
+globalThis.document = dom.window.document as any;
+globalThis.navigator = dom.window.navigator as any;
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act, renderHook } from "@testing-library/react";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useWalletStore.setState({ isConnected: false, address: null });
+  mockConnectWalletKit.mockReset();
+  mockGetWalletKit.mockReset();
+  mockGetWalletKit.mockReturnValue(mockKit);
+  mockSignTransaction.mockReset();
+  mockSignTransaction.mockResolvedValue({ signedTxXdr: MOCK_SIGNED_XDR });
+  submitMock.mockResolvedValue(MOCK_TX_HASH);
+  waitMock.mockResolvedValue("success");
+});
+
+describe("useGameWallet — login", () => {
+  it("connects the real wallet kit and stores the returned address", async () => {
+    mockConnectWalletKit.mockResolvedValue({
+      kit: mockKit,
+      address: CONNECTED_ADDRESS,
+    });
+
+    const { result } = renderHook(() => useGameWallet());
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(mockConnectWalletKit).toHaveBeenCalledTimes(1);
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.address).toBe(CONNECTED_ADDRESS);
+  });
+
+  it("leaves state disconnected when the user closes the wallet picker", async () => {
+    mockConnectWalletKit.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useGameWallet());
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+});
+
+describe("useGameWallet — logout", () => {
+  it("resets the wallet kit singleton and clears connection state", () => {
+    useWalletStore.setState({
+      isConnected: true,
+      address: CONNECTED_ADDRESS,
+    });
+
+    const { result } = renderHook(() => useGameWallet());
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(mockResetWalletKit).toHaveBeenCalledTimes(1);
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+});
+
+describe("useGameWallet — signAndSubmitTx", () => {
+  it("signs with the connected address, submits, and waits for confirmation", async () => {
+    useWalletStore.setState({
+      isConnected: true,
+      address: CONNECTED_ADDRESS,
+    });
+
+    const { result } = renderHook(() => useGameWallet());
+
+    await act(async () => {
+      await result.current.signAndSubmitTx(MOCK_UNSIGNED_XDR);
+    });
+
+    expect(mockSignTransaction).toHaveBeenCalledWith(MOCK_UNSIGNED_XDR, {
+      networkPassphrase: NETWORK_PASSPHRASE,
+      address: CONNECTED_ADDRESS,
+    });
+    expect(submitMock).toHaveBeenCalledWith(MOCK_SIGNED_XDR);
+    expect(waitMock).toHaveBeenCalledWith(MOCK_TX_HASH);
+  });
+
+  it("never resolves via a fake timeout — a signing rejection propagates", async () => {
+    useWalletStore.setState({
+      isConnected: true,
+      address: CONNECTED_ADDRESS,
+    });
+    mockSignTransaction.mockRejectedValueOnce(new Error("User rejected"));
+
+    const { result } = renderHook(() => useGameWallet());
+
+    let caughtError: Error | null = null;
+    await act(async () => {
+      try {
+        await result.current.signAndSubmitTx(MOCK_UNSIGNED_XDR);
+      } catch (err) {
+        caughtError = err as Error;
+      }
+    });
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).toBe("User rejected");
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when the wallet kit was never initialized", async () => {
+    mockGetWalletKit.mockReturnValueOnce(null as any);
+    useWalletStore.setState({
+      isConnected: true,
+      address: CONNECTED_ADDRESS,
+    });
+
+    const { result } = renderHook(() => useGameWallet());
+
+    let caughtError: Error | null = null;
+    await act(async () => {
+      try {
+        await result.current.signAndSubmitTx(MOCK_UNSIGNED_XDR);
+      } catch (err) {
+        caughtError = err as Error;
+      }
+    });
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).toBe("Stellar Wallet Kit is not initialized.");
+  });
+
+  it("throws when no wallet address is connected", async () => {
+    useWalletStore.setState({ isConnected: false, address: null });
+
+    const { result } = renderHook(() => useGameWallet());
+
+    let caughtError: Error | null = null;
+    await act(async () => {
+      try {
+        await result.current.signAndSubmitTx(MOCK_UNSIGNED_XDR);
+      } catch (err) {
+        caughtError = err as Error;
+      }
+    });
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).toBe("Wallet not connected.");
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts
+++ b/apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts
@@ -26,11 +26,13 @@ vi.mock("@/lib/soroban-tx", () => ({
   buildBuyFromTreasuryXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
   buildBuyFromPlayerXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
   buildImprovePropertyXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
+  buildApproveMarketplaceXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
   buildListForSaleXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
   buildClaimIncomeXdr: vi.fn().mockResolvedValue(MOCK_UNSIGNED_XDR),
   submitSorobanTx: vi.fn().mockResolvedValue(MOCK_TX_HASH),
   waitForSorobanTx: vi.fn().mockResolvedValue("success"),
   NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  TREASURY_ADDRESS: TREASURY,
 }));
 
 // Mock walletKit to return a controllable signTransaction function
@@ -55,6 +57,8 @@ vi.mock("@/lib/walletKit", () => ({
 
 import {
   buildBuyFromTreasuryXdr,
+  buildApproveMarketplaceXdr,
+  buildListForSaleXdr,
   submitSorobanTx,
   waitForSorobanTx,
 } from "@/lib/soroban-tx";
@@ -664,6 +668,50 @@ describe("usePropertyActions", () => {
       );
       expect(result.current.error).toBeNull();
       expect(result.current.pendingAction).toBeNull();
+    });
+
+    it("approves the marketplace as spender before listing (transfer_from prerequisite)", async () => {
+      const onPropertyUpdate = vi.fn();
+      const approveMock = buildApproveMarketplaceXdr as ReturnType<
+        typeof vi.fn
+      >;
+      const listMock = buildListForSaleXdr as ReturnType<typeof vi.fn>;
+
+      const callOrder: string[] = [];
+      approveMock.mockImplementationOnce(async () => {
+        callOrder.push("approve");
+        return MOCK_UNSIGNED_XDR;
+      });
+      listMock.mockImplementationOnce(async () => {
+        callOrder.push("list");
+        return MOCK_UNSIGNED_XDR;
+      });
+
+      const { result } = renderHook(() =>
+        usePropertyActions(
+          baseProperty,
+          onPropertyUpdate,
+          VIEWER_ADDRESS,
+          true,
+        ),
+      );
+
+      await act(async () => {
+        await result.current.listForSale(300);
+      });
+
+      expect(approveMock).toHaveBeenCalledWith(
+        VIEWER_ADDRESS,
+        baseProperty.id,
+      );
+      expect(listMock).toHaveBeenCalledWith(
+        VIEWER_ADDRESS,
+        baseProperty.id,
+        300,
+      );
+      // Approval must be signed+submitted before the listing transaction.
+      expect(mockSignTransaction).toHaveBeenCalledTimes(2);
+      expect(callOrder).toEqual(["approve", "list"]);
     });
   });
 

--- a/apps/akkuea-land/src/hooks/useGameWallet.ts
+++ b/apps/akkuea-land/src/hooks/useGameWallet.ts
@@ -1,4 +1,14 @@
 import { create } from "zustand";
+import {
+  connectWalletKit,
+  getWalletKit,
+  resetWalletKit,
+} from "@/lib/walletKit";
+import {
+  submitSorobanTx,
+  waitForSorobanTx,
+  NETWORK_PASSPHRASE,
+} from "@/lib/soroban-tx";
 
 interface WalletStore {
   isConnected: boolean;
@@ -7,11 +17,9 @@ interface WalletStore {
   setAddress: (address: string | null) => void;
 }
 
-const DEFAULT_ADDRESS = process.env.NEXT_PUBLIC_DEFAULT_VIEWER_ADDRESS ?? "";
-
 export const useWalletStore = create<WalletStore>((set) => ({
-  isConnected: true, // Default to true for the sandbox environment
-  address: DEFAULT_ADDRESS,
+  isConnected: false,
+  address: null,
   setIsConnected: (connected) => set({ isConnected: connected }),
   setAddress: (address) => set({ address }),
 }));
@@ -19,19 +27,41 @@ export const useWalletStore = create<WalletStore>((set) => ({
 export function useGameWallet() {
   const { isConnected, address, setIsConnected, setAddress } = useWalletStore();
 
-  const login = () => {
+  /**
+   * Opens the Stellar wallet picker (Freighter, etc.) and connects the
+   * selected account. Leaves state untouched if the user closes the picker
+   * without choosing a wallet.
+   */
+  const login = async () => {
+    const wallet = await connectWalletKit();
+    if (!wallet) return;
     setIsConnected(true);
-    setAddress(DEFAULT_ADDRESS);
+    setAddress(wallet.address);
   };
 
   const logout = () => {
+    resetWalletKit();
     setIsConnected(false);
     setAddress(null);
   };
 
-  const signAndSubmitTx = async (xdr: string) => {
-    // Simulate transaction submission delay
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+  /**
+   * Sign a built XDR with the connected wallet, submit it to the Soroban RPC,
+   * and wait for on-chain confirmation. Throws on signing failure, submission
+   * error, or on-chain failure.
+   */
+  const signAndSubmitTx = async (xdr: string): Promise<void> => {
+    const kit = getWalletKit();
+    if (!kit) throw new Error("Stellar Wallet Kit is not initialized.");
+    if (!address) throw new Error("Wallet not connected.");
+
+    const { signedTxXdr } = await kit.signTransaction(xdr, {
+      networkPassphrase: NETWORK_PASSPHRASE,
+      address,
+    });
+
+    const txHash = await submitSorobanTx(signedTxXdr);
+    await waitForSorobanTx(txHash);
   };
 
   return {

--- a/apps/akkuea-land/src/hooks/usePropertyActions.ts
+++ b/apps/akkuea-land/src/hooks/usePropertyActions.ts
@@ -5,16 +5,14 @@ import {
   buildBuyFromTreasuryXdr,
   buildBuyFromPlayerXdr,
   buildImprovePropertyXdr,
+  buildApproveMarketplaceXdr,
   buildListForSaleXdr,
   buildClaimIncomeXdr,
   submitSorobanTx,
   waitForSorobanTx,
   NETWORK_PASSPHRASE,
+  TREASURY_ADDRESS,
 } from "@/lib/soroban-tx";
-
-/** Stellar address used as the treasury in the game contract. */
-const TREASURY_ADDRESS =
-  process.env.NEXT_PUBLIC_TREASURY_ADDRESS ?? "GBTREASURY";
 
 export const usePropertyActions = (
   property: GameProperty,
@@ -143,12 +141,20 @@ export const usePropertyActions = (
         isListed: true,
       }),
       async () => {
-        const xdr = await buildListForSaleXdr(
+        // The marketplace escrows the NFT via transfer_from, so it must be
+        // approved as spender before list() will succeed.
+        const approveXdr = await buildApproveMarketplaceXdr(
+          viewerAddress!,
+          property.id,
+        );
+        await signAndSubmit(approveXdr);
+
+        const listXdr = await buildListForSaleXdr(
           viewerAddress!,
           property.id,
           price,
         );
-        await signAndSubmit(xdr);
+        await signAndSubmit(listXdr);
       },
     );
   };

--- a/apps/akkuea-land/src/lib/__tests__/soroban-tx.test.ts
+++ b/apps/akkuea-land/src/lib/__tests__/soroban-tx.test.ts
@@ -1,0 +1,98 @@
+/**
+ * soroban-tx — contract ID wiring regression tests
+ *
+ * Before this fix, PROPERTY_NFT_CONTRACT_ID / GAME_ENGINE_CONTRACT_ID /
+ * MARKETPLACE_CONTRACT_ID fell back to IDs from the unrelated defi-rwa
+ * deployment (contracts.testnet.json — REAL_ESTATE_TOKEN / DEFI_LENDING)
+ * whenever an env var override was not set, so every simulated transaction
+ * silently targeted the wrong contract.
+ *
+ * These tests import the real (unmocked) module and confirm every contract
+ * ID + the treasury address now default to the actually-deployed game
+ * contracts recorded in game-contracts.testnet.json.
+ */
+
+import { describe, it, expect } from "bun:test";
+import gameContractsTestnet from "@akkuea/shared/game-contracts.testnet.json";
+import defiRwaContractsTestnet from "@akkuea/shared/contracts.testnet.json";
+import {
+  PROPERTY_NFT_CONTRACT_ID,
+  GAME_ENGINE_CONTRACT_ID,
+  MARKETPLACE_CONTRACT_ID,
+  LAND_TOKEN_CONTRACT_ID,
+  TREASURY_ADDRESS,
+  propertyIdToU32,
+  buildApproveMarketplaceXdr,
+  buildFaucetClaimXdr,
+} from "@/lib/soroban-tx";
+
+describe("soroban-tx — game contract ID resolution", () => {
+  it("PROPERTY_NFT_CONTRACT_ID defaults to the deployed GAME_PROPERTY_NFT contract", () => {
+    expect(PROPERTY_NFT_CONTRACT_ID).toBe(
+      gameContractsTestnet.contracts.GAME_PROPERTY_NFT.contractId,
+    );
+  });
+
+  it("GAME_ENGINE_CONTRACT_ID defaults to the deployed GAME_ENGINE contract", () => {
+    expect(GAME_ENGINE_CONTRACT_ID).toBe(
+      gameContractsTestnet.contracts.GAME_ENGINE.contractId,
+    );
+  });
+
+  it("MARKETPLACE_CONTRACT_ID defaults to the deployed GAME_MARKETPLACE contract", () => {
+    expect(MARKETPLACE_CONTRACT_ID).toBe(
+      gameContractsTestnet.contracts.GAME_MARKETPLACE.contractId,
+    );
+  });
+
+  it("LAND_TOKEN_CONTRACT_ID defaults to the deployed GAME_LAND_TOKEN contract", () => {
+    expect(LAND_TOKEN_CONTRACT_ID).toBe(
+      gameContractsTestnet.contracts.GAME_LAND_TOKEN.contractId,
+    );
+  });
+
+  it("TREASURY_ADDRESS defaults to the game contracts deployer, not a placeholder string", () => {
+    expect(TREASURY_ADDRESS).toBe(gameContractsTestnet.deployedBy);
+    expect(TREASURY_ADDRESS).not.toBe("GBTREASURY");
+    // A real Stellar public key: 56 chars, starts with G.
+    expect(TREASURY_ADDRESS).toMatch(/^G[A-Z0-9]{55}$/);
+  });
+
+  it("never falls back to the unrelated defi-rwa deployment", () => {
+    expect(PROPERTY_NFT_CONTRACT_ID).not.toBe(
+      defiRwaContractsTestnet.contracts.REAL_ESTATE_TOKEN,
+    );
+    expect(GAME_ENGINE_CONTRACT_ID).not.toBe(
+      defiRwaContractsTestnet.contracts.DEFI_LENDING,
+    );
+    expect(MARKETPLACE_CONTRACT_ID).not.toBe(
+      defiRwaContractsTestnet.contracts.REAL_ESTATE_TOKEN,
+    );
+  });
+
+  it("every game contract ID is unique (no accidental cross-wiring)", () => {
+    const ids = [
+      PROPERTY_NFT_CONTRACT_ID,
+      GAME_ENGINE_CONTRACT_ID,
+      MARKETPLACE_CONTRACT_ID,
+      LAND_TOKEN_CONTRACT_ID,
+    ];
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("soroban-tx — propertyIdToU32 (regression, still real)", () => {
+  it('still converts "prop-3-7" to 67 with the real module import path', () => {
+    expect(propertyIdToU32("prop-3-7")).toBe(67);
+  });
+});
+
+describe("soroban-tx — new real-contract builders exist", () => {
+  it("exports buildFaucetClaimXdr for the onboarding LAND claim step", () => {
+    expect(typeof buildFaucetClaimXdr).toBe("function");
+  });
+
+  it("exports buildApproveMarketplaceXdr for the list-for-sale approval step", () => {
+    expect(typeof buildApproveMarketplaceXdr).toBe("function");
+  });
+});

--- a/apps/akkuea-land/src/lib/soroban-tx.ts
+++ b/apps/akkuea-land/src/lib/soroban-tx.ts
@@ -22,41 +22,62 @@ import {
   rpc as SorobanRpc,
   xdr,
 } from "@stellar/stellar-sdk";
-import contractsTestnet from "@akkuea/shared/contracts.testnet.json";
+import gameContractsTestnet from "@akkuea/shared/game-contracts.testnet.json";
 
 // ── Network constants ────────────────────────────────────────────────────────
 
 export const NETWORK_PASSPHRASE = Networks.TESTNET;
 export const RPC_URL =
   process.env.NEXT_PUBLIC_STELLAR_RPC_URL ??
-  contractsTestnet.rpcUrl ??
+  gameContractsTestnet.rpcUrl ??
   "https://soroban-testnet.stellar.org";
 
 // ── Contract addresses ───────────────────────────────────────────────────────
+//
+// Every ID below falls back to the real, deployed game contracts recorded in
+// game-contracts.testnet.json (see docs/deployment/deploy-game-contracts.md).
+// An env var override lets a reviewer point the app at their own deploy
+// without editing this file.
 
 /**
- * The game's property NFT contract (REAL_ESTATE_TOKEN instance on testnet).
+ * The game's property NFT contract.
  * Treasury purchases and NFT transfers go through this contract.
  */
 export const PROPERTY_NFT_CONTRACT_ID =
   process.env.NEXT_PUBLIC_PROPERTY_NFT_CONTRACT_ID ??
-  contractsTestnet.contracts.REAL_ESTATE_TOKEN;
+  gameContractsTestnet.contracts.GAME_PROPERTY_NFT.contractId;
 
 /**
  * The game engine contract, used for improve and claim_rental.
- * Falls back to the DEFI_LENDING instance ID if a dedicated env var is not set.
  */
 export const GAME_ENGINE_CONTRACT_ID =
   process.env.NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID ??
-  contractsTestnet.contracts.DEFI_LENDING;
+  gameContractsTestnet.contracts.GAME_ENGINE.contractId;
 
 /**
  * The marketplace contract for player-to-player purchases.
- * Override via env var once that contract is deployed separately.
  */
 export const MARKETPLACE_CONTRACT_ID =
   process.env.NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID ??
-  contractsTestnet.contracts.REAL_ESTATE_TOKEN;
+  gameContractsTestnet.contracts.GAME_MARKETPLACE.contractId;
+
+/**
+ * The LAND utility token contract, used for the onboarding faucet claim and
+ * balance reads.
+ */
+export const LAND_TOKEN_CONTRACT_ID =
+  process.env.NEXT_PUBLIC_LAND_TOKEN_CONTRACT_ID ??
+  gameContractsTestnet.contracts.GAME_LAND_TOKEN.contractId;
+
+/**
+ * The Stellar account that owns every unclaimed tile on-chain. Defaults to
+ * the address that deployed and initialized the game contracts (see
+ * `deployedBy` in game-contracts.testnet.json) — by convention the same key
+ * also holds the treasury role unless a separate treasury was passed to the
+ * deploy script.
+ */
+export const TREASURY_ADDRESS =
+  process.env.NEXT_PUBLIC_TREASURY_ADDRESS ?? gameContractsTestnet.deployedBy;
 
 // ── Shared RPC server singleton ──────────────────────────────────────────────
 
@@ -261,9 +282,43 @@ export async function buildImprovePropertyXdr(
 }
 
 /**
+ * Build XDR for: GamePropertyNft.approve(owner, spender, property_id)
+ *
+ * The marketplace contract's `list` calls `transfer_from` to take custody of
+ * the NFT, so the seller must approve the marketplace contract as spender
+ * before listing. Must be signed and confirmed before buildListForSaleXdr.
+ *
+ * @param ownerAddress  Seller's Stellar address (current owner of the tile).
+ * @param propertyId    GameProperty.id string.
+ */
+export async function buildApproveMarketplaceXdr(
+  ownerAddress: string,
+  propertyId: string,
+): Promise<string> {
+  const u32Id = propertyIdToU32(propertyId);
+
+  return buildSorobanTx({
+    sourceAddress: ownerAddress,
+    contractId: PROPERTY_NFT_CONTRACT_ID,
+    functionName: "approve",
+    args: [
+      // owner: Address
+      nativeToScVal(ownerAddress, { type: "address" }),
+      // spender: Address (the marketplace contract itself)
+      nativeToScVal(MARKETPLACE_CONTRACT_ID, { type: "address" }),
+      // property_id: u32
+      nativeToScVal(u32Id, { type: "u32" }),
+    ],
+  });
+}
+
+/**
  * Build XDR for: GameMarketplace.list(seller, property_id, price)
  *
  * Lists a property for sale on the marketplace at the given price (in LAND).
+ * The seller must already have approved the marketplace as spender via
+ * buildApproveMarketplaceXdr — the marketplace's `list` immediately calls
+ * `transfer_from` to escrow the NFT.
  *
  * @param sellerAddress  Owner's Stellar address.
  * @param propertyId     GameProperty.id string.
@@ -316,6 +371,29 @@ export async function buildClaimIncomeXdr(
       nativeToScVal(callerAddress, { type: "address" }),
       // property_id: u32
       nativeToScVal(u32Id, { type: "u32" }),
+    ],
+  });
+}
+
+/**
+ * Build XDR for: GameLandToken.faucet(recipient)
+ *
+ * Claims the one-time testnet faucet grant of LAND tokens. Used by the
+ * onboarding "Claim your starter LAND" step. Only callable when the token
+ * contract was initialized with `is_testnet = true`.
+ *
+ * @param recipientAddress  Stellar address to receive the faucet grant.
+ */
+export async function buildFaucetClaimXdr(
+  recipientAddress: string,
+): Promise<string> {
+  return buildSorobanTx({
+    sourceAddress: recipientAddress,
+    contractId: LAND_TOKEN_CONTRACT_ID,
+    functionName: "faucet",
+    args: [
+      // recipient: Address
+      nativeToScVal(recipientAddress, { type: "address" }),
     ],
   });
 }

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -10,7 +10,8 @@
       "default": "./dist/index.js"
     },
     "./contracts.testnet.json": "./src/contracts.testnet.json",
-    "./contracts.mainnet.json": "./src/contracts.mainnet.json"
+    "./contracts.mainnet.json": "./src/contracts.mainnet.json",
+    "./game-contracts.testnet.json": "./src/contracts/game-contracts.testnet.json"
   },
   "scripts": {
     "build": "tsc",

--- a/docs/deployment/deploy-game-contracts.md
+++ b/docs/deployment/deploy-game-contracts.md
@@ -1,6 +1,6 @@
 # Game Contracts Deployment Guide (Akkuea Land)
 
-This guide deploys the three Akkuea Land game contracts to Stellar **testnet** and wires the resulting contract IDs into the `apps/akkuea-land` frontend so the dashboard's "Claim All" button signs and submits real `claim_rental` transactions.
+This guide deploys the four Akkuea Land game contracts to Stellar **testnet** and wires the resulting contract IDs into the `apps/akkuea-land` frontend so the full flow — claim a starter property and LAND, view the dashboard, claim rental income, list/buy on the marketplace — signs and submits real transactions end to end. No part of the flow talks to mocked data or the unrelated defi-rwa contracts.
 
 **Contract sources:**
 
@@ -9,8 +9,11 @@ This guide deploys the three Akkuea Land game contracts to Stellar **testnet** a
 | Property NFT | `apps/contracts/contracts/game-property-nft` | `game_property_nft.wasm` |
 | LAND token   | `apps/contracts/contracts/game-land-token`   | `game_land_token.wasm`   |
 | Game engine  | `apps/contracts/contracts/game-engine`       | `game_engine.wasm`       |
+| Marketplace  | `apps/contracts/contracts/game-marketplace`  | `game_marketplace.wasm`  |
 
 Unlike the defi-rwa contract (which uses `__constructor`), each game contract is deployed **and then explicitly initialized** with a separate `initialize` invocation. The script below does both.
+
+> This repo already carries a deployed instance at `apps/shared/src/contracts/game-contracts.testnet.json` (all four contracts, deployed 2026-06-24). Steps 1–2 below are only needed if you want to deploy your **own** instance instead of reusing that one — the frontend falls back to the checked-in IDs automatically when the `NEXT_PUBLIC_*_CONTRACT_ID` env vars are unset (see Step 3).
 
 ---
 
@@ -41,11 +44,12 @@ The script:
 
 1. Generates + funds the `game-deployer` identity if it doesn't exist (testnet friendbot).
 2. Builds all contracts with `stellar contract build` (targets `wasm32v1-none`; a raw `cargo build --target wasm32-unknown-unknown` on modern rustc emits reference-types the Soroban VM rejects at upload).
-3. Deploys the three WASMs and captures their contract IDs.
+3. Deploys the four WASMs and captures their contract IDs.
 4. Initializes them in dependency order:
    - `game_property_nft.initialize(treasury, game_engine)` — after this, the **treasury logically owns all 400 tiles**; no minting or seeding is needed.
    - `game_land_token.initialize(treasury, engine, is_testnet=true)`
    - `game_engine.initialize(nft_contract, token_contract, treasury)`
+   - `game_marketplace.initialize(nft_contract, land_token)`
 5. Prints a ready-to-paste `.env.local` block.
 
 By default the deployer identity **is** the treasury, so the same key that deployed can claim rental income in the browser. To use a different treasury: `./scripts/deploy-game-contracts.sh testnet game-deployer G...TREASURY`.
@@ -75,12 +79,14 @@ Create `apps/akkuea-land/.env.local` (gitignored) from the script's output:
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_DEFAULT_VIEWER_ADDRESS=G...   # deployer/treasury public key
 NEXT_PUBLIC_TREASURY_ADDRESS=G...         # same as above by default
-NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID=C...  # from script output — MANDATORY
+NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID=C...  # from script output
 NEXT_PUBLIC_PROPERTY_NFT_CONTRACT_ID=C...
 NEXT_PUBLIC_LAND_TOKEN_CONTRACT_ID=C...
+NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID=C...
 ```
 
-`NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID` is mandatory: without it, `soroban-tx.ts` falls back to the DeFi lending contract ID and every `claim_rental` simulation fails against the wrong contract.
+None of these are strictly mandatory: every contract ID in `soroban-tx.ts` (`PROPERTY_NFT_CONTRACT_ID`, `GAME_ENGINE_CONTRACT_ID`, `MARKETPLACE_CONTRACT_ID`, `LAND_TOKEN_CONTRACT_ID`) and `TREASURY_ADDRESS` fall back to the checked-in `game-contracts.testnet.json` deploy when the env var is unset. Set them only when pointing the app at your **own** deploy from Step 1 — otherwise the app already talks to the shared testnet instance recorded in that file.
+(Historically `NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID` was the one exception — an unset value silently fell back to the unrelated DeFi lending contract ID. That fallback bug is fixed: every ID now falls back to the correct game contract.)
 
 ---
 
@@ -107,6 +113,27 @@ stellar contract invoke --id $TOKEN_ID --source-account $IDENTITY --network test
   -- balance --id $TREASURY
 ```
 
+Marketplace round-trip (list → buy), using a second funded identity as the buyer:
+
+```bash
+MARKETPLACE_ID=C...   # from script output
+NFT_ID=C...
+
+# 1. Treasury approves the marketplace as spender for tile 5, then lists it
+stellar contract invoke --id $NFT_ID --source-account $IDENTITY --network testnet \
+  -- approve --owner $TREASURY --spender $MARKETPLACE_ID --property_id 5
+stellar contract invoke --id $MARKETPLACE_ID --source-account $IDENTITY --network testnet \
+  -- list --seller $TREASURY --property_id 5 --price 1000000000
+
+# 2. A second identity ("buyer") with a LAND balance buys it
+stellar contract invoke --id $MARKETPLACE_ID --source-account buyer --network testnet \
+  -- buy --buyer $(stellar keys address buyer) --property_id 5
+
+# 3. Owner should now be the buyer
+stellar contract invoke --id $NFT_ID --source-account $IDENTITY --network testnet \
+  -- get_owner --property_id 5
+```
+
 ---
 
 ## Step 5 — Verify in the browser
@@ -115,17 +142,25 @@ stellar contract invoke --id $TOKEN_ID --source-account $IDENTITY --network test
 bun run dev   # from repo root, akkuea-land on its dev port
 ```
 
-Open the Akkuea Land dashboard (`/dashboard`) and press **Claim All**. On first use a wallet-picker modal opens — choose Freighter (with the imported key selected and Freighter on Testnet). Each claimable property then triggers a real Freighter signing prompt; the transaction is submitted to the Soroban RPC and polled until confirmed. Rejecting a prompt records that property in the "Failed" list and the loop continues with the next one; closing the wallet picker aborts without claiming.
+The full flow now goes through real contract calls, no mocked data or hardcoded XDR:
+
+- **Onboarding** (`/onboarding`): "Claim your starter LAND" builds a real `GameLandToken.faucet` transaction for the connected wallet; "Claim your first property" builds a real `GamePropertyNft.transfer` (treasury → viewer) for the selected tile. Both open a real Freighter signing prompt.
+- **Dashboard** (`/dashboard`): **Claim All** builds a real `claim_rental` transaction per claimable property, sequentially, sign-submit-confirm.
+- **City map** (`/`): selecting a treasury tile and clicking **Buy from Treasury** builds a real treasury transfer; selecting an owned tile and clicking **Improve** or **List for Sale** builds a real `improve` / `approve` + `list` pair; selecting a listed tile and clicking **Buy Land Tile** builds a real marketplace `buy`.
+
+On first wallet action a wallet-picker modal opens — choose Freighter (with the imported key selected and Freighter on Testnet). Each action then triggers a real Freighter signing prompt; the transaction is submitted to the Soroban RPC and polled until confirmed. For **Claim All**, rejecting a prompt records that property in the "Failed" list and the loop continues with the next one; closing the wallet picker aborts without claiming.
 
 ---
 
 ## Troubleshooting
 
-| Symptom                                           | Cause                                                                                 | Fix                                                                                                                                                    |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Error(Contract, #2)` (NotOwner)                  | Signing wallet is not the on-chain tile owner                                         | Sign with the treasury key, or transfer the tile: `stellar contract invoke --id $NFT_ID ... -- transfer --from $TREASURY --to $WALLET --property_id N` |
-| `Error(Contract, #4)` (NothingToClaim)            | Less than one epoch (100 ledgers) since init / last claim                             | Wait ~9 minutes and retry                                                                                                                              |
-| `Error(Contract, #5)` (InsufficientBalance)       | Engine-side balance check failed                                                      | Check the LAND token init used the correct engine address                                                                                              |
-| Simulation fails with an unrelated contract error | `NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID` unset — frontend fell back to the DeFi contract | Set the env var in `.env.local` and restart the dev server                                                                                             |
-| `Transaction submission rejected by node`         | Source account can't cover the fee                                                    | Fund the account: `stellar keys fund $IDENTITY --network testnet`                                                                                      |
-| Contract IDs stop working                         | Stellar testnet is periodically reset                                                 | Re-run the deploy script and update `.env.local`                                                                                                       |
+| Symptom                                                | Cause                                                                       | Fix                                                                                                                                                    |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Error(Contract, #2)` (NotOwner)                       | Signing wallet is not the on-chain tile owner                               | Sign with the treasury key, or transfer the tile: `stellar contract invoke --id $NFT_ID ... -- transfer --from $TREASURY --to $WALLET --property_id N` |
+| `Error(Contract, #4)` (NothingToClaim, game_engine)    | Less than one epoch (100 ledgers) since init / last claim                   | Wait ~9 minutes and retry                                                                                                                              |
+| `Error(Contract, #4)` (NotListed, game_marketplace)    | Listing was already bought/cancelled, or `list` was never called            | Re-list the tile before calling `buy`                                                                                                                  |
+| `Error(Contract, #3)` (NotApproved, game_property_nft) | `approve(owner, marketplace, property_id)` was skipped before `list`        | The frontend now does this automatically in `usePropertyActions.listForSale`; via CLI, call `approve` before `list`                                    |
+| `Error(Contract, #5)` (InsufficientBalance)            | Engine-side balance check failed, or buyer lacks enough LAND on marketplace | Check the LAND token init used the correct engine address / fund the buyer via `faucet`                                                                |
+| Simulation fails with an unrelated contract error      | A `NEXT_PUBLIC_*_CONTRACT_ID` override points at the wrong contract         | Unset the override to fall back to `game-contracts.testnet.json`, or double-check the ID against your own deploy output                                |
+| `Transaction submission rejected by node`              | Source account can't cover the fee                                          | Fund the account: `stellar keys fund $IDENTITY --network testnet`                                                                                      |
+| Contract IDs stop working                              | Stellar testnet is periodically reset                                       | Re-run the deploy script and update `.env.local`                                                                                                       |

--- a/scripts/deploy-game-contracts.sh
+++ b/scripts/deploy-game-contracts.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Deploys and initializes the three Akkuea Land game contracts
-# (game-property-nft, game-land-token, game-engine) to a Stellar network.
+# Deploys and initializes the four Akkuea Land game contracts
+# (game-property-nft, game-land-token, game-engine, game-marketplace) to a
+# Stellar network.
 #
 # Usage:
 #   ./scripts/deploy-game-contracts.sh [network] [identity] [treasury]
@@ -50,7 +51,7 @@ echo "Treasury: $TREASURY"
 echo "Building contracts..."
 (cd "$CONTRACTS_DIR" && stellar contract build)
 
-for wasm in game_property_nft game_land_token game_engine; do
+for wasm in game_property_nft game_land_token game_engine game_marketplace; do
     if [ ! -f "$WASM_DIR/$wasm.wasm" ]; then
         echo "Missing $WASM_DIR/$wasm.wasm after build." >&2
         exit 1
@@ -77,6 +78,10 @@ echo "  -> $TOKEN_ID"
 echo "Deploying game_engine..."
 ENGINE_ID="$(deploy game_engine)"
 echo "  -> $ENGINE_ID"
+
+echo "Deploying game_marketplace..."
+MARKETPLACE_ID="$(deploy game_marketplace)"
+echo "  -> $MARKETPLACE_ID"
 
 # ── 4. Initialize ─────────────────────────────────────────────────────────────
 # Arg names match the Rust signatures exactly. The NFT and token contracts
@@ -105,6 +110,9 @@ invoke "$TOKEN_ID" initialize --treasury "$TREASURY" --engine "$ENGINE_ID" --is_
 echo "Initializing game_engine..."
 invoke "$ENGINE_ID" initialize --nft_contract "$NFT_ID" --token_contract "$TOKEN_ID" --treasury "$TREASURY"
 
+echo "Initializing game_marketplace..."
+invoke "$MARKETPLACE_ID" initialize --nft_contract "$NFT_ID" --land_token "$TOKEN_ID"
+
 # ── 5. Summary ────────────────────────────────────────────────────────────────
 
 cat <<EOF
@@ -114,6 +122,7 @@ Deployment complete.
   game_property_nft: $NFT_ID
   game_land_token:   $TOKEN_ID
   game_engine:       $ENGINE_ID
+  game_marketplace:  $MARKETPLACE_ID
   treasury:          $TREASURY
 
 Paste into apps/akkuea-land/.env.local:
@@ -124,6 +133,7 @@ NEXT_PUBLIC_TREASURY_ADDRESS=$TREASURY
 NEXT_PUBLIC_GAME_ENGINE_CONTRACT_ID=$ENGINE_ID
 NEXT_PUBLIC_PROPERTY_NFT_CONTRACT_ID=$NFT_ID
 NEXT_PUBLIC_LAND_TOKEN_CONTRACT_ID=$TOKEN_ID
+NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID=$MARKETPLACE_ID
 
 Income accrues once per epoch (100 ledgers, ~9 min on testnet) — wait one
 epoch after init before the first claim_rental can succeed.


### PR DESCRIPTION
Closes #1016

## Summary

Completes the real-contract wiring for the Akkuea Land game flow so `useGameWallet` and `usePropertyActions` — and everything that calls into them (onboarding, city map, dashboard) — talk to the actually deployed testnet game contracts end to end, with no mocked data or hardcoded/simulated transaction payloads left on the hot path.

This reuses the 4 game contracts already deployed to testnet in a prior branch/fork (recorded in `apps/shared/src/contracts/game-contracts.testnet.json`, deployed 2026-06-24) rather than redeploying, per the issue's "or reuse the deploy from #983 / #984 if you tackle them in the same branch/fork" option. The deploy script/docs are extended to cover the 4th contract (marketplace), which was deployed but not previously scripted, so a reviewer can reproduce the whole deployment (or point their own instance at it) from one command.

## What was actually broken

- `useGameWallet.login()` just set a hardcoded env-var address and flipped a flag — it never called the real wallet kit. `logout()` never reset the kit. `signAndSubmitTx()` was a literal `setTimeout` "signature" that always resolved.
- `soroban-tx.ts` resolved `GAME_ENGINE_CONTRACT_ID` and `MARKETPLACE_CONTRACT_ID` from the **wrong, unrelated defi-rwa deployment** (`DEFI_LENDING` / `REAL_ESTATE_TOKEN` in `contracts.testnet.json`) whenever an env var override wasn't set — every `improve`/`claim_rental`/`list`/`buy` simulation would silently target the wrong contract.
- `usePropertyActions.ts` hardcoded a `"GBTREASURY"` placeholder treasury address (not a valid Stellar key), and `PropertyPanel`'s ownership-state resolver compared against that same literal, so the "unowned/treasury" UI branch could never match a real on-chain treasury address.
- Onboarding's `ClaimLandStep` / `ClaimPropertyStep` passed literal strings (`"placeholder-faucet-xdr"`, `"placeholder-starter-claim-xdr"`) straight into `signAndSubmitTx`, so both onboarding steps only ever pretended to submit a transaction.
- `usePropertyActions.listForSale` called the marketplace's `list()` directly, but the real `GameMarketplace` contract escrows the NFT via `transfer_from`, which requires the seller to have called `PropertyNft.approve(seller, marketplace, property_id)` first — the missing approval would make every real listing fail with `NotApproved`.
- The 4th deployed contract (`game_marketplace`) had no corresponding step in `scripts/deploy-game-contracts.sh`, so the checked-in deployment couldn't be reproduced from the documented script.

## What changed

### `apps/akkuea-land/src/hooks/useGameWallet.ts`
- `login()` now calls `connectWalletKit()` (opens the real wallet picker, e.g. Freighter) and stores the address it returns; leaves state untouched if the user closes the picker.
- `logout()` calls `resetWalletKit()` and clears connection state.
- `signAndSubmitTx()` now signs with the real wallet kit, submits via `submitSorobanTx`, and polls via `waitForSorobanTx` — real sign → submit → confirm, no fake delay.
- Store now defaults to disconnected (`isConnected: false`, `address: null`) instead of auto-connecting to a fixed sandbox address.

### `apps/akkuea-land/src/lib/soroban-tx.ts`
- All contract ID constants (`PROPERTY_NFT_CONTRACT_ID`, `GAME_ENGINE_CONTRACT_ID`, `MARKETPLACE_CONTRACT_ID`) now fall back to the real deployed game contracts in `game-contracts.testnet.json` instead of the defi-rwa deployment.
- Added `LAND_TOKEN_CONTRACT_ID` (falls back to `GAME_LAND_TOKEN`).
- Added `TREASURY_ADDRESS`, defaulting to the deploy's recorded `deployedBy` treasury key instead of the `"GBTREASURY"` placeholder.
- Added `buildFaucetClaimXdr(recipient)` — `GameLandToken.faucet(recipient)`.
- Added `buildApproveMarketplaceXdr(owner, propertyId)` — `PropertyNft.approve(owner, marketplace, propertyId)`, the prerequisite for listing.

### `apps/akkuea-land/src/hooks/usePropertyActions.ts`
- Imports `TREASURY_ADDRESS` from `soroban-tx.ts` instead of hardcoding a fallback.
- `listForSale` now builds + signs + submits the approve transaction before building + signing + submitting the list transaction.

### `apps/akkuea-land/src/components/game/onboarding/ClaimLandStep.tsx` / `ClaimPropertyStep.tsx`
- Read the connected `address` from `useGameWallet` and build a real `buildFaucetClaimXdr` / `buildBuyFromTreasuryXdr` transaction instead of passing a literal placeholder string. No-op (rather than silently "succeeding") when no wallet is connected.

### `apps/akkuea-land/src/components/game/PropertyPanel/index.tsx`
- `getOwnershipState` compares `property.owner` against the real `TREASURY_ADDRESS` constant instead of the `"GBTREASURY"` literal.

### `apps/shared/package.json`
- Exposed `./game-contracts.testnet.json` as a subpath export (mirroring the existing `contracts.testnet.json` / `contracts.mainnet.json` exports) so the frontend can import the real deployed game contract IDs.

### `scripts/deploy-game-contracts.sh` / `docs/deployment/deploy-game-contracts.md`
- Script now also deploys and initializes `game_marketplace` (`initialize(nft_contract, land_token)`), alongside the existing property-nft/land-token/engine steps, and prints `NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID` in the `.env.local` block.
- Doc updated: 4-contract table, note that the repo already carries a deployed instance (reused by this PR) and env vars are optional overrides rather than mandatory, a CLI marketplace list→buy walkthrough, and a browser walkthrough covering onboarding, dashboard, and city-map flows against real contracts. Troubleshooting table extended with marketplace-specific error codes (`NotListed`, `NotApproved`).

## Files

**New files**
- `apps/akkuea-land/src/hooks/__tests__/useGameWallet.test.ts`
- `apps/akkuea-land/src/lib/__tests__/soroban-tx.test.ts`
- `apps/akkuea-land/src/components/game/onboarding/__tests__/ClaimLandStep.test.tsx`
- `apps/akkuea-land/src/components/game/onboarding/__tests__/ClaimPropertyStep.test.tsx`

**Modified files**
- `apps/akkuea-land/src/hooks/useGameWallet.ts`
- `apps/akkuea-land/src/hooks/usePropertyActions.ts`
- `apps/akkuea-land/src/lib/soroban-tx.ts`
- `apps/akkuea-land/src/components/game/PropertyPanel/index.tsx`
- `apps/akkuea-land/src/components/game/onboarding/ClaimLandStep.tsx`
- `apps/akkuea-land/src/components/game/onboarding/ClaimPropertyStep.tsx`
- `apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts` (updated mocks + new approve-before-list regression test)
- `apps/akkuea-land/src/components/game/__tests__/PropertyPanel.test.tsx` (updated to use the real treasury address + mock `soroban-tx` — this also fixes 2 pre-existing tests that were flaky/failing because they made real, unmocked network calls to the Soroban RPC with fake test addresses)
- `apps/shared/package.json`
- `scripts/deploy-game-contracts.sh`
- `docs/deployment/deploy-game-contracts.md`

## Tests added

- **`useGameWallet.test.ts`** (7 tests): login connects the real wallet kit and stores its address; login leaves state disconnected if the picker is closed; logout resets the wallet kit singleton and clears state; signAndSubmitTx signs/submits/confirms with the connected address; a signing rejection propagates (no fake success); throws if the kit was never initialized; throws if no address is connected.
- **`soroban-tx.test.ts`** (10 tests): every contract ID constant + `TREASURY_ADDRESS` resolves to the real deployed game contract (regression against the old wrong-contract fallback); none of them equal the old defi-rwa IDs; all 4 contract IDs are distinct; `propertyIdToU32` still works; `buildFaucetClaimXdr` / `buildApproveMarketplaceXdr` are exported functions.
- **`ClaimLandStep.test.tsx`** (4 tests): builds a real faucet XDR for the connected address and signs it; never signs the old hardcoded placeholder string; shows the error state on a signing failure; no-ops when no wallet is connected.
- **`ClaimPropertyStep.test.tsx`** (3 tests): builds a real treasury-transfer XDR for the selected tile and signs it; never signs the old hardcoded placeholder string; no-ops when no wallet is connected.
- **`usePropertyActions.test.ts`** (+1 test, 32 total): asserts `listForSale` calls `buildApproveMarketplaceXdr` before `buildListForSaleXdr` and signs both transactions, in order.
- **`PropertyPanel.test.tsx`** (5 tests, fixed): now mocks `soroban-tx` so the "unowned" and "listed_by_other" purchase flows don't make real network calls — this fixes 2 tests that were previously failing (timing out waiting on a real, unmocked RPC call to a nonexistent test account).

All 8 touched/added test files pass together: **77 pass, 0 fail** (`bun test` from `apps/akkuea-land`). `tsc --noEmit` and `eslint .` are clean in both `apps/akkuea-land` and `apps/shared`.

Note: `src/components/game/__tests__/CityMap.test.tsx` hangs/times out in this environment. Verified this is **pre-existing** on `develop` before this branch's changes (reproduced on a clean stash of `develop`) and unrelated to `mockProperties.ts`/`useGameWallet`/`usePropertyActions` — `CityMap.tsx` and its mock grid generator are explicitly out of scope for this issue (only `useGameWallet`/`usePropertyActions` are listed as relevant hooks) and were left untouched.

## How to test

1. Reuse the checked-in deployment (default, no setup needed) — the app already falls back to `game-contracts.testnet.json`'s contract IDs and treasury when no `NEXT_PUBLIC_*_CONTRACT_ID` / `NEXT_PUBLIC_TREASURY_ADDRESS` env vars are set. Or deploy your own instance:
   ```bash
   ./scripts/deploy-game-contracts.sh testnet game-deployer
   ```
   and paste the printed block into `apps/akkuea-land/.env.local` (see `docs/deployment/deploy-game-contracts.md` for the full walkthrough, including importing the deployer key into Freighter and a CLI-only marketplace list→buy verification).
2. Run the app:
   ```bash
   bun install
   bun run dev
   ```
3. In the browser: connect a real Freighter wallet (testnet) via the onboarding flow — "Claim your starter LAND" and "Claim your first property" now trigger real signing prompts. On the city map, buy a treasury tile, improve it, list it for sale (triggers two signing prompts: approve, then list), and buy a listed tile from another account. On the dashboard, "Claim All" signs and submits real `claim_rental` transactions.
4. Automated tests:
   ```bash
   cd apps/akkuea-land
   bun test src/hooks/__tests__/usePropertyActions.test.ts src/hooks/__tests__/useGameWallet.test.ts src/lib/__tests__/walletKit.test.ts src/lib/__tests__/soroban-tx.test.ts src/lib/__tests__/claim-rental.test.ts src/components/game/__tests__/PropertyPanel.test.tsx src/components/game/onboarding/__tests__/ClaimLandStep.test.tsx src/components/game/onboarding/__tests__/ClaimPropertyStep.test.tsx
   bun run type-check
   bun run lint
   ```
