### PR TITLE
feat(webapp): portfolio performance chart (#1006)

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -21,6 +21,7 @@
     "@pollar/react": "^0.8.0",
     "@privy-io/react-auth": "^2.0.0",
     "@privy-io/server-auth": "^1.32.5",
+    "@stellar/stellar-sdk": "^13.3.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.18.2",
     "lucide-react": "^0.468.0",
@@ -29,8 +30,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
+    "recharts": "2.15.3",
     "smart-account-kit": "0.2.10",
-    "@stellar/stellar-sdk": "^13.3.0",
     "zod": "^3.25.76",
     "zustand": "^5.0.11"
   },

--- a/apps/webapp/src/app/[locale]/dashboard/page.tsx
+++ b/apps/webapp/src/app/[locale]/dashboard/page.tsx
@@ -36,6 +36,7 @@ import { useHealthFactor } from "@/hooks/useHealthFactor";
 import { useLiveUpdates } from "@/hooks/useLiveUpdates";
 import {
   AllocationChart,
+  PortfolioChart,
   PropertyReportCard,
   StatsSkeleton,
   PropertiesListSkeleton,
@@ -368,6 +369,11 @@ export default function DashboardPage() {
                   </Card>
                 </div>
               )}
+            </motion.div>
+
+            {/* Performance Chart */}
+            <motion.div variants={staggerItem}>
+              <PortfolioChart walletAddress={address} />
             </motion.div>
 
             {/* Main Content */}

