### PR TITLE
test(contracts): expand unit test suite for game-marketplace

### DIFF
--- a/apps/contracts/contracts/game-marketplace/src/lib.rs
+++ b/apps/contracts/contracts/game-marketplace/src/lib.rs
@@ -437,4 +437,250 @@ mod tests {
         let result = s.marketplace.try_list(&s.treasury, &6, &200);
         assert_eq!(result, Err(Ok(MarketError::AlreadyListed.into())));
     }
+
+    // ── initialize ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_initialize_starts_with_no_listings() {
+        let s = setup();
+
+        assert!(s.marketplace.get_listing(&0).is_none());
+        assert_eq!(s.marketplace.get_all_listings(&0, &10).len(), 0);
+    }
+
+    #[test]
+    fn test_initialize_twice_fails() {
+        let s = setup();
+
+        let result = s.marketplace.try_initialize(&s.nft.address, &s.land_id);
+        assert_eq!(result, Err(Ok(MarketError::AlreadyInitialized.into())));
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_list_before_initialize_fails() {
+        let s = setup();
+        let uninitialized_id = s.env.register(GameMarketplace, ());
+        let uninitialized = GameMarketplaceClient::new(&s.env, &uninitialized_id);
+        s.nft.approve(&s.treasury, &uninitialized_id, &7);
+
+        let result = uninitialized.try_list(&s.treasury, &7, &100);
+        assert_eq!(result, Err(Ok(MarketError::NotInitialized.into())));
+    }
+
+    #[test]
+    fn test_list_without_nft_approval_fails() {
+        let s = setup();
+
+        // No `approve` call: the escrow `transfer_from` is rejected by the NFT
+        // contract, so the marketplace must not record a listing either.
+        let result = s.marketplace.try_list(&s.treasury, &8, &100);
+        assert!(result.is_err());
+
+        assert!(s.marketplace.get_listing(&8).is_none());
+        assert_eq!(s.nft.get_owner(&8), s.treasury);
+    }
+
+    #[test]
+    fn test_list_by_non_owner_fails() {
+        let s = setup();
+        let attacker = Address::generate(&s.env);
+
+        let result = s.marketplace.try_list(&attacker, &9, &100);
+        assert!(result.is_err());
+
+        assert!(s.marketplace.get_listing(&9).is_none());
+        assert_eq!(s.nft.get_owner(&9), s.treasury);
+    }
+
+    #[test]
+    fn test_list_requires_seller_auth() {
+        let s = setup();
+        s.nft.approve(&s.treasury, &s.marketplace_id, &10);
+
+        s.env.set_auths(&[]);
+        let result = s.marketplace.try_list(&s.treasury, &10, &100);
+        assert!(result.is_err());
+
+        assert!(s.marketplace.get_listing(&10).is_none());
+    }
+
+    // ── buy ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_buy_nonexistent_listing_fails() {
+        let s = setup();
+        let buyer = Address::generate(&s.env);
+        mint_land(&s, &buyer, 1000);
+
+        let result = s.marketplace.try_buy(&buyer, &11);
+        assert_eq!(result, Err(Ok(MarketError::NotListed.into())));
+    }
+
+    #[test]
+    fn test_buy_with_exact_balance_succeeds() {
+        let s = setup();
+        let buyer = Address::generate(&s.env);
+        mint_land(&s, &buyer, 250);
+
+        s.nft.approve(&s.treasury, &s.marketplace_id, &12);
+        s.marketplace.list(&s.treasury, &12, &250);
+        s.marketplace.buy(&buyer, &12);
+
+        assert_eq!(s.nft.get_owner(&12), buyer);
+        assert_eq!(TokenClient::new(&s.env, &s.land_id).balance(&buyer), 0);
+    }
+
+    #[test]
+    fn test_buy_removes_listing_from_index() {
+        let s = setup();
+        let buyer = Address::generate(&s.env);
+        mint_land(&s, &buyer, 1000);
+
+        for id in 13..16_u32 {
+            s.nft.approve(&s.treasury, &s.marketplace_id, &id);
+            s.marketplace.list(&s.treasury, &id, &100);
+        }
+        s.marketplace.buy(&buyer, &14);
+
+        let remaining = s.marketplace.get_all_listings(&0, &10);
+        assert_eq!(remaining.len(), 2);
+        assert_eq!(remaining.get(0).unwrap().property_id, 13);
+        assert_eq!(remaining.get(1).unwrap().property_id, 15);
+    }
+
+    #[test]
+    fn test_buy_requires_buyer_auth() {
+        let s = setup();
+        let buyer = Address::generate(&s.env);
+        mint_land(&s, &buyer, 1000);
+
+        s.nft.approve(&s.treasury, &s.marketplace_id, &16);
+        s.marketplace.list(&s.treasury, &16, &100);
+
+        s.env.set_auths(&[]);
+        let result = s.marketplace.try_buy(&buyer, &16);
+        assert!(result.is_err());
+
+        assert!(s.marketplace.get_listing(&16).is_some());
+        assert_eq!(s.nft.get_owner(&16), s.marketplace_id);
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_nonexistent_listing_fails() {
+        let s = setup();
+
+        let result = s.marketplace.try_cancel(&s.treasury, &17);
+        assert_eq!(result, Err(Ok(MarketError::NotListed.into())));
+    }
+
+    #[test]
+    fn test_cancel_twice_fails() {
+        let s = setup();
+        s.nft.approve(&s.treasury, &s.marketplace_id, &18);
+        s.marketplace.list(&s.treasury, &18, &100);
+        s.marketplace.cancel(&s.treasury, &18);
+
+        let result = s.marketplace.try_cancel(&s.treasury, &18);
+        assert_eq!(result, Err(Ok(MarketError::NotListed.into())));
+        assert_eq!(s.nft.get_owner(&18), s.treasury);
+    }
+
+    #[test]
+    fn test_cancel_requires_seller_auth() {
+        let s = setup();
+        s.nft.approve(&s.treasury, &s.marketplace_id, &19);
+        s.marketplace.list(&s.treasury, &19, &100);
+
+        s.env.set_auths(&[]);
+        let result = s.marketplace.try_cancel(&s.treasury, &19);
+        assert!(result.is_err());
+
+        assert!(s.marketplace.get_listing(&19).is_some());
+        assert_eq!(s.nft.get_owner(&19), s.marketplace_id);
+    }
+
+    #[test]
+    fn test_cancel_removes_listing_from_index_and_allows_relisting() {
+        let s = setup();
+        s.nft.approve(&s.treasury, &s.marketplace_id, &20);
+        s.marketplace.list(&s.treasury, &20, &100);
+        s.marketplace.cancel(&s.treasury, &20);
+
+        assert_eq!(s.marketplace.get_all_listings(&0, &10).len(), 0);
+
+        // Re-listing the same property must succeed after a cancellation.
+        s.nft.approve(&s.treasury, &s.marketplace_id, &20);
+        s.marketplace.list(&s.treasury, &20, &200);
+
+        assert_eq!(s.marketplace.get_listing(&20).unwrap().price, 200);
+        assert_eq!(s.marketplace.get_all_listings(&0, &10).len(), 1);
+    }
+
+    #[test]
+    fn test_cancel_by_non_seller_leaves_nft_in_escrow() {
+        let s = setup();
+        let alice = Address::generate(&s.env);
+        s.nft.transfer(&s.treasury, &alice, &21);
+        s.nft.approve(&alice, &s.marketplace_id, &21);
+        s.marketplace.list(&alice, &21, &100);
+
+        let result = s.marketplace.try_cancel(&s.treasury, &21);
+        assert_eq!(result, Err(Ok(MarketError::NotSeller.into())));
+
+        assert_eq!(s.nft.get_owner(&21), s.marketplace_id);
+        assert_eq!(s.marketplace.get_listing(&21).unwrap().seller, alice);
+    }
+
+    // ── get_listing / get_all_listings ────────────────────────────────────────
+
+    #[test]
+    fn test_get_listing_returns_none_when_not_listed() {
+        let s = setup();
+
+        assert!(s.marketplace.get_listing(&22).is_none());
+    }
+
+    #[test]
+    fn test_get_all_listings_edge_offsets_and_limits() {
+        let s = setup();
+        s.nft.approve(&s.treasury, &s.marketplace_id, &23);
+        s.marketplace.list(&s.treasury, &23, &100);
+
+        // Zero limit, offset at the end, and offset past the end are all empty.
+        assert_eq!(s.marketplace.get_all_listings(&0, &0).len(), 0);
+        assert_eq!(s.marketplace.get_all_listings(&1, &10).len(), 0);
+        assert_eq!(s.marketplace.get_all_listings(&99, &10).len(), 0);
+
+        // A limit larger than the number of listings is clamped.
+        assert_eq!(s.marketplace.get_all_listings(&0, &100).len(), 1);
+    }
+
+    #[test]
+    fn test_get_all_listings_returns_each_seller_and_price() {
+        let s = setup();
+        let alice = Address::generate(&s.env);
+        s.nft.transfer(&s.treasury, &alice, &24);
+
+        s.nft.approve(&alice, &s.marketplace_id, &24);
+        s.marketplace.list(&alice, &24, &777);
+        s.nft.approve(&s.treasury, &s.marketplace_id, &25);
+        s.marketplace.list(&s.treasury, &25, &888);
+
+        let all = s.marketplace.get_all_listings(&0, &10);
+        assert_eq!(all.len(), 2);
+
+        let first = all.get(0).unwrap();
+        assert_eq!(first.seller, alice);
+        assert_eq!(first.property_id, 24);
+        assert_eq!(first.price, 777);
+
+        let second = all.get(1).unwrap();
+        assert_eq!(second.seller, s.treasury);
+        assert_eq!(second.property_id, 25);
+        assert_eq!(second.price, 888);
+    }
 }


