### PR TITLE
test(shared): add versioning guard for shared schemas

### DIFF
--- a/apps/shared/src/utils/index.ts
+++ b/apps/shared/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./format";
 export * from "./pagination";
 export * from "./interest";
 export * from "./performance";
+export * from "./schema-versioning";

--- a/apps/shared/src/utils/schema-versioning.ts
+++ b/apps/shared/src/utils/schema-versioning.ts
@@ -1,0 +1,198 @@
+import { z } from "zod";
+
+/**
+ * Structural definition of a schema field for version snapshotting
+ */
+export interface SchemaFieldDefinition {
+  type: string;
+  isOptional: boolean;
+  properties?: Record<string, SchemaFieldDefinition>;
+  element?: SchemaFieldDefinition;
+}
+
+/**
+ * Metadata wrapper for a schema snapshot
+ */
+export interface SchemaSnapshot {
+  version: string;
+  schemas: Record<string, SchemaFieldDefinition>;
+}
+
+/**
+ * Result of a schema snapshot comparison
+ */
+export interface SchemaComparisonResult {
+  compatible: boolean;
+  errors: string[];
+}
+
+/**
+ * Unwraps Zod schema wrappers (optional, nullable, default, effects) to find the core schema
+ */
+function unwrapZodSchema(schema: z.ZodTypeAny): {
+  coreSchema: z.ZodTypeAny;
+  isOptional: boolean;
+} {
+  let current: z.ZodTypeAny = schema;
+  let isOptional = false;
+
+  while (current) {
+    const typeName = current._def?.typeName;
+    if (typeName === "ZodOptional" || typeName === "ZodNullable") {
+      isOptional = true;
+      current = (current._def as { innerType: z.ZodTypeAny }).innerType;
+    } else if (typeName === "ZodDefault") {
+      isOptional = true;
+      current = (current._def as { innerType: z.ZodTypeAny }).innerType;
+    } else if (typeName === "ZodEffects") {
+      current = (current._def as { schema: z.ZodTypeAny }).schema;
+    } else if (typeName === "ZodPipeline") {
+      current = (current._def as { out: z.ZodTypeAny }).out;
+    } else {
+      break;
+    }
+  }
+
+  return { coreSchema: current, isOptional };
+}
+
+/**
+ * Extracts a structural field definition from a Zod schema
+ */
+export function extractSchemaShape(schema: z.ZodTypeAny): SchemaFieldDefinition {
+  const { coreSchema, isOptional } = unwrapZodSchema(schema);
+  const typeName = coreSchema._def?.typeName || "Unknown";
+
+  if (typeName === "ZodObject") {
+    const shape = (coreSchema as z.ZodObject<z.ZodRawShape>).shape;
+    const properties: Record<string, SchemaFieldDefinition> = {};
+    for (const key of Object.keys(shape)) {
+      properties[key] = extractSchemaShape(shape[key]);
+    }
+    return {
+      type: "ZodObject",
+      isOptional,
+      properties,
+    };
+  }
+
+  if (typeName === "ZodArray") {
+    const elementType = (coreSchema as z.ZodArray<z.ZodTypeAny>).element;
+    return {
+      type: "ZodArray",
+      isOptional,
+      element: extractSchemaShape(elementType),
+    };
+  }
+
+  return {
+    type: typeName,
+    isOptional,
+  };
+}
+
+/**
+ * Recursively compares a current schema field definition against a snapshot definition
+ */
+function compareFieldDefinition(
+  current: SchemaFieldDefinition,
+  snapshot: SchemaFieldDefinition,
+  path: string
+): string[] {
+  const errors: string[] = [];
+
+  // Check type compatibility
+  if (current.type !== snapshot.type) {
+    errors.push(
+      `Field '${path}' type changed from '${snapshot.type}' to '${current.type}'`
+    );
+    return errors;
+  }
+
+  // Check optionality changes
+  if (snapshot.isOptional && !current.isOptional) {
+    errors.push(`Field '${path}' became required (was optional in snapshot)`);
+  }
+
+  if (!snapshot.isOptional && current.isOptional) {
+    errors.push(`Field '${path}' became optional (was required in snapshot)`);
+  }
+
+  // Compare ZodObject properties
+  if (current.type === "ZodObject") {
+    const snapshotProps = snapshot.properties || {};
+    const currentProps = current.properties || {};
+
+    // 1. All snapshot properties must exist in current schema and be compatible
+    for (const key of Object.keys(snapshotProps)) {
+      const fieldPath = path ? `${path}.${key}` : key;
+      if (!(key in currentProps)) {
+        errors.push(`Required field '${fieldPath}' from snapshot was removed`);
+      } else {
+        errors.push(
+          ...compareFieldDefinition(
+            currentProps[key],
+            snapshotProps[key],
+            fieldPath
+          )
+        );
+      }
+    }
+
+    // 2. Any new properties in current schema must be optional
+    for (const key of Object.keys(currentProps)) {
+      const fieldPath = path ? `${path}.${key}` : key;
+      if (!(key in snapshotProps)) {
+        if (!currentProps[key].isOptional) {
+          errors.push(
+            `New required field '${fieldPath}' added without updating snapshot`
+          );
+        }
+      }
+    }
+  }
+
+  // Compare ZodArray elements
+  if (current.type === "ZodArray" && snapshot.element && current.element) {
+    errors.push(
+      ...compareFieldDefinition(
+        current.element,
+        snapshot.element,
+        `${path}[]`
+      )
+    );
+  }
+
+  return errors;
+}
+
+/**
+ * Validates a map of current Zod schemas against a versioned snapshot
+ */
+export function validateSchemaSnapshot(
+  schemas: Record<string, z.ZodTypeAny>,
+  snapshot: SchemaSnapshot
+): SchemaComparisonResult {
+  const errors: string[] = [];
+
+  for (const [schemaName, snapshotShape] of Object.entries(snapshot.schemas)) {
+    const currentZodSchema = schemas[schemaName];
+    if (!currentZodSchema) {
+      errors.push(`Schema '${schemaName}' defined in snapshot is missing`);
+      continue;
+    }
+
+    const currentShape = extractSchemaShape(currentZodSchema);
+    const fieldErrors = compareFieldDefinition(
+      currentShape,
+      snapshotShape,
+      schemaName
+    );
+    errors.push(...fieldErrors);
+  }
+
+  return {
+    compatible: errors.length === 0,
+    errors,
+  };
+}

