### PR TITLE
[API]-Atomic-sliding-window-rate-limiting-with-Redis

### DIFF
--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'bun:test';
-import { rateLimit, createRedisStore, createMemoryStore } from './rateLimit';
+import {
+  rateLimit,
+  createRedisStore,
+  createMemoryStore,
+  SLIDING_WINDOW_SCRIPT,
+} from './rateLimit';
 import type { RateLimitRedisClient } from './rateLimit';
 import type { Context } from 'elysia';
 
@@ -12,6 +17,96 @@ function createMockSet(): Context['set'] {
   return {
     headers: {},
   };
+}
+
+// ---------------------------------------------------------------------------
+// Fake Redis: runs the sliding-window script body atomically (sync in eval)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal Redis sorted-set simulator that executes the rate-limit Lua script
+ * atomically inside `eval` — concurrent callers serialize through a queue so
+ * the counter cannot race the way separate INCR+EXPIRE commands could.
+ */
+function makeFakeRedisClient(): RateLimitRedisClient & {
+  zsets: Map<string, Map<string, number>>;
+  evalCalls: number;
+} {
+  const zsets = new Map<string, Map<string, number>>();
+  let chain: Promise<unknown> = Promise.resolve();
+  let evalCalls = 0;
+
+  function runScript(
+    numKeys: number,
+    args: (string | number)[],
+  ): [number, number, number, number] {
+    // Mirror SLIDING_WINDOW_SCRIPT semantics in JS
+    const key = String(args[0]);
+    const now = Number(args[1]);
+    const windowMs = Number(args[2]);
+    const max = Number(args[3]);
+    const member = String(args[4]);
+    const windowStart = now - windowMs;
+
+    let zset = zsets.get(key);
+    if (!zset) {
+      zset = new Map();
+      zsets.set(key, zset);
+    }
+
+    // ZREMRANGEBYSCORE key -inf windowStart
+    for (const [m, score] of [...zset.entries()]) {
+      if (score <= windowStart) zset.delete(m);
+    }
+
+    let count = zset.size;
+
+    if (count < max) {
+      zset.set(member, now);
+      count += 1;
+      const remaining = max - count;
+      let oldestScore = now;
+      for (const score of zset.values()) {
+        if (score < oldestScore) oldestScore = score;
+      }
+      const resetAt = oldestScore + windowMs;
+      return [1, remaining, resetAt, 0];
+    }
+
+    let oldestScore = now;
+    for (const score of zset.values()) {
+      if (score < oldestScore) oldestScore = score;
+    }
+    const resetAt = oldestScore + windowMs;
+    const retryAfter = Math.max(0, Math.ceil((resetAt - now) / 1000));
+    return [0, 0, resetAt, retryAfter];
+  }
+
+  const client: RateLimitRedisClient & {
+    zsets: Map<string, Map<string, number>>;
+    evalCalls: number;
+  } = {
+    zsets,
+    get evalCalls() {
+      return evalCalls;
+    },
+    async eval(script: string, numKeys: number, ...args: (string | number)[]) {
+      // Serialize eval invocations to model Redis single-threaded command execution
+      const run = chain.then(() => {
+        evalCalls += 1;
+        expect(script).toContain('ZREMRANGEBYSCORE');
+        expect(numKeys).toBe(1);
+        return runScript(numKeys, args);
+      });
+      chain = run.then(
+        () => undefined,
+        () => undefined,
+      );
+      return run;
+    },
+  };
+
+  return client;
 }
 
 // ---------------------------------------------------------------------------
@@ -35,12 +130,13 @@ describe('createMemoryStore', () => {
     expect(result.retryAfter).toBeGreaterThan(0);
   });
 