### PR DESCRIPTION
Closes #1015

## Summary
Completes the unit test suite for `apps/contracts/contracts/game-marketplace`, taking it from 8 to 26 tests with coverage of every public function and its error paths.

## Note on the issue description
The issue states the contract "has no tests at all". That is no longer accurate — `src/lib.rs` already contained a `#[cfg(test)] mod tests` with 8 passing tests (added in c9d146c7). I kept those tests as-is and filled the gaps instead of rewriting them, so this PR is purely additive.

## What changed
Only `apps/contracts/contracts/game-marketplace/src/lib.rs` (test module only — no production code touched). 18 new tests:

- **initialize** — empty initial state; `AlreadyInitialized` on re-init
- **list** — `NotInitialized` on an uninitialized marketplace; missing NFT approval; listing a property the caller doesn't own; missing seller auth
- **buy** — `NotListed` for a nonexistent listing; exact-balance boundary; removal from the listing index; missing buyer auth
- **cancel** — `NotListed` for a nonexistent listing; cancelling twice; missing seller auth; index cleanup and re-listing after cancel; `NotSeller` leaves the NFT in escrow
- **get_listing** — `None` for an unlisted property
- **get_all_listings** — zero limit; offset at and past the end; limit larger than the listing count; seller/price/property_id contents across two sellers

