### PR TITLE
test(game-engine): cover initialize error path and accrued-income branches

### DIFF
--- a/apps/contracts/contracts/game-engine/src/additional_tests.rs
+++ b/apps/contracts/contracts/game-engine/src/additional_tests.rs
@@ -1,0 +1,79 @@
+//! Additional unit tests for the `game-engine` contract (issue #1014).
+//!
+//! These complement the existing in-crate `tests` module by covering paths it
+//! did not exercise:
+//! - `GameEngine::initialize` rejecting a second call with
+//!   `EngineError::AlreadyInitialized` (the one public entry point whose error
+//!   path had no coverage).
+//! - Direct branch coverage for the pure `calculate_accrued_income` helper: the
+//!   early return when no time has passed, a sub-epoch elapse, the vacant
+//!   multiplier, an unknown level (which defaults to vacant), and monotonic
+//!   growth of income across improvement levels.
+
+use crate::constants::*;
+use crate::{calculate_accrued_income, EngineError, GameEngine, GameEngineClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ---------------- Pure helper: calculate_accrued_income ----------------
+
+#[test]
+fn accrued_income_is_zero_when_no_time_has_passed() {
+    // current_ledger < last_claimed_ledger
+    assert_eq!(calculate_accrued_income(50, 100, LEVEL_RESIDENTIAL), 0);
+    // current_ledger == last_claimed_ledger
+    assert_eq!(calculate_accrued_income(100, 100, LEVEL_RESIDENTIAL), 0);
+}
+
+#[test]
+fn accrued_income_is_zero_for_a_partial_epoch() {
+    // Strictly less than one full epoch has elapsed.
+    assert_eq!(calculate_accrued_income(EPOCH_LENGTH - 1, 0, LEVEL_RESIDENTIAL), 0);
+}
+
+#[test]
+fn accrued_income_uses_vacant_multiplier() {
+    let income = calculate_accrued_income(EPOCH_LENGTH, 0, LEVEL_VACANT);
+    let (num, den) = MULTIPLIER_VACANT;
+    assert_eq!(income, BASE_RENTAL_RATE * num / den);
+}
+
+#[test]
+fn accrued_income_unknown_level_defaults_to_vacant() {
+    let unknown_level: u32 = 99;
+    let income = calculate_accrued_income(EPOCH_LENGTH, 0, unknown_level);
+    let (num, den) = MULTIPLIER_VACANT;
+    assert_eq!(income, BASE_RENTAL_RATE * num / den);
+}
+
+#[test]
+fn accrued_income_grows_with_improvement_level() {
+    let vacant = calculate_accrued_income(EPOCH_LENGTH, 0, LEVEL_VACANT);
+    let residential = calculate_accrued_income(EPOCH_LENGTH, 0, LEVEL_RESIDENTIAL);
+    let commercial = calculate_accrued_income(EPOCH_LENGTH, 0, LEVEL_COMMERCIAL);
+    let skyscraper = calculate_accrued_income(EPOCH_LENGTH, 0, LEVEL_SKYSCRAPER);
+
+    assert!(residential >= vacant);
+    assert!(commercial >= residential);
+    assert!(skyscraper >= commercial);
+}
+
+// ---------------- Contract: initialize error path ----------------
+
+#[test]
+fn double_initialize_fails_with_already_initialized() {
+    let env = Env::default();
+
+    let nft = Address::generate(&env);
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let engine_id = env.register(GameEngine, ());
+    let engine_client = GameEngineClient::new(&env, &engine_id);
+
+    // First initialization succeeds.
+    engine_client.initialize(&nft, &token, &treasury);
+
+    // A second initialization must fail with AlreadyInitialized.
+    let res = engine_client.try_initialize(&nft, &token, &treasury);
+    assert_eq!(res, Err(Ok(EngineError::AlreadyInitialized.into())));
+}

--- a/apps/contracts/contracts/game-engine/src/additional_tests.rs
+++ b/apps/contracts/contracts/game-engine/src/additional_tests.rs
@@ -27,7 +27,10 @@ fn accrued_income_is_zero_when_no_time_has_passed() {
 #[test]
 fn accrued_income_is_zero_for_a_partial_epoch() {
     // Strictly less than one full epoch has elapsed.
-    assert_eq!(calculate_accrued_income(EPOCH_LENGTH - 1, 0, LEVEL_RESIDENTIAL), 0);
+    assert_eq!(
+        calculate_accrued_income(EPOCH_LENGTH - 1, 0, LEVEL_RESIDENTIAL),
+        0
+    );
 }
 
 #[test]

--- a/apps/contracts/contracts/game-engine/src/lib.rs
+++ b/apps/contracts/contracts/game-engine/src/lib.rs
@@ -10,6 +10,9 @@ use soroban_sdk::{
 pub mod constants;
 pub mod cougr_core;
 
+#[cfg(test)]
+mod additional_tests;
+
 use constants::*;
 use cougr_core::app::{named_system, GameApp, ScheduleStage};
 // Define PropertyState structure for cross-contract communication


### PR DESCRIPTION
## What & why

The `game-engine` contract already had an inline `tests` module covering the
happy and error paths of `improve`, `claim_rental`, and `get_accrued_income`.
This PR adds a small, self-contained `additional_tests` module that fills the
remaining gaps in that suite so every public entry point and its error paths
are exercised.

## New coverage

**`initialize` error path (previously untested)**
- `double_initialize_fails_with_already_initialized` — a second `initialize`
  call now asserts it fails with `EngineError::AlreadyInitialized`. This was the
  one public function whose error path had no test.

**Direct branch coverage for the pure `calculate_accrued_income` helper**
- `accrued_income_is_zero_when_no_time_has_passed` — `current_ledger` less than
  or equal to `last_claimed_ledger` returns `0`.
- `accrued_income_is_zero_for_a_partial_epoch` — less than one full epoch
  elapsed returns `0`.
- `accrued_income_uses_vacant_multiplier` — vacant level uses the vacant
  multiplier.
- `accrued_income_unknown_level_defaults_to_vacant` — an unrecognised level
  falls back to the vacant multiplier.
- `accrued_income_grows_with_improvement_level` — income is monotonic across
  vacant → residential → commercial → skyscraper.

## Scope / safety

- Purely additive: one new file (`src/additional_tests.rs`) plus a two-line
  `#[cfg(test)] mod additional_tests;` declaration in `lib.rs`.
- No production code changed; the existing `tests` module is untouched, so
  nothing can regress.

## How to verify
cargo test -p game-engine

Closes #1014