--- a/apps/shared/tests/schemas/schema-versioning.test.ts
+++ b/apps/shared/tests/schemas/schema-versioning.test.ts
@@ -1,0 +1,135 @@
+/// <reference types="bun-types" />
+import { describe, it, expect } from "bun:test";
+import { z } from "zod";
+import { propertyInfoSchema, lendingPoolSchema } from "../../src/schemas";
+import {
+  validateSchemaSnapshot,
+  extractSchemaShape,
+  type SchemaSnapshot,
+} from "../../src/utils/schema-versioning";
+import schemaV1 from "../snapshots/schema-v1.json";
+
+describe("Schema Versioning Guard", () => {
+  it("should pass baseline check for PropertyInfo and LendingPool against v1 snapshot", () => {
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: propertyInfoSchema,
+        LendingPool: lendingPoolSchema,
+      },
+      schemaV1 as SchemaSnapshot
+    );
+
+    expect(result.compatible).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should fail when an existing required field is modified or removed without a snapshot update", () => {
+    // Simulate removing a required field 'description' from PropertyInfo schema
+    const modifiedPropertySchema = z.object({
+      id: z.string().uuid(),
+      name: z.string(),
+      // description missing
+      propertyType: z.enum([
+        "residential",
+        "commercial",
+        "industrial",
+        "land",
+        "mixed",
+      ]),
+    });
+
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: modifiedPropertySchema,
+      },
+      schemaV1 as SchemaSnapshot
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(result.errors.some((err) => err.includes("description"))).toBe(true);
+  });
+
+  it("should fail when an existing required field type is changed", () => {
+    const modifiedLendingSchema = z.object({
+      ...lendingPoolSchema.shape,
+      utilizationRate: z.string(), // Changed from number to string
+    });
+
+    const result = validateSchemaSnapshot(
+      {
+        LendingPool: modifiedLendingSchema,
+      },
+      schemaV1 as SchemaSnapshot
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) => err.includes("utilizationRate") && err.includes("type changed")
+      )
+    ).toBe(true);
+  });
+
+  it("should fail when a new required field is added without a snapshot update", () => {
+    const modifiedPropertySchema = propertyInfoSchema.extend({
+      newRequiredField: z.string(),
+    });
+
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: modifiedPropertySchema,
+      },
+      schemaV1 as SchemaSnapshot
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("newRequiredField") && err.includes("added without updating snapshot")
+      )
+    ).toBe(true);
+  });
+
+  it("should NOT break when a new optional field is added (acceptance criterion #2)", () => {
+    const modifiedPropertySchema = propertyInfoSchema.extend({
+      metadata: z.record(z.string()).optional(),
+    });
+
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: modifiedPropertySchema,
+        LendingPool: lendingPoolSchema,
+      },
+      schemaV1 as SchemaSnapshot
+    );
+
+    expect(result.compatible).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should pass after updating snapshot for intentional schema changes", () => {
+    const updatedPropertySchema = propertyInfoSchema.extend({
+      newFeatureFlag: z.boolean(),
+    });
+
+    const updatedSnapshot: SchemaSnapshot = {
+      version: "1.1.0",
+      schemas: {
+        PropertyInfo: extractSchemaShape(updatedPropertySchema),
+        LendingPool: extractSchemaShape(lendingPoolSchema),
+      },
+    };
+
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: updatedPropertySchema,
+        LendingPool: lendingPoolSchema,
+      },
+      updatedSnapshot
+    );
+
+    expect(result.compatible).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/apps/shared/tests/snapshots/schema-v1.json
+++ b/apps/shared/tests/snapshots/schema-v1.json
@@ -1,0 +1,87 @@
+{
+  "version": "1.0.0",
+  "schemas": {
+    "PropertyInfo": {
+      "type": "ZodObject",
+      "isOptional": false,
+      "properties": {
+        "id": { "type": "ZodString", "isOptional": false },
+        "name": { "type": "ZodString", "isOptional": false },
+        "description": { "type": "ZodString", "isOptional": false },
+        "propertyType": { "type": "ZodEnum", "isOptional": false },
+        "location": {
+          "type": "ZodObject",
+          "isOptional": false,
+          "properties": {
+            "address": { "type": "ZodString", "isOptional": false },
+            "city": { "type": "ZodString", "isOptional": false },
+            "country": { "type": "ZodString", "isOptional": false },
+            "postalCode": { "type": "ZodString", "isOptional": true },
+            "coordinates": {
+              "type": "ZodObject",
+              "isOptional": true,
+              "properties": {
+                "latitude": { "type": "ZodNumber", "isOptional": false },
+                "longitude": { "type": "ZodNumber", "isOptional": false }
+              }
+            }
+          }
+        },
+        "totalValue": { "type": "ZodString", "isOptional": false },
+        "tokenAddress": { "type": "ZodString", "isOptional": true },
+        "totalShares": { "type": "ZodNumber", "isOptional": false },
+        "availableShares": { "type": "ZodNumber", "isOptional": false },
+        "pricePerShare": { "type": "ZodString", "isOptional": false },
+        "expectedYield": { "type": "ZodNumber", "isOptional": true },
+        "images": {
+          "type": "ZodArray",
+          "isOptional": false,
+          "element": { "type": "ZodString", "isOptional": false }
+        },
+        "splatUrl": { "type": "ZodString", "isOptional": true },
+        "documents": {
+          "type": "ZodArray",
+          "isOptional": false,
+          "element": {
+            "type": "ZodObject",
+            "isOptional": false,
+            "properties": {
+              "id": { "type": "ZodString", "isOptional": false },
+              "type": { "type": "ZodEnum", "isOptional": false },
+              "name": { "type": "ZodString", "isOptional": false },
+              "url": { "type": "ZodString", "isOptional": false },
+              "uploadedAt": { "type": "ZodString", "isOptional": false },
+              "verified": { "type": "ZodBoolean", "isOptional": false }
+            }
+          }
+        },
+        "verified": { "type": "ZodBoolean", "isOptional": false },
+        "listedAt": { "type": "ZodString", "isOptional": false },
+        "owner": { "type": "ZodString", "isOptional": false }
+      }
+    },
+    "LendingPool": {
+      "type": "ZodObject",
+      "isOptional": false,
+      "properties": {
+        "id": { "type": "ZodString", "isOptional": false },
+        "name": { "type": "ZodString", "isOptional": false },
+        "asset": { "type": "ZodString", "isOptional": false },
+        "assetAddress": { "type": "ZodString", "isOptional": false },
+        "totalDeposits": { "type": "ZodString", "isOptional": false },
+        "totalBorrows": { "type": "ZodString", "isOptional": false },
+        "availableLiquidity": { "type": "ZodString", "isOptional": false },
+        "utilizationRate": { "type": "ZodNumber", "isOptional": false },
+        "supplyAPY": { "type": "ZodNumber", "isOptional": false },
+        "borrowAPY": { "type": "ZodNumber", "isOptional": false },
+        "collateralFactor": { "type": "ZodNumber", "isOptional": false },
+        "liquidationThreshold": { "type": "ZodNumber", "isOptional": false },
+        "liquidationPenalty": { "type": "ZodNumber", "isOptional": false },
+        "reserveFactor": { "type": "ZodNumber", "isOptional": false },
+        "isActive": { "type": "ZodBoolean", "isOptional": false },
+        "isPaused": { "type": "ZodBoolean", "isOptional": false },
+        "createdAt": { "type": "ZodString", "isOptional": false }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Adds a versioning guard for shared schemas (`PropertyInfo` and `LendingPool`) to prevent breaking changes from slipping through unnoticed and breaking the webapp or API.

Closes #1020

### What Changed
- Created `apps/shared/src/utils/schema-versioning.ts` for schema shape extraction and snapshot comparison.
- Added baseline snapshot `apps/shared/tests/snapshots/schema-v1.json` for `PropertyInfo` and `LendingPool`.
- Added unit tests in `apps/shared/tests/schemas/schema-versioning.test.ts`.
- Re-exported versioning utilities in `apps/shared/src/utils/index.ts`.

### Acceptance Criteria Checklist
- [x] Changing an existing required field without updating the snapshot makes the check fail.
- [x] Adding a new optional field does not break the check.
- [x] All 147 tests pass.
- [x] Type check and lint pass with 0 errors.

### Security Note
No secrets, keys, or sensitive environment configurations were touched or exposed.