## Design decisions
- Kept the tests inline in `lib.rs` rather than extracting a `test.rs`, matching what this contract (and `game-land-token`, `game-engine`) already do.
- Reused the existing `setup()` fixture and `mint_land` helper — no new harness.
- Asserted specific error codes with `try_*` + `Err(Ok(MarketError::X.into()))`, matching `game-property-nft` and `game-engine`.
- Cross-contract failures (NFT `NotApproved` / `NotOwner`) are asserted as `is_err()` plus explicit state assertions, since the surfaced code belongs to the NFT contract and is not a `MarketError`.
- Auth paths use `env.set_auths(&[])` to switch off `mock_all_auths` for a single invocation, and additionally assert that no state changed.

## Acceptance criteria
- [x] `cargo test` passes
- [x] Listing covered (success + error paths)
- [x] Buying covered, incl. buying a nonexistent listing
- [x] Canceling covered, incl. cancelling without being the seller
- [x] Every public function covered: `initialize`, `list`, `buy`, `cancel`, `get_listing`, `get_all_listings`

## Test output
```
running 26 tests
test tests::test_buy_nonexistent_listing_fails ... ok
test tests::test_cancel_by_non_seller_fails ... ok
test tests::test_cancel_by_non_seller_leaves_nft_in_escrow ... ok
test tests::test_buy_insufficient_balance_leaves_listing_intact ... ok
test tests::test_buy_requires_buyer_auth ... ok
test tests::test_buy_with_exact_balance_succeeds ... ok
test tests::test_buy_transfers_nft_and_land ... ok
test tests::test_cancel_nonexistent_listing_fails ... ok
test tests::test_buy_removes_listing_from_index ... ok
test tests::test_cancel_requires_seller_auth ... ok
test tests::test_cancel_returns_nft_to_seller ... ok
test tests::test_get_all_listings_edge_offsets_and_limits ... ok
test tests::test_cancel_twice_fails ... ok
test tests::test_double_sell_prevented ... ok
test tests::test_initialize_starts_with_no_listings ... ok
test tests::test_get_listing_returns_none_when_not_listed ... ok
test tests::test_cancel_removes_listing_from_index_and_allows_relisting ... ok
test tests::test_get_all_listings_returns_each_seller_and_price ... ok
test tests::test_initialize_twice_fails ... ok
test tests::test_list_already_listed_fails ... ok
test tests::test_list_by_non_owner_fails ... ok
test tests::test_list_before_initialize_fails ... ok
test tests::test_list_requires_seller_auth ... ok
test tests::test_list_takes_custody ... ok
test tests::test_list_without_nft_approval_fails ... ok
test tests::test_get_all_listings_pagination ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Full workspace `cargo test --lib`: 159 passed, 0 failed — no regressions.

Coverage (`cargo llvm-cov --lib -p game-marketplace`):
```
Filename                            Regions  Cover    Lines  Cover
game-marketplace/src/lib.rs            1090  97.98%     426  97.65%
```
Well above the 80% threshold enforced by `contracts-ci.yml`.

`cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` both clean.

## Honest follow-ups (out of scope here)
1. **`MarketError::Reentrancy` is untestable** (the only meaningful uncovered line, 55). The Soroban host rejects same-contract re-entry before the `ExecutionGuard` is ever consulted, so the branch can't be reached from a test without a contrived mock that would assert host behaviour rather than contract behaviour. The guard remains valid defense-in-depth. Flagging rather than faking coverage for it.
2. **Latent overflow in `get_all_listings`** (`let end = (offset + limit).min(len)`, line ~245): with `overflow-checks = true` in the release profile, a call such as `get_all_listings(u32::MAX, 1)` traps instead of returning an empty page. A one-line `offset.saturating_add(limit)` would fix it. Left out because this issue is scoped to tests and it changes production behaviour — happy to open a separate issue/PR if maintainers want it.

## Security note
Tests only; no production logic, dependencies, config, or secrets changed. All tests run in an in-memory `Env::default()` with no network or key material. The new auth tests strengthen the guarantee that `list`/`buy`/`cancel` reject calls without the correct `require_auth`, and the failure-path tests assert that no NFT or token moves and no listing state changes when a call is rejected.