--- a/apps/webapp/src/components/portfolio/PortfolioChart.tsx
+++ b/apps/webapp/src/components/portfolio/PortfolioChart.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { AlertCircle, RefreshCw, TrendingUp } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import {
+  usePortfolioPerformance,
+  type TimeRange,
+} from "@/hooks/usePortfolioPerformance";
+
+interface PortfolioChartProps {
+  walletAddress: string | null | undefined;
+  className?: string;
+}
+
+/** Format a USD value compactly: 1 250 000 → $1.25M */
+function formatUSD(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}k`;
+  return `$${value.toFixed(0)}`;
+}
+
+/** Format a collateral ratio percentage */
+function formatRatio(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+/** Short month-day label for the x-axis */
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+const TIME_RANGES: TimeRange[] = ["1M", "3M", "ALL"];
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function ChartSkeleton() {
+  return (
+    <div
+      className="w-full h-64 rounded-lg bg-[#1a1a1a] animate-pulse"
+      role="status"
+      aria-label="Loading chart"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+interface ChartErrorProps {
+  message: string;
+  onRetry: () => void;
+}
+
+function ChartError({ message, onRetry }: ChartErrorProps) {
+  return (
+    <div
+      className="w-full h-64 flex flex-col items-center justify-center gap-3 rounded-lg border border-red-500/20 bg-red-500/5"
+      role="alert"
+    >
+      <AlertCircle className="w-6 h-6 text-red-400" aria-hidden="true" />
+      <p className="text-xs text-red-400 text-center max-w-xs">{message}</p>
+      <button
+        onClick={onRetry}
+        className="flex items-center gap-1.5 text-xs text-red-400 underline hover:text-red-300 transition-colors"
+        aria-label="Retry loading chart data"
+      >
+        <RefreshCw className="w-3 h-3" />
+        Retry
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state (wallet connected but no data yet)
+// ---------------------------------------------------------------------------
+
+function ChartEmpty() {
+  return (
+    <div className="w-full h-64 flex flex-col items-center justify-center gap-3 rounded-lg border border-[#262626] bg-[#0a0a0a]">
+      <TrendingUp className="w-8 h-8 text-neutral-700" aria-hidden="true" />
+      <p className="text-xs text-neutral-500">No performance data yet</p>
+      <p className="text-[10px] text-neutral-600">
+        Data will appear once you hold tokenised properties
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recharts custom tooltip
+// ---------------------------------------------------------------------------
+
+interface TooltipPayloadEntry {
+  name: string;
+  value: number;
+  color: string;
+  dataKey: string;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-lg border border-[#262626] bg-[#111111] p-3 shadow-xl text-xs space-y-1.5">
+      <p className="text-neutral-400 font-medium">{label}</p>
+      {payload.map((entry) => (
+        <div key={entry.dataKey} className="flex items-center gap-2">
+          <span
+            className="w-2 h-2 rounded-full shrink-0"
+            style={{ background: entry.color }}
+          />
+          <span className="text-neutral-400">{entry.name}:</span>
+          <span className="font-mono font-medium text-white">
+            {entry.dataKey === "holdingsValue"
+              ? formatUSD(entry.value)
+              : formatRatio(entry.value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function PortfolioChart({ walletAddress, className }: PortfolioChartProps) {
+  const [range, setRange] = useState<TimeRange>("3M");
+  const { data, isLoading, error, refetch } = usePortfolioPerformance(
+    walletAddress,
+    range,
+  );
+
+  // Decide how many x-axis ticks to show based on range
+  const tickCount = range === "1M" ? 6 : range === "3M" ? 7 : 8;
+
+  // Build evenly-spaced tick indexes
+  const tickIndexes = Array.from({ length: tickCount }, (_, i) =>
+    Math.round((i / (tickCount - 1)) * Math.max(data.length - 1, 0)),
+  );
+  const xTicks = tickIndexes
+    .map((idx) => data[idx]?.date)
+    .filter((d): d is string => Boolean(d));
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <CardTitle>Portfolio Performance</CardTitle>
+
+          {/* Time-range switcher */}
+          <div
+            className="flex items-center gap-1 p-0.5 rounded-lg bg-[#1a1a1a] border border-[#262626]"
+            role="group"
+            aria-label="Select time range"
+          >
+            {TIME_RANGES.map((r) => (
+              <button
+                key={r}
+                onClick={() => setRange(r)}
+                aria-pressed={range === r}
+                className={`px-3 py-1 text-xs rounded-md font-medium transition-colors ${
+                  range === r
+                    ? "bg-[#262626] text-white"
+                    : "text-neutral-500 hover:text-neutral-300"
+                }`}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Legend row */}
+        {!isLoading && !error && data.length > 0 && (
+          <div className="flex items-center gap-4 mt-2">
+            <div className="flex items-center gap-1.5">
+              <span className="w-3 h-0.5 bg-[#00ff88] inline-block rounded" />
+              <span className="text-[10px] text-neutral-500">
+                Holdings Value
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-3 h-0.5 bg-[#ff3e00] inline-block rounded" />
+              <span className="text-[10px] text-neutral-500">
+                Collateral Ratio
+              </span>
+            </div>
+          </div>
+        )}
+      </CardHeader>
+
+      <CardContent>
+        {isLoading ? (
+          <ChartSkeleton />
+        ) : error ? (
+          <ChartError message={error} onRetry={refetch} />
+        ) : data.length === 0 ? (
+          <ChartEmpty />
+        ) : (
+          <ResponsiveContainer width="100%" height={260}>
+            <AreaChart
+              data={data}
+              margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient
+                  id="portfolioGreenGrad"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="5%" stopColor="#00ff88" stopOpacity={0.25} />
+                  <stop offset="95%" stopColor="#00ff88" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient
+                  id="portfolioOrangeGrad"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="5%" stopColor="#ff3e00" stopOpacity={0.2} />
+                  <stop offset="95%" stopColor="#ff3e00" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#1a1a1a"
+                vertical={false}
+              />
+
+              <XAxis
+                dataKey="date"
+                ticks={xTicks}
+                tickFormatter={formatDate}
+                tick={{ fill: "#737373", fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+              />
+
+              {/* Left y-axis: holdings value */}
+              <YAxis
+                yAxisId="holdings"
+                orientation="left"
+                tickFormatter={formatUSD}
+                tick={{ fill: "#737373", fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={56}
+              />
+
+              {/* Right y-axis: collateral ratio */}
+              <YAxis
+                yAxisId="ratio"
+                orientation="right"
+                tickFormatter={(v: number) => `${v}%`}
+                tick={{ fill: "#737373", fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={44}
+                domain={["auto", "auto"]}
+              />
+
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{ stroke: "#333333", strokeWidth: 1 }}
+              />
+
+              {/* Hidden Legend — we render our own above */}
+              <Legend wrapperStyle={{ display: "none" }} />
+
+              <Area
+                yAxisId="holdings"
+                type="monotone"
+                dataKey="holdingsValue"
+                name="Holdings Value"
+                stroke="#00ff88"
+                strokeWidth={1.5}
+                fill="url(#portfolioGreenGrad)"
+                dot={false}
+                activeDot={{ r: 3, fill: "#00ff88" }}
+              />
+
+              <Area
+                yAxisId="ratio"
+                type="monotone"
+                dataKey="collateralRatio"
+                name="Collateral Ratio"
+                stroke="#ff3e00"
+                strokeWidth={1.5}
+                fill="url(#portfolioOrangeGrad)"
+                dot={false}
+                activeDot={{ r: 3, fill: "#ff3e00" }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/webapp/src/components/portfolio/PortfolioChart.tsx
+++ b/apps/webapp/src/components/portfolio/PortfolioChart.tsx
@@ -151,7 +151,10 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
 // Main component
 // ---------------------------------------------------------------------------
 
-export function PortfolioChart({ walletAddress, className }: PortfolioChartProps) {
+export function PortfolioChart({
+  walletAddress,
+  className,
+}: PortfolioChartProps) {
   const [range, setRange] = useState<TimeRange>("3M");
   const { data, isLoading, error, refetch } = usePortfolioPerformance(
     walletAddress,

--- a/apps/webapp/src/components/portfolio/__tests__/PortfolioChart.test.tsx
+++ b/apps/webapp/src/components/portfolio/__tests__/PortfolioChart.test.tsx
@@ -1,0 +1,377 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, react/display-name */
+/**
+ * Render tests for PortfolioChart.
+ *
+ * Strategy:
+ *   - Mock `usePortfolioPerformance` so the component renders predictably
+ *     without any real fetch calls.
+ *   - Mock `recharts` so its SVG internals are replaced with plain divs,
+ *     avoiding JSDOM limitations with SVG sizing (recharts calls
+ *     ResizeObserver / getBoundingClientRect internally).
+ *   - Mock `framer-motion` (same pattern used by InvestModal.test.tsx) to
+ *     prevent framer-motion from requiring WAAPI / Element.animate.
+ *   - Assert each distinct render state: loading, error, empty, and data.
+ */
+
+import "@/test/setup-dom";
+
+// ---------------------------------------------------------------------------
+// Polyfill missing DOM globals that framer-motion and @testing-library need.
+// setup-dom.ts initialises JSDOM but doesn't expose all globals.
+// ---------------------------------------------------------------------------
+{
+  const win = globalThis.window as Window & typeof globalThis;
+
+  const globals: Array<keyof (Window & typeof globalThis)> = [
+    "SVGElement",
+    "Element",
+    "Event",
+    "CustomEvent",
+    "getComputedStyle",
+    "ResizeObserver",
+  ] as Array<keyof (Window & typeof globalThis)>;
+
+  for (const key of globals) {
+    if (!(key in globalThis) && key in win) {
+      Object.defineProperty(globalThis, key, {
+        value: win[key],
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  // ResizeObserver is not in JSDOM — stub it so recharts doesn't throw
+  if (!("ResizeObserver" in globalThis)) {
+    class FakeResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      value: FakeResizeObserver,
+      writable: true,
+      configurable: true,
+    });
+  }
+}
+
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+} from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { UsePortfolioPerformanceReturn } from "@/hooks/usePortfolioPerformance";
+import { mockPortfolioPerformance } from "@/mocks/fixtures/portfolioPerformance";
+
+// ---------------------------------------------------------------------------
+// Mock framer-motion (identical to InvestModal.test.tsx)
+// ---------------------------------------------------------------------------
+
+mock.module("framer-motion", () => {
+  const passthroughDiv = ({
+    children,
+    whileHover: _wh,
+    whileTap: _wt,
+    initial: _i,
+    animate: _a,
+    exit: _e,
+    transition: _t,
+    variants: _v,
+    ...props
+  }: HTMLAttributes<HTMLDivElement> & Record<string, unknown>) => (
+    <div {...props}>{children}</div>
+  );
+  const passthroughButton = ({
+    children,
+    whileHover: _wh,
+    whileTap: _wt,
+    initial: _i,
+    animate: _a,
+    exit: _e,
+    transition: _t,
+    variants: _v,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  );
+
+  return {
+    AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+    motion: new Proxy(
+      { div: passthroughDiv, button: passthroughButton },
+      {
+        get: (target, prop) =>
+          prop in target
+            ? target[prop as keyof typeof target]
+            : passthroughDiv,
+      },
+    ),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock recharts — replace with plain divs to avoid SVG / ResizeObserver issues
+// ---------------------------------------------------------------------------
+
+mock.module("recharts", () => {
+  const passDiv =
+    (label: string) =>
+    ({ children }: { children?: ReactNode }) =>
+      <div data-testid={label}>{children ?? null}</div>;
+
+  return {
+    ResponsiveContainer: passDiv("recharts-responsive-container"),
+    AreaChart: passDiv("recharts-area-chart"),
+    Area: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    Legend: () => null,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock next-intl — useTranslations falls back to the key
+// ---------------------------------------------------------------------------
+
+mock.module("next-intl", () => ({
+  useTranslations:
+    () =>
+    (key: string) =>
+      key,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the data hook — each test controls what the component receives
+// ---------------------------------------------------------------------------
+
+let hookImpl: UsePortfolioPerformanceReturn = {
+  data: [],
+  isLoading: true,
+  error: null,
+  refetch: mock(() => {}),
+};
+
+mock.module("@/hooks/usePortfolioPerformance", () => ({
+  usePortfolioPerformance: () => hookImpl,
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic import AFTER all mocks are registered
+// ---------------------------------------------------------------------------
+
+const { PortfolioChart } = await import(
+  "@/components/portfolio/PortfolioChart"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WALLET = "GDEMOUSER1234567890AKKUEA00000000000000000000000000000000";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PortfolioChart", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+
+  // -----------------------------------------------------------------------
+  // Loading state
+  // -----------------------------------------------------------------------
+
+  it("renders a loading skeleton while data is being fetched", () => {
+    hookImpl = {
+      data: [],
+      isLoading: true,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    const skeleton = view.queryByRole("status", { name: /loading chart/i });
+    expect(skeleton).not.toBeNull();
+    // Chart should not be present during loading
+    expect(view.queryByTestId("recharts-area-chart")).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Error state
+  // -----------------------------------------------------------------------
+
+  it("renders an error message with a retry button on failure", () => {
+    const retryFn = mock(() => {});
+    hookImpl = {
+      data: [],
+      isLoading: false,
+      error: "Network error: unable to reach server",
+      refetch: retryFn,
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    const alert = view.queryByRole("alert");
+    expect(alert).not.toBeNull();
+    expect(
+      view.queryByText(/Network error: unable to reach server/i),
+    ).not.toBeNull();
+
+    const retryBtn = view.queryByRole("button", {
+      name: /retry loading chart data/i,
+    });
+    expect(retryBtn).not.toBeNull();
+
+    fireEvent.click(retryBtn!);
+    expect(retryFn).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty state
+  // -----------------------------------------------------------------------
+
+  it("renders the empty state when there are no data points", () => {
+    hookImpl = {
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    expect(view.queryByText(/No performance data yet/i)).not.toBeNull();
+    expect(view.queryByTestId("recharts-area-chart")).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Data state
+  // -----------------------------------------------------------------------
+
+  it("renders the recharts container when data is available", () => {
+    hookImpl = {
+      data: mockPortfolioPerformance.points,
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    expect(
+      view.queryByTestId("recharts-responsive-container"),
+    ).not.toBeNull();
+    expect(view.queryByTestId("recharts-area-chart")).not.toBeNull();
+
+    // No error or skeleton
+    expect(view.queryByRole("alert")).toBeNull();
+    expect(view.queryByRole("status", { name: /loading chart/i })).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Legend labels visible when data is present
+  // -----------------------------------------------------------------------
+
+  it("shows Holdings Value and Collateral Ratio legend labels", () => {
+    hookImpl = {
+      data: mockPortfolioPerformance.points,
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    expect(view.queryByText(/Holdings Value/i)).not.toBeNull();
+    expect(view.queryByText(/Collateral Ratio/i)).not.toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Time-range switcher renders
+  // -----------------------------------------------------------------------
+
+  it("renders the 1M / 3M / ALL time-range buttons", () => {
+    hookImpl = {
+      data: mockPortfolioPerformance.points,
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    expect(view.queryByRole("button", { name: "1M" })).not.toBeNull();
+    expect(view.queryByRole("button", { name: "3M" })).not.toBeNull();
+    expect(view.queryByRole("button", { name: "ALL" })).not.toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Active range reflected via aria-pressed
+  // -----------------------------------------------------------------------
+
+  it("highlights the active range button with aria-pressed=true", () => {
+    hookImpl = {
+      data: mockPortfolioPerformance.points,
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+
+    // Default range is "3M"
+    const btn3M = view.getByRole("button", { name: "3M" });
+    expect(btn3M.getAttribute("aria-pressed")).toBe("true");
+
+    const btn1M = view.getByRole("button", { name: "1M" });
+    expect(btn1M.getAttribute("aria-pressed")).toBe("false");
+
+    // Switch to 1M
+    fireEvent.click(btn1M);
+    expect(btn1M.getAttribute("aria-pressed")).toBe("true");
+    expect(btn3M.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  // -----------------------------------------------------------------------
+  // Card title always visible
+  // -----------------------------------------------------------------------
+
+  it("renders the 'Portfolio Performance' card title", () => {
+    hookImpl = {
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={WALLET} />);
+    expect(view.queryByText(/Portfolio Performance/i)).not.toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Null wallet address — empty state
+  // -----------------------------------------------------------------------
+
+  it("renders the empty state when walletAddress is null", () => {
+    hookImpl = {
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: mock(() => {}),
+    };
+
+    const view = render(<PortfolioChart walletAddress={null} />);
+    expect(view.queryByText(/No performance data yet/i)).not.toBeNull();
+  });
+});

--- a/apps/webapp/src/components/portfolio/__tests__/PortfolioChart.test.tsx
+++ b/apps/webapp/src/components/portfolio/__tests__/PortfolioChart.test.tsx
@@ -57,11 +57,7 @@ import "@/test/setup-dom";
 }
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type {
-  ButtonHTMLAttributes,
-  HTMLAttributes,
-  ReactNode,
-} from "react";
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import type { UsePortfolioPerformanceReturn } from "@/hooks/usePortfolioPerformance";
 import { mockPortfolioPerformance } from "@/mocks/fixtures/portfolioPerformance";
@@ -104,9 +100,7 @@ mock.module("framer-motion", () => {
       { div: passthroughDiv, button: passthroughButton },
       {
         get: (target, prop) =>
-          prop in target
-            ? target[prop as keyof typeof target]
-            : passthroughDiv,
+          prop in target ? target[prop as keyof typeof target] : passthroughDiv,
       },
     ),
   };
@@ -119,8 +113,9 @@ mock.module("framer-motion", () => {
 mock.module("recharts", () => {
   const passDiv =
     (label: string) =>
-    ({ children }: { children?: ReactNode }) =>
-      <div data-testid={label}>{children ?? null}</div>;
+    ({ children }: { children?: ReactNode }) => (
+      <div data-testid={label}>{children ?? null}</div>
+    );
 
   return {
     ResponsiveContainer: passDiv("recharts-responsive-container"),
@@ -139,10 +134,7 @@ mock.module("recharts", () => {
 // ---------------------------------------------------------------------------
 
 mock.module("next-intl", () => ({
-  useTranslations:
-    () =>
-    (key: string) =>
-      key,
+  useTranslations: () => (key: string) => key,
 }));
 
 // ---------------------------------------------------------------------------
@@ -164,9 +156,8 @@ mock.module("@/hooks/usePortfolioPerformance", () => ({
 // Dynamic import AFTER all mocks are registered
 // ---------------------------------------------------------------------------
 
-const { PortfolioChart } = await import(
-  "@/components/portfolio/PortfolioChart"
-);
+const { PortfolioChart } =
+  await import("@/components/portfolio/PortfolioChart");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -269,9 +260,7 @@ describe("PortfolioChart", () => {
 
     const view = render(<PortfolioChart walletAddress={WALLET} />);
 
-    expect(
-      view.queryByTestId("recharts-responsive-container"),
-    ).not.toBeNull();
+    expect(view.queryByTestId("recharts-responsive-container")).not.toBeNull();
     expect(view.queryByTestId("recharts-area-chart")).not.toBeNull();
 
     // No error or skeleton

--- a/apps/webapp/src/components/portfolio/index.ts
+++ b/apps/webapp/src/components/portfolio/index.ts
@@ -1,3 +1,4 @@
 export { AllocationChart } from "./AllocationChart";
 export { PropertyReportCard } from "./PropertyReportCard";
 export { StatsSkeleton, PropertiesListSkeleton } from "./PortfolioSkeleton";
+export { PortfolioChart } from "./PortfolioChart";

--- a/apps/webapp/src/hooks/usePortfolioPerformance.ts
+++ b/apps/webapp/src/hooks/usePortfolioPerformance.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type {
+  PortfolioPerformancePoint,
+  PortfolioPerformanceResponse,
+} from "@/mocks/fixtures/portfolioPerformance";
+
+export type { PortfolioPerformancePoint, PortfolioPerformanceResponse };
+
+export type TimeRange = "1M" | "3M" | "ALL";
+
+const TIME_RANGE_DAYS: Record<TimeRange, number> = {
+  "1M": 30,
+  "3M": 90,
+  ALL: Infinity,
+};
+
+export interface UsePortfolioPerformanceReturn {
+  data: PortfolioPerformancePoint[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+export function usePortfolioPerformance(
+  walletAddress: string | null | undefined,
+  range: TimeRange = "3M",
+): UsePortfolioPerformanceReturn {
+  const [data, setData] = useState<PortfolioPerformancePoint[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const refetch = useCallback(() => setFetchKey((k) => k + 1), []);
+
+  useEffect(() => {
+    if (!walletAddress) {
+      const timer = setTimeout(() => {
+        setData([]);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const url = `${API_BASE}/portfolio/performance?address=${encodeURIComponent(walletAddress!)}`;
+        const res = await fetch(url);
+
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            message?: string;
+          };
+          throw new Error(
+            body.message ?? `Failed to load performance data (${res.status})`,
+          );
+        }
+
+        const json = (await res.json()) as PortfolioPerformanceResponse;
+
+        if (cancelled) return;
+
+        // Trim to the requested time range
+        const maxDays = TIME_RANGE_DAYS[range];
+        const trimmed =
+          maxDays === Infinity
+            ? json.points
+            : json.points.slice(-maxDays);
+
+        setData(trimmed);
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load portfolio performance.",
+        );
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress, range, fetchKey]);
+
+  return { data, isLoading, error, refetch };
+}

--- a/apps/webapp/src/hooks/usePortfolioPerformance.ts
+++ b/apps/webapp/src/hooks/usePortfolioPerformance.ts
@@ -23,8 +23,7 @@ export interface UsePortfolioPerformanceReturn {
   refetch: () => void;
 }
 
-const API_BASE =
-  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
 export function usePortfolioPerformance(
   walletAddress: string | null | undefined,
@@ -71,9 +70,7 @@ export function usePortfolioPerformance(
         // Trim to the requested time range
         const maxDays = TIME_RANGE_DAYS[range];
         const trimmed =
-          maxDays === Infinity
-            ? json.points
-            : json.points.slice(-maxDays);
+          maxDays === Infinity ? json.points : json.points.slice(-maxDays);
 
         setData(trimmed);
       } catch (err) {

--- a/apps/webapp/src/mocks/fixtures/portfolioPerformance.ts
+++ b/apps/webapp/src/mocks/fixtures/portfolioPerformance.ts
@@ -56,8 +56,7 @@ function toDateStr(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-const MOCK_WALLET =
-  "GDEMOUSER1234567890AKKUEA00000000000000000000000000000000";
+const MOCK_WALLET = "GDEMOUSER1234567890AKKUEA00000000000000000000000000000000";
 
 /**
  * Pre-built 90-day performance history starting from 2026-04-26 (today minus 90 days

--- a/apps/webapp/src/mocks/fixtures/portfolioPerformance.ts
+++ b/apps/webapp/src/mocks/fixtures/portfolioPerformance.ts
@@ -1,0 +1,93 @@
+/**
+ * Mock fixture data for the /portfolio/performance endpoint (issue #1001).
+ *
+ * Each data point represents a daily snapshot of:
+ *   - holdingsValue:    total estimated value of tokenised property shares (USD)
+ *   - collateralRatio:  holdings value / total borrowed, expressed as a percentage
+ *
+ * 90 days of history are generated so the chart has enough range to be meaningful.
+ */
+
+export interface PortfolioPerformancePoint {
+  /** ISO-8601 date string (YYYY-MM-DD) */
+  date: string;
+  /** Total estimated holdings value in USD */
+  holdingsValue: number;
+  /** Collateral ratio as a percentage (e.g. 175 means 175 %) */
+  collateralRatio: number;
+}
+
+export interface PortfolioPerformanceResponse {
+  walletAddress: string;
+  points: PortfolioPerformancePoint[];
+  /** Date range covered */
+  from: string;
+  to: string;
+}
+
+/** Number of days of history to generate */
+const HISTORY_DAYS = 90;
+
+/**
+ * Deterministically generates a realistic-looking time series using a seeded
+ * pseudo-random walk so the data looks the same on every render.
+ */
+function generateSeries(
+  startValue: number,
+  volatility: number,
+  seed: number,
+): number[] {
+  const values: number[] = [startValue];
+  let s = seed;
+
+  for (let i = 1; i < HISTORY_DAYS; i++) {
+    // LCG pseudo-random — gives repeatable, visually smooth walks
+    s = (s * 1664525 + 1013904223) & 0xffffffff;
+    const rand = (s >>> 0) / 0xffffffff; // [0, 1)
+    const delta = (rand - 0.5) * 2 * volatility;
+    values.push(Math.max(0, values[i - 1]! + delta));
+  }
+
+  return values;
+}
+
+/** Formats a Date as YYYY-MM-DD */
+function toDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+const MOCK_WALLET =
+  "GDEMOUSER1234567890AKKUEA00000000000000000000000000000000";
+
+/**
+ * Pre-built 90-day performance history starting from 2026-04-26 (today minus 90 days
+ * relative to the current mock snapshot date of 2026-07-25).
+ */
+function buildPerformanceHistory(): PortfolioPerformanceResponse {
+  const toDate = new Date("2026-07-25T00:00:00.000Z");
+  const fromDate = new Date(toDate);
+  fromDate.setUTCDate(fromDate.getUTCDate() - HISTORY_DAYS + 1);
+
+  const holdingsSeries = generateSeries(420_000, 8_000, 42);
+  const collateralSeries = generateSeries(175, 4, 99);
+
+  const points: PortfolioPerformancePoint[] = holdingsSeries.map((hv, i) => {
+    const d = new Date(fromDate);
+    d.setUTCDate(d.getUTCDate() + i);
+    return {
+      date: toDateStr(d),
+      holdingsValue: Math.round(hv * 100) / 100,
+      collateralRatio: Math.round(collateralSeries[i]! * 10) / 10,
+    };
+  });
+
+  return {
+    walletAddress: MOCK_WALLET,
+    points,
+    from: toDateStr(fromDate),
+    to: toDateStr(toDate),
+  };
+}
+
+export const mockPortfolioPerformance: PortfolioPerformanceResponse =
+  buildPerformanceHistory();

--- a/apps/webapp/src/mocks/handlers/index.ts
+++ b/apps/webapp/src/mocks/handlers/index.ts
@@ -3,6 +3,7 @@ import { lendingHandlers } from "./lending";
 import { userHandlers } from "./users";
 import { transactionHandlers } from "./transactions";
 import { adminHandlers } from "./admin";
+import { portfolioPerformanceHandlers } from "./portfolioPerformance";
 
 /**
  * All MSW request handlers, combined in one export.
@@ -14,4 +15,5 @@ export const handlers = [
   ...userHandlers,
   ...transactionHandlers,
   ...adminHandlers,
+  ...portfolioPerformanceHandlers,
 ];

--- a/apps/webapp/src/mocks/handlers/portfolioPerformance.ts
+++ b/apps/webapp/src/mocks/handlers/portfolioPerformance.ts
@@ -1,0 +1,35 @@
+import { http, HttpResponse } from "msw";
+import { mockPortfolioPerformance } from "../fixtures/portfolioPerformance";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+export const portfolioPerformanceHandlers = [
+  /**
+   * GET /portfolio/performance?address=<wallet>
+   *
+   * Returns the 90-day time series of holdings value and collateral ratio for
+   * the given wallet address.  Corresponds to the endpoint that will be
+   * implemented in issue #1001.
+   */
+  http.get(`${API_BASE}/portfolio/performance`, ({ request }) => {
+    const url = new URL(request.url);
+    const address = url.searchParams.get("address");
+
+    if (!address) {
+      return HttpResponse.json(
+        {
+          code: "MISSING_ADDRESS",
+          message: "Query parameter 'address' is required.",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Return the shared mock regardless of the wallet address so any connected
+    // wallet gets meaningful demo data.
+    return HttpResponse.json({
+      ...mockPortfolioPerformance,
+      walletAddress: address,
+    });
+  }),
+];

--- a/bun.lock
+++ b/bun.lock
@@ -137,6 +137,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
+        "recharts": "2.15.3",
         "smart-account-kit": "0.2.10",
         "zod": "^3.25.76",
         "zustand": "^5.0.11",
@@ -1119,6 +1120,24 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -1533,6 +1552,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
@@ -1552,6 +1593,8 @@
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
@@ -1594,6 +1637,8 @@
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -1732,6 +1777,8 @@
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.1", "", {}, "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ=="],
 
     "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
@@ -1910,6 +1957,8 @@
     "int64-buffer": ["int64-buffer@1.1.0", "", {}, "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "intl-messageformat": ["intl-messageformat@10.7.18", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/fast-memoize": "2.2.7", "@formatjs/icu-messageformat-parser": "2.11.4", "tslib": "^2.8.0" } }, "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g=="],
 
@@ -2162,6 +2211,8 @@
     "lit-html": ["lit-html@3.3.3", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
 
@@ -2439,19 +2490,27 @@
 
     "react-hook-form": ["react-hook-form@7.77.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg=="],
 
-    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-is-18": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-is-19": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
 
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
     "react-stately": ["react-stately@3.47.0", "", { "dependencies": { "@internationalized/date": "^3.12.2", "@internationalized/number": "^3.6.7", "@internationalized/string": "^3.2.9", "@react-types/shared": "^3.35.0", "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg=="],
+
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "real-require": ["real-require@0.1.0", "", {}, "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="],
+
+    "recharts": ["recharts@2.15.3", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "redaxios": ["redaxios@0.5.1", "", {}, "sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg=="],
 
@@ -2685,6 +2744,8 @@
 
     "thread-stream": ["thread-stream@0.15.2", "", { "dependencies": { "real-require": "^0.1.0" } }, "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tiny-secp256k1": ["tiny-secp256k1@1.1.7", "", { "dependencies": { "bindings": "^1.3.0", "bn.js": "^4.11.8", "create-hmac": "^1.1.7", "elliptic": "^6.4.0", "nan": "^2.13.2" } }, "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
@@ -2808,6 +2869,8 @@
     "valtio": ["valtio@2.1.7", "", { "dependencies": { "proxy-compare": "^3.0.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg=="],
 
     "varuint-bitcoin": ["varuint-bitcoin@2.0.0", "", { "dependencies": { "uint8array-tools": "^0.0.8" } }, "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog=="],
+
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
     "viem": ["viem@2.52.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.29", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew=="],
 
@@ -3293,6 +3356,8 @@
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
+    "recharts/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "ripple-address-codec/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
@@ -3558,6 +3623,8 @@
     "@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@3.1.2", "", {}, "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="],
 
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "@trezor/analytics/@trezor/env-utils/ua-parser-js": ["ua-parser-js@2.0.10", "", { "dependencies": { "detect-europe-js": "^0.1.2", "is-standalone-pwa": "^0.1.1", "ua-is-frozen": "^0.1.2" }, "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw=="],
 


### PR DESCRIPTION
closest #1006 

- Add PortfolioChart component (recharts AreaChart, dual y-axes)
  - Holdings value (USD) and collateral ratio (%) over time
  - Responsive via ResponsiveContainer
  - Loading skeleton, error state with retry, empty state
  - 1M / 3M / ALL time-range switcher with aria-pressed
  - Custom tooltip with formatted USD and percentage values

- Add usePortfolioPerformance hook
  - Fetches GET /portfolio/performance?address=<wallet>
  - Supports 1M / 3M / ALL range trimming
  - Loading, error, and refetch state

- Add mock fixture (90-day deterministic time series) and MSW handler for GET /portfolio/performance (bridges gap until #1001 lands)

- Integrate chart into dashboard between Stats Grid and properties list

- Add 9 render tests (all pass): loading, error, empty, data, legend labels, time-range buttons, aria-pressed, card title, null wallet

Closes #1006

## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

<!-- Describe the key changes and the reasoning behind them. -->

## How to Test

<!-- Step-by-step instructions so a reviewer can verify the change. -->

1.
2.

## Checklist

- [ ] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [ ] No `.env` files or secrets are committed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

<!-- Closes #<issue_number> -->
