### PR TITLE
[WEBAPP] Optimistic UI for lending actions

### DIFF
--- a/apps/webapp/src/app/[locale]/lending/page.tsx
+++ b/apps/webapp/src/app/[locale]/lending/page.tsx
@@ -203,9 +203,12 @@ export default function LendingPage() {
   const {
     pools,
     userPositions,
+    pendingActions,
     isLoading,
     error,
     refetch,
+    addPendingAction,
+    removePendingAction,
     connectionStatus,
     lastUpdatedAt,
     isPolling,
@@ -316,21 +319,35 @@ export default function LendingPage() {
   // Helper: user's total deposit / borrow amount in a specific pool
   // -------------------------------------------------------------------------
   function poolUserDeposit(poolId: string): number {
-    return (
+    const base =
       userPositions[poolId]?.deposits.reduce(
         (s, d) => s + parseFloat(d.amount),
         0,
-      ) ?? 0
-    );
+      ) ?? 0;
+    const pending = pendingActions
+      .filter((a) => a.poolId === poolId)
+      .reduce((acc, a) => {
+        if (a.type === "supply") return acc + a.amount;
+        if (a.type === "withdraw") return acc - a.amount;
+        return acc;
+      }, 0);
+    return Math.max(0, base + pending);
   }
 
   function poolUserBorrow(poolId: string): number {
-    return (
+    const base =
       userPositions[poolId]?.borrows.reduce(
         (s, b) => s + parseFloat(b.principal) + parseFloat(b.accruedInterest),
         0,
-      ) ?? 0
-    );
+      ) ?? 0;
+    const pending = pendingActions
+      .filter((a) => a.poolId === poolId)
+      .reduce((acc, a) => {
+        if (a.type === "borrow") return acc + a.amount;
+        if (a.type === "repay") return acc - a.amount;
+        return acc;
+      }, 0);
+    return Math.max(0, base + pending);
   }
 
   // -------------------------------------------------------------------------
@@ -730,7 +747,7 @@ export default function LendingPage() {
 
                               {/* User position (shown only when non-zero) */}
                               {(deposit > 0 || borrow > 0) && (
-                                <div className="p-3 bg-[#0a0a0a] border border-[#262626] rounded-lg lg:w-48">
+                                <div className="p-3 bg-[#0a0a0a] border border-[#262626] rounded-lg lg:w-52">
                                   <p className="text-[10px] text-neutral-600 mb-2 uppercase tracking-wider">
                                     Your Position
                                   </p>
@@ -740,6 +757,17 @@ export default function LendingPage() {
                                       {hideBalances
                                         ? "••••"
                                         : formatCurrency(deposit)}
+                                      {pendingActions.some(
+                                        (a) =>
+                                          a.poolId === pool.id &&
+                                          (a.type === "supply" ||
+                                            a.type === "withdraw"),
+                                      ) && (
+                                        <span className="ml-1.5 inline-flex items-center gap-1 text-[10px] text-amber-400">
+                                          <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+                                          pending
+                                        </span>
+                                      )}
                                     </p>
                                   )}
                                   {borrow > 0 && (
@@ -748,6 +776,17 @@ export default function LendingPage() {
                                       {hideBalances
                                         ? "••••"
                                         : formatCurrency(borrow)}
+                                      {pendingActions.some(
+                                        (a) =>
+                                          a.poolId === pool.id &&
+                                          (a.type === "borrow" ||
+                                            a.type === "repay"),
+                                      ) && (
+                                        <span className="ml-1.5 inline-flex items-center gap-1 text-[10px] text-amber-400">
+                                          <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+                                          pending
+                                        </span>
+                                      )}
                                     </p>
                                   )}
                                 </div>
@@ -870,6 +909,15 @@ export default function LendingPage() {
           refetch();
           void refreshBalance();
         }}
+        onPendingAction={(action) =>
+          addPendingAction({
+            poolId: action.poolId,
+            type: action.type,
+            amount: action.amount,
+            timestamp: Date.now(),
+          })
+        }
+        onSettleAction={(poolId, type) => removePendingAction(poolId, type)}
       />
     </motion.div>
   );

--- a/apps/webapp/src/components/lending/PoolActionModal.tsx
+++ b/apps/webapp/src/components/lending/PoolActionModal.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { motion } from "framer-motion";
-import { Shield, Coins, CheckCircle2, ExternalLink } from "lucide-react";
+import {
+  Shield,
+  Coins,
+  CheckCircle2,
+  ExternalLink,
+  AlertCircle,
+  RefreshCw,
+  Loader2,
+} from "lucide-react";
 import type { LendingPool } from "@real-estate-defi/shared";
 import { Modal, Badge, Button, Toggle } from "@/components/ui";
 import { Form, FormInput } from "@/components/forms";
@@ -12,18 +20,25 @@ import {
 } from "@/schemas/forms";
 import { lendingApi } from "@/services/api";
 import { formatCurrency } from "@/lib/utils";
+import type { PendingActionType } from "@/hooks/useLendingPools";
 
 export type PoolAction = "supply" | "borrow" | "withdraw" | "repay";
+
+type ModalStatus = "form" | "confirming" | "success" | "error";
 
 export interface PoolActionModalProps {
   pool: LendingPool | null;
   action: PoolAction;
   isOpen: boolean;
   onClose: () => void;
-  /** Connected wallet address - required for real TX submission */
   userAddress?: string | null;
-  /** Callback fired after a successful transaction so the parent can refetch */
   onSuccess?: () => void;
+  onPendingAction?: (action: {
+    poolId: string;
+    type: PendingActionType;
+    amount: number;
+  }) => void;
+  onSettleAction?: (poolId: string, type: PendingActionType) => void;
 }
 
 /** Present a valid 64-hex-char Stellar-style tx hash in a shortened form */
@@ -85,8 +100,14 @@ export function PoolActionModal({
   onClose,
   userAddress,
   onSuccess,
+  onPendingAction,
+  onSettleAction,
 }: PoolActionModalProps) {
+  const [status, setStatus] = useState<ModalStatus>("form");
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submittedAmount, setSubmittedAmount] = useState<number | null>(null);
+
   const successMessage = useMemo(() => {
     switch (action) {
       case "supply":
@@ -100,12 +121,20 @@ export function PoolActionModal({
     }
   }, [action]);
 
+  const resetState = useCallback(() => {
+    setStatus("form");
+    setTxHash(null);
+    setErrorMessage(null);
+    setSubmittedAmount(null);
+  }, []);
+
   if (!pool) return null;
 
   const cfg = ACTION_CONFIG[action];
   const apy = pool[cfg.apyKey];
   const maxAmount = parseFloat(pool.availableLiquidity);
   const canSubmit = Boolean(userAddress);
+  const isSupplyOrWithdraw = action === "supply" || action === "withdraw";
 
   const handleSubmit = async (values: LendingActionFormValues) => {
     if (!userAddress) {
@@ -115,53 +144,130 @@ export function PoolActionModal({
     }
 
     const amount = parseFloat(values.amount);
+    setSubmittedAmount(amount);
+    setStatus("confirming");
+    setErrorMessage(null);
 
-    if (action === "supply") {
-      await lendingApi.deposit(pool.id, {
-        userAddress,
-        amount,
-      });
-    } else if (action === "withdraw") {
-      await lendingApi.withdraw(pool.id, {
-        userAddress,
-        amount,
-      });
-    } else if (action === "borrow") {
-      await lendingApi.borrow(pool.id, {
-        userAddress,
-        collateralAmount: amount,
-        collateralAsset: pool.assetAddress,
-        borrowAmount: amount,
-      });
-    } else {
-      await lendingApi.repay(pool.id, {
-        userAddress,
-        amount,
-      });
+    const pendingType = action as PendingActionType;
+    onPendingAction?.({ poolId: pool.id, type: pendingType, amount });
+
+    try {
+      if (action === "supply") {
+        await lendingApi.deposit(pool.id, {
+          userAddress,
+          amount,
+        });
+      } else if (action === "withdraw") {
+        await lendingApi.withdraw(pool.id, {
+          userAddress,
+          amount,
+        });
+      } else if (action === "borrow") {
+        await lendingApi.borrow(pool.id, {
+          userAddress,
+          collateralAmount: amount,
+          collateralAsset: pool.assetAddress,
+          borrowAmount: amount,
+        });
+      } else {
+        await lendingApi.repay(pool.id, {
+          userAddress,
+          amount,
+        });
+      }
+
+      const hash = `submitted-${Date.now()}`;
+      setTxHash(hash);
+      setStatus("success");
+      onSettleAction?.(pool.id, pendingType);
+      onSuccess?.();
+
+      setTimeout(() => {
+        resetState();
+        onClose();
+      }, 2500);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Transaction failed. Please try again.";
+      setErrorMessage(message);
+      setStatus("error");
+      onSettleAction?.(pool.id, pendingType);
     }
+  };
 
-    setTxHash(`submitted-${Date.now()}`);
-    onSuccess?.();
-
-    // Auto-close after showing the hash
-    setTimeout(() => {
-      setTxHash(null);
-      onClose();
-    }, 2500);
+  const handleRetry = () => {
+    setStatus("form");
+    setErrorMessage(null);
+    setTxHash(null);
   };
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={() => {
-        setTxHash(null);
+        resetState();
         onClose();
       }}
-      title={cfg.title}
-      description={cfg.description}
+      title={
+        status === "confirming"
+          ? "Confirming Transaction"
+          : status === "success"
+            ? "Transaction Submitted"
+            : status === "error"
+              ? "Transaction Failed"
+              : cfg.title
+      }
+      description={
+        status === "confirming"
+          ? "Please wait while your transaction is being processed..."
+          : status === "error"
+            ? undefined
+            : cfg.description
+      }
     >
-      {/* Success state - show TX hash */}
-      {txHash ? (
+      {/* Confirming state - skeleton/loading indicator */}
+      {status === "confirming" && submittedAmount !== null ? (
+        <div className="flex flex-col items-center gap-6 py-6 text-center">
+          <div className="w-14 h-14 rounded-full bg-[#ff3e00]/10 border border-[#ff3e00]/30 flex items-center justify-center">
+            <Loader2 className="w-7 h-7 text-[#ff3e00] animate-spin" />
+          </div>
+          <div className="w-full space-y-4">
+            <div>
+              <p className="text-base font-semibold text-white mb-1">
+                Processing {cfg.buttonText.toLowerCase()}
+              </p>
+              <p className="text-xs text-neutral-500">
+                Waiting for on-chain confirmation...
+              </p>
+            </div>
+            <div className="p-4 bg-[#1a1a1a] border border-[#262626] rounded-lg space-y-3">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-neutral-500">Action</span>
+                <span className="text-white font-semibold">{cfg.buttonText}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-neutral-500">Amount</span>
+                <span className="text-white font-mono font-semibold">
+                  {formatCurrency(submittedAmount)} {pool.asset}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-neutral-500">Pool</span>
+                <span className="text-white">{pool.name}</span>
+              </div>
+            </div>
+            <div className="p-4 bg-[#0a0a0a] border border-[#262626] rounded-lg">
+              <div className="flex items-center gap-3">
+                <div className="flex-1 space-y-2">
+                  <div className="h-2 bg-[#262626] rounded animate-pulse w-3/4" />
+                  <div className="h-2 bg-[#262626] rounded animate-pulse w-1/2" />
+                  <div className="h-2 bg-[#262626] rounded animate-pulse w-2/3" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : status === "success" && txHash ? (
         <div className="flex flex-col items-center gap-4 py-6 text-center">
           <div className="w-14 h-14 rounded-full bg-[#00ff88]/10 border border-[#00ff88]/30 flex items-center justify-center">
             <CheckCircle2 className="w-7 h-7 text-[#00ff88]" />
@@ -171,12 +277,49 @@ export function PoolActionModal({
               Action submitted
             </p>
             <p className="text-xs text-neutral-500 mb-3">{successMessage}</p>
-            {txHash ? (
-              <span className="inline-flex items-center gap-1.5 text-xs text-[#ff3e00] font-mono">
-                {shortenTxHash(txHash)}
-                <ExternalLink className="w-3 h-3" aria-hidden="true" />
-              </span>
-            ) : null}
+            {submittedAmount !== null && (
+              <p className="text-sm text-neutral-400 mb-3">
+                {formatCurrency(submittedAmount)} {pool.asset}
+              </p>
+            )}
+            <span className="inline-flex items-center gap-1.5 text-xs text-[#ff3e00] font-mono">
+              {shortenTxHash(txHash)}
+              <ExternalLink className="w-3 h-3" aria-hidden="true" />
+            </span>
+          </div>
+        </div>
+      ) : status === "error" ? (
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <div className="w-14 h-14 rounded-full bg-red-500/10 border border-red-500/30 flex items-center justify-center">
+            <AlertCircle className="w-7 h-7 text-red-400" />
+          </div>
+          <div>
+            <p className="text-base font-semibold text-white mb-1">
+              Transaction Failed
+            </p>
+            <p className="text-xs text-red-400/80 mb-4">{errorMessage}</p>
+          </div>
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRetry}
+              leftIcon={<RefreshCw className="w-3.5 h-3.5" />}
+              aria-label="Retry transaction"
+            >
+              Retry
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                resetState();
+                onClose();
+              }}
+              aria-label="Close modal"
+            >
+              Close
+            </Button>
           </div>
         </div>
       ) : (

--- a/apps/webapp/src/components/lending/__tests__/PoolActionModal.test.tsx
+++ b/apps/webapp/src/components/lending/__tests__/PoolActionModal.test.tsx
@@ -1,0 +1,306 @@
+import "@/test/setup-dom";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ImgHTMLAttributes,
+  ReactNode,
+} from "react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import type { LendingPool } from "@real-estate-defi/shared";
+import { createLendingPool } from "@real-estate-defi/shared";
+import { lendingApi } from "@/services/api";
+
+const depositMock = mock(() =>
+  Promise.resolve({
+    id: "dep-1",
+    poolId: "550e8400-e29b-41d4-a716-446655440000",
+    depositor: "GDB6EXAMPLEWALLETADDRESS1234567890123456789012345678901234",
+    amount: "1000",
+    shares: "1000",
+    depositedAt: new Date().toISOString(),
+    lastAccrualAt: new Date().toISOString(),
+    accruedInterest: "0",
+  }),
+);
+
+const borrowMock = mock(() =>
+  Promise.resolve({
+    id: "bor-1",
+    poolId: "550e8400-e29b-41d4-a716-446655440000",
+    borrower: "GDB6EXAMPLEWALLETADDRESS1234567890123456789012345678901234",
+    principal: "500",
+    accruedInterest: "0",
+    collateralAmount: "1000",
+    collateralAsset: "GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU",
+    healthFactor: 1.5,
+    borrowedAt: new Date().toISOString(),
+    lastAccrualAt: new Date().toISOString(),
+  }),
+);
+
+const depositFailMock = mock(() =>
+  Promise.reject(new Error("Insufficient liquidity")),
+);
+
+const borrowFailMock = mock(() =>
+  Promise.reject(new Error("Insufficient collateral")),
+);
+
+const originalDeposit = lendingApi.deposit;
+const originalBorrow = lendingApi.borrow;
+
+mock.module("next/image", () => ({
+  default: (props: ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+mock.module("framer-motion", () => {
+  const passthroughDiv = ({
+    children,
+    whileHover: _whileHover,
+    whileTap: _whileTap,
+    initial: _initial,
+    animate: _animate,
+    exit: _exit,
+    transition: _transition,
+    variants: _variants,
+    ...props
+  }: HTMLAttributes<HTMLDivElement> & Record<string, unknown>) => (
+    <div {...props}>{children}</div>
+  );
+  const passthroughButton = ({
+    children,
+    whileHover: _whileHover,
+    whileTap: _whileTap,
+    initial: _initial,
+    animate: _animate,
+    exit: _exit,
+    transition: _transition,
+    variants: _variants,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  );
+
+  return {
+    AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+    motion: new Proxy(
+      {
+        div: passthroughDiv,
+        button: passthroughButton,
+      },
+      {
+        get: (target, property) =>
+          property in target
+            ? target[property as keyof typeof target]
+            : passthroughDiv,
+      },
+    ),
+  };
+});
+
+mock.module("@/components/forms", () => {
+  const FormInput = ({ label }: { label: string }) => (
+    <div data-testid="mock-input">{label}</div>
+  );
+  return {
+    Form: ({ children, onSubmit }: { children: unknown; onSubmit: (values: { amount: string }) => Promise<void> }) => {
+      const handleClick = () => {
+        void onSubmit({ amount: "1000", zkPrivacy: false });
+      };
+      if (typeof children === "function") {
+        return (
+          <div data-testid="mock-form">
+            {children({
+              watch: () => false,
+              setValue: () => {},
+              formState: { isSubmitting: false, isValid: true },
+            })}
+            <button
+              data-testid="submit-btn"
+              onClick={handleClick}
+              type="button"
+            >
+              Submit
+            </button>
+          </div>
+        );
+      }
+      return <div data-testid="mock-form">{children}</div>;
+    },
+    FormInput,
+  };
+});
+
+const { PoolActionModal } = await import("../PoolActionModal");
+
+const pool: LendingPool = createLendingPool({
+  name: "USD Pool",
+  asset: "USD",
+  totalDeposits: "1000000",
+  totalBorrows: "500000",
+  availableLiquidity: "500000",
+  utilizationRate: 50,
+  supplyAPY: 2.5,
+  borrowAPY: 5.0,
+  collateralFactor: 60,
+});
+
+const WALLET = "GDB6EXAMPLEWALLETADDRESS1234567890123456789012345678901234";
+
+describe("PoolActionModal - optimistic UI", () => {
+  beforeEach(() => {
+    cleanup();
+    lendingApi.deposit = depositMock;
+    lendingApi.borrow = borrowMock;
+    depositMock.mockClear();
+    borrowMock.mockClear();
+  });
+
+  afterAll(() => {
+    lendingApi.deposit = originalDeposit;
+    lendingApi.borrow = originalBorrow;
+  });
+
+  it("shows confirming skeleton immediately after submit, then success", async () => {
+    const onSuccess = mock(() => {});
+    const onPendingAction = mock(() => {});
+    const onSettleAction = mock(() => {});
+
+    const view = render(
+      <PoolActionModal
+        pool={pool}
+        action="supply"
+        isOpen
+        onClose={() => {}}
+        userAddress={WALLET}
+        onSuccess={onSuccess}
+        onPendingAction={onPendingAction}
+        onSettleAction={onSettleAction}
+      />,
+    );
+
+    fireEvent.click(view.getByTestId("submit-btn"));
+
+    expect(onPendingAction).toHaveBeenCalledWith({
+      poolId: pool.id,
+      type: "supply",
+      amount: 1000,
+    });
+
+    expect(view.queryByText(/Processing supply/i)).not.toBeNull();
+    expect(view.queryByText(/Waiting for on-chain confirmation/i)).not.toBeNull();
+
+    const skeleton = document.querySelector(".animate-pulse");
+    expect(skeleton).not.toBeNull();
+
+    await waitFor(() => {
+      expect(view.queryByText(/1,000 USD/)).not.toBeNull();
+      expect(view.queryByText(/Supply submitted successfully/i)).not.toBeNull();
+    });
+
+    expect(onSettleAction).toHaveBeenCalledWith(pool.id, "supply");
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error state and retry button on failed tx", async () => {
+    lendingApi.deposit = depositFailMock;
+    const onSettleAction = mock(() => {});
+
+    const view = render(
+      <PoolActionModal
+        pool={pool}
+        action="supply"
+        isOpen
+        onClose={() => {}}
+        userAddress={WALLET}
+        onSuccess={() => {}}
+        onPendingAction={() => {}}
+        onSettleAction={onSettleAction}
+      />,
+    );
+
+    fireEvent.click(view.getByTestId("submit-btn"));
+
+    await waitFor(() => {
+      expect(view.queryByText(/Insufficient liquidity/i)).not.toBeNull();
+    });
+
+    expect(onSettleAction).toHaveBeenCalledWith(pool.id, "supply");
+
+    const retryButton = view.getByRole("button", { name: /Retry transaction/i });
+    expect(retryButton).not.toBeNull();
+  });
+
+  it("shows confirming state for borrow action, then success", async () => {
+    const onPendingAction = mock(() => {});
+
+    const view = render(
+      <PoolActionModal
+        pool={pool}
+        action="borrow"
+        isOpen
+        onClose={() => {}}
+        userAddress={WALLET}
+        onSuccess={() => {}}
+        onPendingAction={onPendingAction}
+        onSettleAction={() => {}}
+      />,
+    );
+
+    fireEvent.click(view.getByTestId("submit-btn"));
+
+    expect(onPendingAction).toHaveBeenCalledWith({
+      poolId: pool.id,
+      type: "borrow",
+      amount: 1000,
+    });
+
+    expect(view.queryByText(/Processing borrow/i)).not.toBeNull();
+
+    await waitFor(() => {
+      expect(view.queryByText(/Borrow submitted successfully/i)).not.toBeNull();
+    });
+  });
+
+  it("shows error state for failed borrow", async () => {
+    lendingApi.borrow = borrowFailMock;
+
+    const view = render(
+      <PoolActionModal
+        pool={pool}
+        action="borrow"
+        isOpen
+        onClose={() => {}}
+        userAddress={WALLET}
+        onSuccess={() => {}}
+        onPendingAction={() => {}}
+        onSettleAction={() => {}}
+      />,
+    );
+
+    fireEvent.click(view.getByTestId("submit-btn"));
+
+    await waitFor(() => {
+      expect(view.queryByText(/Insufficient collateral/i)).not.toBeNull();
+    });
+  });
+
+  it("shows connect wallet prompt when no wallet is connected", () => {
+    const view = render(
+      <PoolActionModal
+        pool={pool}
+        action="supply"
+        isOpen
+        onClose={() => {}}
+        userAddress={null}
+      />,
+    );
+
+    expect(
+      view.queryByText(/Connect your wallet before submitting/i),
+    ).not.toBeNull();
+  });
+});

--- a/apps/webapp/src/hooks/useLendingPools.ts
+++ b/apps/webapp/src/hooks/useLendingPools.ts
@@ -15,27 +15,31 @@ export interface UserPositions {
   borrows: BorrowPosition[];
 }
 
+export type PendingActionType = "supply" | "withdraw" | "borrow" | "repay";
+
+export interface PendingAction {
+  poolId: string;
+  type: PendingActionType;
+  amount: number;
+  timestamp: number;
+}
+
 export interface UseLendingPoolsOptions {
   enableLiveUpdates?: boolean;
   pollingInterval?: number;
 }
 
 export interface UseLendingPoolsReturn {
-  /** All available lending pools from the API */
   pools: LendingPool[];
-  /** Map of poolId → user's deposit + borrow positions in that pool */
   userPositions: Record<string, UserPositions>;
-  /** True while the initial pools fetch or position fetch is in-flight */
+  pendingActions: PendingAction[];
   isLoading: boolean;
-  /** Non-null when any fetch has failed */
   error: string | null;
-  /** Re-trigger a full reload (pools + positions) */
   refetch: () => void;
-  /** Current connection status for live updates */
+  addPendingAction: (action: PendingAction) => void;
+  removePendingAction: (poolId: string, type: PendingActionType) => void;
   connectionStatus: ConnectionStatus;
-  /** Last time the data was updated */
   lastUpdatedAt: Date | null;
-  /** Whether currently using fallback polling */
   isPolling: boolean;
 }
 
@@ -63,6 +67,7 @@ export function useLendingPools(
   const [userPositions, setUserPositions] = useState<
     Record<string, UserPositions>
   >({});
+  const [pendingActions, setPendingActions] = useState<PendingAction[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fetchKey, setFetchKey] = useState(0);
@@ -72,6 +77,19 @@ export function useLendingPools(
   const refetch = useCallback(() => {
     setFetchKey((k) => k + 1);
   }, []);
+
+  const addPendingAction = useCallback((action: PendingAction) => {
+    setPendingActions((prev) => [...prev, action]);
+  }, []);
+
+  const removePendingAction = useCallback(
+    (poolId: string, type: PendingActionType) => {
+      setPendingActions((prev) =>
+        prev.filter((a) => !(a.poolId === poolId && a.type === type)),
+      );
+    },
+    [],
+  );
 
   const fetchPoolsOnly = useCallback(async () => {
     const fetchedPools = await lendingApi.getPools();
@@ -158,9 +176,12 @@ export function useLendingPools(
   return {
     pools,
     userPositions,
+    pendingActions,
     isLoading,
     error,
     refetch: refetchWithLive,
+    addPendingAction,
+    removePendingAction,
     connectionStatus,
     lastUpdatedAt,
     isPolling,


### PR DESCRIPTION
## Overview

This PR adds an optimistic UI to the lending flow (supply, borrow, withdraw, repay). Instead of waiting for the full on-chain confirmation before reflecting any change, the UI now:

- Shows a **confirming state** with skeleton loading immediately after the transaction is submitted
- Displays the **optimistic amount** in the confirming state, making the app feel responsive
- **Reconciles** on success (data refreshes via the existing refetch mechanism)
- **Rolls back** on failure with a clear **error state** and **Retry** button
- Shows a **pending badge** on pool position rows while the transaction is being processed

## Related Issue

Closes #1010

## Changes

### 🎯 Optimistic State Machine
- **[MODIFY]** \pps/webapp/src/components/lending/PoolActionModal.tsx\ - Added a 4-state machine (form → confirming → success/error) with:
  - \confirming\ state with spinning loader, transaction details, and skeleton placeholders
  - \success\ state showing the submitted amount and tx hash
  - \error\ state with error message and retry/close buttons
  - \onPendingAction\ / \onSettleAction\ callbacks for optimistic integration with parent

### 🔄 Pending Action Tracking
- **[MODIFY]** \pps/webapp/src/hooks/useLendingPools.ts\ - Added:
  - \PendingAction\ type and \pendingActions\ state array
  - \ddPendingAction\ / \emovePendingAction\ functions
  - Exposed in \UseLendingPoolsReturn\ interface

### 📊 Optimistic Position Display
- **[MODIFY]** \pps/webapp/src/app/[locale]/lending/page.tsx\ - Updated \poolUserDeposit\ and \poolUserBorrow\ to account for pending actions, and added \pending\ badge indicators on pool position rows

### 🧪 Tests
- **[ADD]** \pps/webapp/src/components/lending/__tests__/PoolActionModal.test.tsx\ - Tests for:
  - Successful supply tx (confirming skeleton → success)
  - Failed supply tx (confirming skeleton → error with retry)
  - Successful borrow tx
  - Failed borrow tx
  - Wallet-not-connected prompt

## Verification Results

\\\
bun test apps/webapp/src/components/lending/__tests__/PoolActionModal.test.tsx
✅ 5/5 passed

Pre-existing tests unaffected:
bun test apps/webapp/src/services/api/__tests__/lending.test.ts
✅ 8/8 passed
\\\

Acceptance Criteria | Status
-- | --
UI reflects change before on-chain confirmation | ✅ Confirming state shown immediately after submit
Correctly rolls back if tx fails | ✅ Error state with retry; onSettleAction removes pending state
Skeleton/loading indicator while waiting | ✅ Spinner + skeleton pulse animation during confirming state
Tests for successful tx | ✅ Supply and borrow success scenarios
Tests for failed tx | ✅ Supply and borrow failure scenarios