-  it('resets the window after expiry', async () => {
+  it('allows a new request once the oldest entry slides out of the window', async () => {
     const store = createMemoryStore();
-    await store.checkLimit('id', 1, 1); // 1ms window
-    await store.checkLimit('id', 1, 1); // over limit
-    await new Promise((r) => setTimeout(r, 5));
-    const result = await store.checkLimit('id', 1, 1); // new window
+    await store.checkLimit('id', 50, 1); // 50ms window, max 1
+    const blocked = await store.checkLimit('id', 50, 1);
+    expect(blocked.allowed).toBe(false);
+    await new Promise((r) => setTimeout(r, 60));
+    const result = await store.checkLimit('id', 50, 1);
     expect(result.allowed).toBe(true);
   });
 
@@ -53,62 +149,48 @@ describe('createMemoryStore', () => {
     expect(resultB.allowed).toBe(true);
   });
 
-  it('sets resetAt in the future', async () => {
+  it('sets resetAt based on the oldest request in the sliding window', async () => {
     const store = createMemoryStore();
     const before = Date.now();
     const result = await store.checkLimit('id', 60000, 10);
     expect(result.resetAt).toBeGreaterThanOrEqual(before + 60000);
   });
+
+  it('handles concurrent checks without exceeding the limit', async () => {
+    const store = createMemoryStore();
+    const max = 10;
+    const concurrent = 50;
+    const results = await Promise.all(
+      Array.from({ length: concurrent }, () => store.checkLimit('concurrent', 60000, max)),
+    );
+    const allowed = results.filter((r) => r.allowed).length;
+    const denied = results.filter((r) => !r.allowed).length;
+    expect(allowed).toBe(max);
+    expect(denied).toBe(concurrent - max);
+  });
 });
 
 // ---------------------------------------------------------------------------
-// createRedisStore
+// createRedisStore (atomic Lua sliding-window)
 // ---------------------------------------------------------------------------
 
 describe('createRedisStore', () => {
-  function makeFakeRedisClient(): RateLimitRedisClient & { counts: Map<string, number> } {
-    const counts = new Map<string, number>();
-    const ttls = new Map<string, number>();
-    return {
-      counts,
-      async incr(key: string) {
-        const c = (counts.get(key) ?? 0) + 1;
-        counts.set(key, c);
-        return c;
-      },
-      async expire(key: string, seconds: number) {
-        ttls.set(key, seconds);
-        return 1;
-      },
-      async ttl(key: string) {
-        return ttls.get(key) ?? 60;
-      },
-    };
-  }
-
-  it('allows the first request and sets expiry', async () => {
+  it('allows the first request via a single atomic eval', async () => {
     const client = makeFakeRedisClient();
     const store = createRedisStore(client);
     const result = await store.checkLimit('user:abc', 60000, 10);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(9);
+    expect(client.evalCalls).toBe(1);
   });
 
-  it('only calls expire on the first increment', async () => {
+  it('uses one eval per check (no separate INCR/EXPIRE race)', async () => {
     const client = makeFakeRedisClient();
-    const expireCalls: string[] = [];
-    const origExpire = client.expire.bind(client);
-    client.expire = async (key, secs) => {
-      expireCalls.push(key);
-      return origExpire(key, secs);
-    };
-
     const store = createRedisStore(client);
     await store.checkLimit('id', 60000, 5);
     await store.checkLimit('id', 60000, 5);
     await store.checkLimit('id', 60000, 5);
-
-    expect(expireCalls.length).toBe(1);
+    expect(client.evalCalls).toBe(3);
   });
 
   it('blocks requests over the limit', async () => {
@@ -121,20 +203,110 @@ describe('createRedisStore', () => {
     expect(result.retryAfter).toBeGreaterThanOrEqual(0);
   });
 
-  it('uses TTL from Redis for resetAt', async () => {
+  it('sets resetAt from the oldest timestamp in the window', async () => {
     const client = makeFakeRedisClient();
     const store = createRedisStore(client);
     const before = Date.now();
     const result = await store.checkLimit('id', 60000, 10);
-    // TTL defaults to 60s in our fake client
     expect(result.resetAt).toBeGreaterThanOrEqual(before);
+    expect(result.resetAt).toBeLessThanOrEqual(Date.now() + 60000 + 50);
   });
 
   it('prefixes the key with ratelimit:', async () => {
     const client = makeFakeRedisClient();
     const store = createRedisStore(client);
     await store.checkLimit('user:xyz', 60000, 5);
-    expect(client.counts.has('ratelimit:user:xyz')).toBe(true);
+    expect(client.zsets.has('ratelimit:user:xyz')).toBe(true);
+  });
+
+  it('concurrency: simultaneous requests do not produce an inconsistent counter', async () => {
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    const max = 15;
+    const concurrent = 100;
+
+    const results = await Promise.all(
+      Array.from({ length: concurrent }, (_, i) =>
+        store.checkLimit(`burst-key`, 60_000, max).then((r) => ({ i, ...r })),
+      ),
+    );
+
+    const allowed = results.filter((r) => r.allowed);
+    const denied = results.filter((r) => !r.allowed);
+
+    expect(allowed.length).toBe(max);
+    expect(denied.length).toBe(concurrent - max);
+
+    // Remaining values for allowed requests must be a permutation of max-1 .. 0
+    const remainings = allowed.map((r) => r.remaining).sort((a, b) => a - b);
+    expect(remainings).toEqual(Array.from({ length: max }, (_, i) => i));
+
+    // Sorted-set cardinality must equal the number of allowed requests
+    const zset = client.zsets.get('ratelimit:burst-key');
+    expect(zset?.size).toBe(max);
+  });
+
+  it('sliding window: crossing the window boundary does not reset the full budget', async () => {
+    // Fixed-window would allow a full new burst at each boundary; sliding window
+    // only frees capacity as individual timestamps age out.
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    const windowMs = 200;
+    const max = 3;
+    const id = 'boundary';
+
+    // Fill the entire budget at the start of the window
+    for (let i = 0; i < max; i++) {
+      const r = await store.checkLimit(id, windowMs, max);
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = await store.checkLimit(id, windowMs, max);
+    expect(blocked.allowed).toBe(false);
+
+    // Wait past half the window — under fixed-window this is still the same
+    // bucket (still blocked). Under sliding window we are also still blocked
+    // because all timestamps remain inside [now-windowMs, now].
+    await new Promise((r) => setTimeout(r, Math.floor(windowMs / 2)));
+    const mid = await store.checkLimit(id, windowMs, max);
+    expect(mid.allowed).toBe(false);
+
+    // Wait until the first batch is fully outside the sliding window.
+    // All three original requests should age out; budget is fully restored.
+    await new Promise((r) => setTimeout(r, windowMs));
+    const after = await store.checkLimit(id, windowMs, max);
+    expect(after.allowed).toBe(true);
+    expect(after.remaining).toBe(max - 1);
+  });
+
+  it('sliding window: partial capacity frees as oldest entries expire', async () => {
+    const client = makeFakeRedisClient();
+    const store = createRedisStore(client);
+    const windowMs = 150;
+    const max = 2;
+    const id = 'partial-slide';
+
+    // Request 1
+    expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(true);
+    // Small gap so timestamps are ordered
+    await new Promise((r) => setTimeout(r, 40));
+    // Request 2 fills the limit
+    expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(true);
+    expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(false);
+
+    // Wait long enough for request 1 to slide out but request 2 to remain
+    await new Promise((r) => setTimeout(r, windowMs - 20));
+    const partial = await store.checkLimit(id, windowMs, max);
+    // Exactly one slot should free (the oldest), so one request is allowed
+    expect(partial.allowed).toBe(true);
+    // Immediately after, we should be at capacity again (req2 + new)
+    expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(false);
+  });
+
+  it('exports a Lua script that uses sorted-set sliding-window operations', () => {
+    expect(SLIDING_WINDOW_SCRIPT).toContain('ZREMRANGEBYSCORE');
+    expect(SLIDING_WINDOW_SCRIPT).toContain('ZADD');
+    expect(SLIDING_WINDOW_SCRIPT).toContain('ZCARD');
+    expect(SLIDING_WINDOW_SCRIPT).toContain('PEXPIRE');
   });
 });
 

--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import {
-  rateLimit,
-  createRedisStore,
-  createMemoryStore,
-  SLIDING_WINDOW_SCRIPT,
-} from './rateLimit';
+import { rateLimit, createRedisStore, createMemoryStore, SLIDING_WINDOW_SCRIPT } from './rateLimit';
 import type { RateLimitRedisClient } from './rateLimit';
 import type { Context } from 'elysia';
 
@@ -20,23 +15,23 @@ function createMockSet(): Context['set'] {
 }
 
 // ---------------------------------------------------------------------------
-// Fake Redis: runs the sliding-window script body atomically (sync in eval)
+// Fake Redis: runs the sliding-window script body atomically (sync in script)
 // ---------------------------------------------------------------------------
 
 /**
  * Minimal Redis sorted-set simulator that executes the rate-limit Lua script
- * atomically inside `eval` — concurrent callers serialize through a queue so
+ * atomically inside `runScript` — concurrent callers serialize through a queue so
  * the counter cannot race the way separate INCR+EXPIRE commands could.
  */
 function makeFakeRedisClient(): RateLimitRedisClient & {
   zsets: Map<string, Map<string, number>>;
-  evalCalls: number;
+  scriptCalls: number;
 } {
   const zsets = new Map<string, Map<string, number>>();
   let chain: Promise<unknown> = Promise.resolve();
-  let evalCalls = 0;
+  let scriptCalls = 0;
 
-  function runScript(
+  function runScriptBody(
     numKeys: number,
     args: (string | number)[],
   ): [number, number, number, number] {
@@ -84,19 +79,19 @@ function makeFakeRedisClient(): RateLimitRedisClient & {
 
   const client: RateLimitRedisClient & {
     zsets: Map<string, Map<string, number>>;
-    evalCalls: number;
+    scriptCalls: number;
   } = {
     zsets,
-    get evalCalls() {
-      return evalCalls;
+    get scriptCalls() {
+      return scriptCalls;
     },
-    async eval(script: string, numKeys: number, ...args: (string | number)[]) {
-      // Serialize eval invocations to model Redis single-threaded command execution
+    async runScript(script: string, numKeys: number, ...args: (string | number)[]) {
+      // Serialize script invocations to model Redis single-threaded command execution
       const run = chain.then(() => {
-        evalCalls += 1;
+        scriptCalls += 1;
         expect(script).toContain('ZREMRANGEBYSCORE');
         expect(numKeys).toBe(1);
-        return runScript(numKeys, args);
+        return runScriptBody(numKeys, args);
       });
       chain = run.then(
         () => undefined,
@@ -175,22 +170,22 @@ describe('createMemoryStore', () => {
 // ---------------------------------------------------------------------------
 
 describe('createRedisStore', () => {
-  it('allows the first request via a single atomic eval', async () => {
+  it('allows the first request via a single atomic script', async () => {
     const client = makeFakeRedisClient();
     const store = createRedisStore(client);
     const result = await store.checkLimit('user:abc', 60000, 10);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(9);
-    expect(client.evalCalls).toBe(1);
+    expect(client.scriptCalls).toBe(1);
   });
 
-  it('uses one eval per check (no separate INCR/EXPIRE race)', async () => {
+  it('uses one script call per check (no separate INCR/EXPIRE race)', async () => {
     const client = makeFakeRedisClient();
     const store = createRedisStore(client);
     await store.checkLimit('id', 60000, 5);
     await store.checkLimit('id', 60000, 5);
     await store.checkLimit('id', 60000, 5);
-    expect(client.evalCalls).toBe(3);
+    expect(client.scriptCalls).toBe(3);
   });
 
   it('blocks requests over the limit', async () => {
@@ -281,20 +276,23 @@ describe('createRedisStore', () => {
   it('sliding window: partial capacity frees as oldest entries expire', async () => {
     const client = makeFakeRedisClient();
     const store = createRedisStore(client);
-    const windowMs = 150;
+    // Wide window + clear gap so timer jitter cannot expire both entries at once.
+    const windowMs = 500;
+    const gapMs = 200;
     const max = 2;
     const id = 'partial-slide';
 
     // Request 1
     expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(true);
-    // Small gap so timestamps are ordered
-    await new Promise((r) => setTimeout(r, 40));
+    // Gap so timestamps are ordered and only the oldest ages out first
+    await new Promise((r) => setTimeout(r, gapMs));
     // Request 2 fills the limit
     expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(true);
     expect((await store.checkLimit(id, windowMs, max)).allowed).toBe(false);
 
-    // Wait long enough for request 1 to slide out but request 2 to remain
-    await new Promise((r) => setTimeout(r, windowMs - 20));
+    // Wait so req1 (age ≈ gap + wait) exits the window while req2 (age ≈ wait) remains.
+    // wait = windowMs - gap/2  →  req1 age = windowMs + gap/2  (out), req2 age = windowMs - gap/2 (in)
+    await new Promise((r) => setTimeout(r, windowMs - Math.floor(gapMs / 2)));
     const partial = await store.checkLimit(id, windowMs, max);
     // Exactly one slot should free (the oldest), so one request is allowed
     expect(partial.allowed).toBe(true);

--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'bun:test';
 import { rateLimit, createRedisStore, createMemoryStore, walletKeyGenerator } from './rateLimit';
->>>>>>> a0e198b756d03d7005e0710f930c70fc36939eeb
 import type { RateLimitRedisClient } from './rateLimit';
 import type { Context } from 'elysia';
 

--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { rateLimit, createRedisStore, createMemoryStore, walletKeyGenerator } from './rateLimit';
+import {
+  rateLimit,
+  createRedisStore,
+  createMemoryStore,
+  walletKeyGenerator,
+  SLIDING_WINDOW_SCRIPT,
+} from './rateLimit';
 import type { RateLimitRedisClient } from './rateLimit';
 import type { Context } from 'elysia';
 

--- a/apps/api/src/middleware/rateLimit.test.ts
+++ b/apps/api/src/middleware/rateLimit.test.ts
@@ -1,7 +1,4 @@
 import { describe, it, expect } from 'bun:test';
-<<<<<<< HEAD
-import { rateLimit, createRedisStore, createMemoryStore, SLIDING_WINDOW_SCRIPT } from './rateLimit';
-=======
 import { rateLimit, createRedisStore, createMemoryStore, walletKeyGenerator } from './rateLimit';
 >>>>>>> a0e198b756d03d7005e0710f930c70fc36939eeb
 import type { RateLimitRedisClient } from './rateLimit';

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -271,9 +271,9 @@ export function rateLimit(options: RateLimitOptions = {}) {
     ctx.set.headers['X-RateLimit-Reset'] = String(Math.ceil(result.resetAt / 1000));
 
     if (!result.allowed) {
-      set.status = 429;
+      ctx.set.status = 429;
       if (result.retryAfter !== undefined) {
-        set.headers['Retry-After'] = String(result.retryAfter);
+        ctx.set.headers['Retry-After'] = String(result.retryAfter);
       }
       return {
         success: false,

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -15,10 +15,10 @@ interface RateLimitResult {
 
 /**
  * Minimal Redis surface used by the rate limiter.
- * `eval` runs a Lua script atomically (INCR+EXPIRE-style multi-step logic).
+ * `runScript` executes a Lua script atomically on Redis.
  */
 export interface RateLimitRedisClient {
-  eval(script: string, numKeys: number, ...args: (string | number)[]): Promise<unknown>;
+  runScript(script: string, numKeys: number, ...args: (string | number)[]): Promise<unknown>;
 }
 
 export interface RateLimitStore {
@@ -97,7 +97,7 @@ function getIdentifier(request: Request, keyGenerator?: (request: Request) => st
   return `ip:${getClientIP(request)}`;
 }
 
-function parseEvalResult(raw: unknown): {
+function parseScriptResult(raw: unknown): {
   allowed: boolean;
   remaining: number;
   resetAt: number;
@@ -126,8 +126,8 @@ export function createRedisStore(client: RateLimitRedisClient): RateLimitStore {
       const now = Date.now();
       const member = uniqueMember(now);
 
-      const raw = await client.eval(SLIDING_WINDOW_SCRIPT, 1, key, now, windowMs, max, member);
-      const parsed = parseEvalResult(raw);
+      const raw = await client.runScript(SLIDING_WINDOW_SCRIPT, 1, key, now, windowMs, max, member);
+      const parsed = parseScriptResult(raw);
 
       if (!parsed.allowed) {
         return {
@@ -200,6 +200,17 @@ export function createMemoryStore(): RateLimitStore {
   };
 }
 
+/** Adapt an ioredis-like client to RateLimitRedisClient via Redis CALL. */
+function wrapIoredisClient(client: {
+  call(command: string, ...args: (string | number | Buffer)[]): Promise<unknown>;
+}): RateLimitRedisClient {
+  return {
+    runScript(script, numKeys, ...args) {
+      return client.call('EVAL', script, numKeys, ...args);
+    },
+  };
+}
+
 export function rateLimit(options: RateLimitOptions = {}) {
   const { windowMs = DEFAULT_WINDOW_MS, max = DEFAULT_MAX, keyGenerator } = options;
 
@@ -213,7 +224,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
         maxRetriesPerRequest: 1,
         connectTimeout: 3000,
       });
-      return createRedisStore(client);
+      return createRedisStore(wrapIoredisClient(client));
     });
   } else {
     console.warn(

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -13,10 +13,12 @@ interface RateLimitResult {
   retryAfter?: number;
 }
 
+/**
+ * Minimal Redis surface used by the rate limiter.
+ * `eval` runs a Lua script atomically (INCR+EXPIRE-style multi-step logic).
+ */
 export interface RateLimitRedisClient {
-  incr(key: string): Promise<number>;
-  expire(key: string, seconds: number): Promise<number>;
-  ttl(key: string): Promise<number>;
+  eval(script: string, numKeys: number, ...args: (string | number)[]): Promise<unknown>;
 }
 
 export interface RateLimitStore {
@@ -25,6 +27,60 @@ export interface RateLimitStore {
 
 const DEFAULT_WINDOW_MS = 60000;
 const DEFAULT_MAX = 10;
+
+/**
+ * Sliding-window log algorithm executed atomically in Redis.
+ *
+ * KEYS[1]  – sorted-set key (scores = request timestamps in ms)
+ * ARGV[1]  – now (ms)
+ * ARGV[2]  – windowMs
+ * ARGV[3]  – max requests
+ * ARGV[4]  – unique member id for this request
+ *
+ * Returns: { allowed (0|1), remaining, resetAt (ms), retryAfter (seconds) }
+ */
+const SLIDING_WINDOW_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local windowMs = tonumber(ARGV[2])
+local max = tonumber(ARGV[3])
+local member = ARGV[4]
+local windowStart = now - windowMs
+
+-- Drop timestamps that fell outside the sliding window
+redis.call('ZREMRANGEBYSCORE', key, '-inf', windowStart)
+
+local count = redis.call('ZCARD', key)
+
+if count < max then
+  redis.call('ZADD', key, now, member)
+  -- Keep the key at least as long as the window; refresh on every allow
+  redis.call('PEXPIRE', key, windowMs)
+  count = count + 1
+
+  local remaining = max - count
+  local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+  local resetAt = now + windowMs
+  if oldest[2] then
+    resetAt = tonumber(oldest[2]) + windowMs
+  end
+
+  return {1, remaining, resetAt, 0}
+end
+
+-- Over limit: do not record this request
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local resetAt = now + windowMs
+if oldest[2] then
+  resetAt = tonumber(oldest[2]) + windowMs
+end
+local retryAfter = math.ceil((resetAt - now) / 1000)
+if retryAfter < 0 then
+  retryAfter = 0
+end
+
+return {0, 0, resetAt, retryAfter}
+`;
 
 function getClientIP(request: Request): string {
   const forwarded = request.headers.get('x-forwarded-for');
@@ -41,53 +97,105 @@ function getIdentifier(request: Request, keyGenerator?: (request: Request) => st
   return `ip:${getClientIP(request)}`;
 }
 
+function parseEvalResult(raw: unknown): {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+  retryAfter: number;
+} {
+  if (!Array.isArray(raw) || raw.length < 4) {
+    throw new Error('Unexpected rate-limit script response from Redis');
+  }
+  const allowed = Number(raw[0]) === 1;
+  const remaining = Math.max(0, Number(raw[1]));
+  const resetAt = Number(raw[2]);
+  const retryAfter = Math.max(0, Number(raw[3]));
+  return { allowed, remaining, resetAt, retryAfter };
+}
+
+function uniqueMember(now: number): string {
+  // Score collisions are fine in ZSET; members must be unique so concurrent
+  // requests in the same millisecond are counted separately.
+  return `${now}:${Math.random().toString(36).slice(2, 11)}`;
+}
+
 export function createRedisStore(client: RateLimitRedisClient): RateLimitStore {
   return {
     async checkLimit(identifier: string, windowMs: number, max: number): Promise<RateLimitResult> {
       const key = `ratelimit:${identifier}`;
-      const ttlSeconds = Math.ceil(windowMs / 1000);
+      const now = Date.now();
+      const member = uniqueMember(now);
 
-      const count = await client.incr(key);
-      if (count === 1) {
-        await client.expire(key, ttlSeconds);
+      const raw = await client.eval(SLIDING_WINDOW_SCRIPT, 1, key, now, windowMs, max, member);
+      const parsed = parseEvalResult(raw);
+
+      if (!parsed.allowed) {
+        return {
+          allowed: false,
+          remaining: 0,
+          resetAt: parsed.resetAt,
+          retryAfter: parsed.retryAfter,
+        };
       }
 
-      const ttl = await client.ttl(key);
-      const resetAt = Date.now() + Math.max(0, ttl) * 1000;
-      const remaining = Math.max(0, max - count);
-
-      if (count > max) {
-        return { allowed: false, remaining: 0, resetAt, retryAfter: Math.max(0, ttl) };
-      }
-
-      return { allowed: true, remaining, resetAt };
+      return {
+        allowed: true,
+        remaining: parsed.remaining,
+        resetAt: parsed.resetAt,
+      };
     },
   };
 }
 
+/**
+ * In-process sliding-window log (same algorithm as Redis; not multi-instance safe).
+ * Uses a simple mutex so concurrent checkLimit calls cannot race the counter.
+ */
 export function createMemoryStore(): RateLimitStore {
-  const store = new Map<string, { count: number; resetAt: number }>();
+  const store = new Map<string, number[]>();
+  /** Per-identifier chain so overlapping async checks stay consistent. */
+  const locks = new Map<string, Promise<void>>();
+
+  async function withLock<T>(identifier: string, fn: () => T | Promise<T>): Promise<T> {
+    const prev = locks.get(identifier) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    locks.set(
+      identifier,
+      prev.then(() => gate).catch(() => gate),
+    );
+    await prev.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
 
   return {
     async checkLimit(identifier: string, windowMs: number, max: number): Promise<RateLimitResult> {
-      const now = Date.now();
-      const entry = store.get(identifier);
+      return withLock(identifier, () => {
+        const now = Date.now();
+        const windowStart = now - windowMs;
+        const timestamps = (store.get(identifier) ?? []).filter((t) => t > windowStart);
 
-      if (!entry || now >= entry.resetAt) {
-        const resetAt = now + windowMs;
-        store.set(identifier, { count: 1, resetAt });
-        return { allowed: true, remaining: max - 1, resetAt };
-      }
+        if (timestamps.length < max) {
+          timestamps.push(now);
+          store.set(identifier, timestamps);
+          const remaining = max - timestamps.length;
+          const oldest = timestamps[0] ?? now;
+          const resetAt = oldest + windowMs;
+          return { allowed: true, remaining, resetAt };
+        }
 
-      entry.count += 1;
-      const remaining = Math.max(0, max - entry.count);
-
-      if (entry.count > max) {
-        const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-        return { allowed: false, remaining: 0, resetAt: entry.resetAt, retryAfter };
-      }
-
-      return { allowed: true, remaining, resetAt: entry.resetAt };
+        store.set(identifier, timestamps);
+        const oldest = timestamps[0] ?? now;
+        const resetAt = oldest + windowMs;
+        const retryAfter = Math.max(0, Math.ceil((resetAt - now) / 1000));
+        return { allowed: false, remaining: 0, resetAt, retryAfter };
+      });
     },
   };
 }
@@ -132,7 +240,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
 
     if (!result.allowed) {
       set.status = 429;
-      if (result.retryAfter) {
+      if (result.retryAfter !== undefined) {
         set.headers['Retry-After'] = String(result.retryAfter);
       }
       return {
@@ -143,3 +251,6 @@ export function rateLimit(options: RateLimitOptions = {}) {
     }
   };
 }
+
+/** Exported for unit tests that need to exercise the Lua script via a fake client. */
+export { SLIDING_WINDOW_SCRIPT };

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,7 +21,7 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false,
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "paths": {
       "@akkuea/shared": ["../shared/src"],
       "@real-estate-defi/shared": ["../shared/src"]

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "lib": ["ESNext"],
     "target": "ESNext",
@@ -20,6 +21,7 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@akkuea/shared": ["../shared/src"],
       "@real-estate-defi/shared": ["../shared/src"]


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / config only
- [ ] Breaking change

## What Changed and Why

<!-- Describe the key changes and the reasoning behind them. -->
Introduced a Lua sliding-window log script (sorted set of request timestamps) executed via EVAL: prune expired entries → count → optionally ZADD → PEXPIRE, all in one atomic step.
Updated RateLimitRedisClient to expose eval instead of incr / expire / ttl.
Aligned the in-memory store with the same sliding-window algorithm and serialized concurrent checks per key so local/dev behavior matches Redis semantics.
Expanded [rateLimit.test.ts](vscode-webview://1ri8vulp3qieo363t8or2td1dnc47bl0pe8lhgv72cjo7fiesojo/rateLimit.test.ts) with concurrency consistency tests and sliding-window boundary / partial-expiry coverage.

## How to Test

<!-- Step-by-step instructions so a reviewer can verify the change. -->
From akkuea/apps/api, run:
bun test src/middleware/rateLimit.test.ts

1. Confirm all tests pass, especially:
concurrent checks never exceed max / leave an inconsistent counter
capacity only returns as oldest timestamps leave the window (not a full fixed-window reset)
2. (Optional) With Redis available, set REDIS_URL, start the API, and hammer a rate-limited route; verify 429, X-RateLimit-*, and Retry-After remain correct under parallel requests.

## Checklist

- [ ] All CI workflows pass (monorepo, API, webapp, shared, contracts)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation
- [ ] No `.env` files or secrets are committed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Closes #1002 