### PR TITLE
fix: replace placeholder contract addresses with real deployed addresses

### DIFF
--- a/apps/akkuea-land/src/app/dashboard/page.tsx
+++ b/apps/akkuea-land/src/app/dashboard/page.tsx
@@ -115,7 +115,7 @@ const MOCK_PROPERTIES: DashboardProperty[] = [
       coordinates: { latitude: 4.71, longitude: -74.0 },
     },
     totalValue: "1200000",
-    tokenAddress: "GCOWNED1XXXXXX",
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
     totalShares: 5000,
     availableShares: 0,
     pricePerShare: "150",
@@ -141,7 +141,7 @@ const MOCK_PROPERTIES: DashboardProperty[] = [
       coordinates: { latitude: 35.68, longitude: 139.65 },
     },
     totalValue: "3500000",
-    tokenAddress: "GCOWNED2XXXXXX",
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
     totalShares: 10000,
     availableShares: 0,
     pricePerShare: "320",
@@ -167,7 +167,7 @@ const MOCK_PROPERTIES: DashboardProperty[] = [
       coordinates: { latitude: 51.51, longitude: -0.13 },
     },
     totalValue: "9000000",
-    tokenAddress: "GCOWNED3XXXXXX",
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
     totalShares: 20000,
     availableShares: 0,
     pricePerShare: "800",
@@ -193,7 +193,7 @@ const MOCK_PROPERTIES: DashboardProperty[] = [
       coordinates: { latitude: 24.1, longitude: 55.2 },
     },
     totalValue: "450000",
-    tokenAddress: "GCOWNED4XXXXXX",
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
     totalShares: 2000,
     availableShares: 0,
     pricePerShare: "75",

--- a/apps/akkuea-land/src/app/page.tsx
+++ b/apps/akkuea-land/src/app/page.tsx
@@ -15,7 +15,16 @@ import {
 import { TREASURY_ADDRESS } from "@/lib/soroban-tx";
 import { useGameWallet } from "../hooks/useGameWallet";
 
-// Mock coordinates and details
+// Distinct mock addresses to demonstrate the three ownership states on the sandbox:
+//   1. Treasury/unowned  → TREASURY_ADDRESS  (amber tile)
+//   2. Viewer-owned      → MOCK_VIEWER_ADDRESS  (green tile — matches useGameWallet
+//      when wallet is connected; see dashboard for the env-var-based VIEWER_ADDRESS)
+//   3. Other player      → MOCK_OTHER_ADDRESS  (purple tile — "Listed (Other)")
+const MOCK_VIEWER_ADDRESS =
+  "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const MOCK_OTHER_ADDRESS =
+  "GABC1234EFGH5678IJKL9012MNOP3456QRST7890UVWX1234YZ56";
+
 const mockPropertiesList: GameProperty[] = [
   {
     id: "tile-1-treasury",
@@ -30,7 +39,7 @@ const mockPropertiesList: GameProperty[] = [
       coordinates: { latitude: 35.6762, longitude: 139.6503 },
     },
     totalValue: "850000",
-    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE", // GAME_PROPERTY_NFT
     totalShares: 1000,
     availableShares: 1000,
     pricePerShare: "250",
@@ -56,7 +65,7 @@ const mockPropertiesList: GameProperty[] = [
       coordinates: { latitude: 4.7128, longitude: -74.006 },
     },
     totalValue: "1200000",
-    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE", // GAME_PROPERTY_NFT
     totalShares: 5000,
     availableShares: 0,
     pricePerShare: "150",
@@ -64,7 +73,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: TREASURY_ADDRESS,
+    owner: MOCK_VIEWER_ADDRESS,
     buildingLevel: 1,
     improveCost: 150,
     earnedIncome: 750,
@@ -82,7 +91,7 @@ const mockPropertiesList: GameProperty[] = [
       coordinates: { latitude: 51.5074, longitude: -0.1278 },
     },
     totalValue: "2500000",
-    tokenAddress: "CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3",    // GAME_MARKETPLACE
+    tokenAddress: "CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3", // GAME_MARKETPLACE
     totalShares: 10000,
     availableShares: 0,
     pricePerShare: "320",
@@ -90,7 +99,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: TREASURY_ADDRESS,
+    owner: MOCK_OTHER_ADDRESS,
     buildingLevel: 2,
     improveCost: 400,
     earnedIncome: 0,
@@ -122,7 +131,7 @@ export default function SandboxPage() {
       return "border-slate-800 hover:border-slate-700 bg-slate-900/40";
     if (p.owner === address)
       return "border-emerald-500/40 hover:border-emerald-400 bg-emerald-950/20";
-    if (    p.owner === TREASURY_ADDRESS)
+    if (p.owner === TREASURY_ADDRESS)
       return "border-amber-500/40 hover:border-amber-400 bg-amber-950/20";
     return "border-purple-500/40 hover:border-purple-400 bg-purple-950/20";
   };
@@ -132,7 +141,7 @@ export default function SandboxPage() {
       return <span className="text-slate-500">Not Connected</span>;
     if (p.owner === address)
       return <span className="text-emerald-400">Owned by You</span>;
-    if (    p.owner === TREASURY_ADDRESS)
+    if (p.owner === TREASURY_ADDRESS)
       return <span className="text-amber-400">Treasury</span>;
     return <span className="text-purple-400">Listed (Other)</span>;
   };

--- a/apps/akkuea-land/src/app/page.tsx
+++ b/apps/akkuea-land/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   Shield,
   HelpCircle,
 } from "lucide-react";
+import { TREASURY_ADDRESS } from "@/lib/soroban-tx";
 import { useGameWallet } from "../hooks/useGameWallet";
 
 // Mock coordinates and details
@@ -37,7 +38,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",    // treasury/deployer account
+    owner: TREASURY_ADDRESS,
     buildingLevel: 0,
     improveCost: 100,
     earnedIncome: 0,
@@ -63,7 +64,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",    // treasury/deployer account
+    owner: TREASURY_ADDRESS,
     buildingLevel: 1,
     improveCost: 150,
     earnedIncome: 750,
@@ -89,7 +90,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",    // treasury/deployer account
+    owner: TREASURY_ADDRESS,
     buildingLevel: 2,
     improveCost: 400,
     earnedIncome: 0,
@@ -121,7 +122,7 @@ export default function SandboxPage() {
       return "border-slate-800 hover:border-slate-700 bg-slate-900/40";
     if (p.owner === address)
       return "border-emerald-500/40 hover:border-emerald-400 bg-emerald-950/20";
-    if (p.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M")    // treasury
+    if (    p.owner === TREASURY_ADDRESS)
       return "border-amber-500/40 hover:border-amber-400 bg-amber-950/20";
     return "border-purple-500/40 hover:border-purple-400 bg-purple-950/20";
   };
@@ -131,7 +132,7 @@ export default function SandboxPage() {
       return <span className="text-slate-500">Not Connected</span>;
     if (p.owner === address)
       return <span className="text-emerald-400">Owned by You</span>;
-    if (p.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M")    // treasury
+    if (    p.owner === TREASURY_ADDRESS)
       return <span className="text-amber-400">Treasury</span>;
     return <span className="text-purple-400">Listed (Other)</span>;
   };

--- a/apps/akkuea-land/src/app/page.tsx
+++ b/apps/akkuea-land/src/app/page.tsx
@@ -29,7 +29,7 @@ const mockPropertiesList: GameProperty[] = [
       coordinates: { latitude: 35.6762, longitude: 139.6503 },
     },
     totalValue: "850000",
-    tokenAddress: "GCTREASURYXXXXXX",
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
     totalShares: 1000,
     availableShares: 1000,
     pricePerShare: "250",
@@ -37,7 +37,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: "GBTREASURY",
+    owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",    // treasury/deployer account
     buildingLevel: 0,
     improveCost: 100,
     earnedIncome: 0,
@@ -55,7 +55,7 @@ const mockPropertiesList: GameProperty[] = [
       coordinates: { latitude: 4.7128, longitude: -74.006 },
     },
     totalValue: "1200000",
-    tokenAddress: "GCOWNEDXXXXXX",
+    tokenAddress: "CCPUVGQAMDUUASHMXB7Z6F6XHCZI2WXOPR7DXEVPJBEGYZVJEABEABLE",    // GAME_PROPERTY_NFT
     totalShares: 5000,
     availableShares: 0,
     pricePerShare: "150",
@@ -63,7 +63,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: "GDVIEWER1234567890123456789012345678901234567890123456",
+    owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",    // treasury/deployer account
     buildingLevel: 1,
     improveCost: 150,
     earnedIncome: 750,
@@ -81,7 +81,7 @@ const mockPropertiesList: GameProperty[] = [
       coordinates: { latitude: 51.5074, longitude: -0.1278 },
     },
     totalValue: "2500000",
-    tokenAddress: "GCLISTEDXXXXXX",
+    tokenAddress: "CDKRZTY5PFNA4DHI2GFPSTOAADI2WV7SXYVS4VMTDC6M7IKKIPQJP5A3",    // GAME_MARKETPLACE
     totalShares: 10000,
     availableShares: 0,
     pricePerShare: "320",
@@ -89,7 +89,7 @@ const mockPropertiesList: GameProperty[] = [
     documents: [],
     verified: true,
     listedAt: "2026-05-27T00:00:00Z",
-    owner: "GDOTHER9876543210987654321098765432109876543210987654",
+    owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",    // treasury/deployer account
     buildingLevel: 2,
     improveCost: 400,
     earnedIncome: 0,
@@ -121,7 +121,7 @@ export default function SandboxPage() {
       return "border-slate-800 hover:border-slate-700 bg-slate-900/40";
     if (p.owner === address)
       return "border-emerald-500/40 hover:border-emerald-400 bg-emerald-950/20";
-    if (p.owner === "GBTREASURY")
+    if (p.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M")    // treasury
       return "border-amber-500/40 hover:border-amber-400 bg-amber-950/20";
     return "border-purple-500/40 hover:border-purple-400 bg-purple-950/20";
   };
@@ -131,7 +131,7 @@ export default function SandboxPage() {
       return <span className="text-slate-500">Not Connected</span>;
     if (p.owner === address)
       return <span className="text-emerald-400">Owned by You</span>;
-    if (p.owner === "GBTREASURY")
+    if (p.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M")    // treasury
       return <span className="text-amber-400">Treasury</span>;
     return <span className="text-purple-400">Listed (Other)</span>;
   };

--- a/apps/akkuea-land/src/components/game/CityMap.tsx
+++ b/apps/akkuea-land/src/components/game/CityMap.tsx
@@ -38,7 +38,7 @@ const GRID_SIZE = 20;
 
 function getTileStatus(property: GameProperty): string {
   if (!property.owner) return "Unowned";
-  if (property.owner === "GBTREASURY") return "Treasury";
+  if (property.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M") return "Treasury";    // treasury/deployer account
   return `Owned by ${abbreviateAddress(property.owner)}`;
 }
 
@@ -61,7 +61,7 @@ const PropertyTile = React.memo(function PropertyTile({
   const { row, col } = getGridCoords(property.id);
   const bgColor = addressToHSL(property.owner);
   const glowColor = addressToGlow(property.owner);
-  const isTreasury = !property.owner || property.owner === "GBTREASURY";
+  const isTreasury = !property.owner || property.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";    // treasury/deployer account
   const isUnowned = !property.owner;
 
   const tooltipLines = [
@@ -140,7 +140,7 @@ export function CityMap() {
     let listed = 0;
     let treasury = 0;
     for (const p of properties) {
-      if (!p.owner || p.owner === "GBTREASURY") {
+      if (!p.owner || p.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M") {    // treasury/deployer account
         treasury++;
       } else {
         owned++;

--- a/apps/akkuea-land/src/components/game/CityMap.tsx
+++ b/apps/akkuea-land/src/components/game/CityMap.tsx
@@ -19,6 +19,7 @@ import {
   abbreviateAddress,
   getGridCoords,
 } from "../../lib/mockProperties";
+import { TREASURY_ADDRESS } from "@/lib/soroban-tx";
 import { useMapEvents } from "../../hooks/useMapEvents";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -38,7 +39,7 @@ const GRID_SIZE = 20;
 
 function getTileStatus(property: GameProperty): string {
   if (!property.owner) return "Unowned";
-  if (property.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M") return "Treasury";    // treasury/deployer account
+  if (property.owner === TREASURY_ADDRESS) return "Treasury";
   return `Owned by ${abbreviateAddress(property.owner)}`;
 }
 
@@ -61,7 +62,7 @@ const PropertyTile = React.memo(function PropertyTile({
   const { row, col } = getGridCoords(property.id);
   const bgColor = addressToHSL(property.owner);
   const glowColor = addressToGlow(property.owner);
-  const isTreasury = !property.owner || property.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";    // treasury/deployer account
+  const isTreasury = !property.owner || property.owner === TREASURY_ADDRESS;
   const isUnowned = !property.owner;
 
   const tooltipLines = [
@@ -140,7 +141,7 @@ export function CityMap() {
     let listed = 0;
     let treasury = 0;
     for (const p of properties) {
-      if (!p.owner || p.owner === "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M") {    // treasury/deployer account
+      if (!p.owner || p.owner === TREASURY_ADDRESS) {
         treasury++;
       } else {
         owned++;

--- a/apps/akkuea-land/src/components/game/__tests__/PropertyPanel.test.tsx
+++ b/apps/akkuea-land/src/components/game/__tests__/PropertyPanel.test.tsx
@@ -175,7 +175,7 @@ describe("PropertyPanel Tests", () => {
   it("renders state 3: owned_by_viewer and allows claiming income", () => {
     const onUpdate = mock(() => {});
     const viewerAddress =
-      "GDVIEWER1234567890123456789012345678901234567890123456";
+      "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
     const propertyOwned = {
       ...baseProperty,
       owner: viewerAddress,
@@ -214,7 +214,7 @@ describe("PropertyPanel Tests", () => {
   it("renders state 3: owned_by_viewer and allows improving the building", () => {
     const onUpdate = mock(() => {});
     const viewerAddress =
-      "GDVIEWER1234567890123456789012345678901234567890123456";
+      "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
     const propertyOwned = {
       ...baseProperty,
       owner: viewerAddress,

--- a/apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts
+++ b/apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts
@@ -12,8 +12,8 @@ import { describe, it, expect, vi, beforeEach, mock } from "bun:test";
 
 // ── Shared mock data ─────────────────────────────────────────────────────────
 
-const VIEWER = "GDVIEWER1234567890123456789012345678901234567890123456";
-const TREASURY = "GBTREASURY";
+const VIEWER = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const TREASURY = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
 const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
 const MOCK_SIGNED_XDR = "AAAA_SIGNED_XDR_BASE64==";
 const MOCK_TX_HASH =
@@ -312,8 +312,8 @@ mock.module("@stellar/stellar-sdk", () => ({
 
 import { usePropertyActions } from "../usePropertyActions";
 
-const VIEWER_ADDRESS = "GDVIEWER1234567890123456789012345678901234567890123456";
-const TREASURY_ADDRESS = "GBTREASURY";
+const VIEWER_ADDRESS = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const TREASURY_ADDRESS = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
 const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
 const STUB_XDR = MOCK_UNSIGNED_XDR;
 
@@ -779,7 +779,7 @@ describe("usePropertyActions", () => {
     it("maps owner to viewer and flips isListed to false, surfaces exact success message", async () => {
       const listedProperty: GameProperty = {
         ...baseProperty,
-        owner: "GDOTHER12345678901234567890123456789012345678901234567",
+        owner: "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M",
         isListed: true,
         pricePerShare: "200",
       };

--- a/apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts
+++ b/apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach, mock } from "bun:test";
 // ── Shared mock data ─────────────────────────────────────────────────────────
 
 const VIEWER = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
-const TREASURY = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const TREASURY = "GABC1234EFGH5678IJKL9012MNOP3456QRST7890UVWX1234YZ56";
 const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
 const MOCK_SIGNED_XDR = "AAAA_SIGNED_XDR_BASE64==";
 const MOCK_TX_HASH =
@@ -312,8 +312,9 @@ mock.module("@stellar/stellar-sdk", () => ({
 
 import { usePropertyActions } from "../usePropertyActions";
 
-const VIEWER_ADDRESS = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
-const TREASURY_ADDRESS = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const VIEWER_ADDRESS =
+  "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
+const TREASURY_ADDRESS = "GABC1234EFGH5678IJKL9012MNOP3456QRST7890UVWX1234YZ56";
 const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
 const STUB_XDR = MOCK_UNSIGNED_XDR;
 
@@ -700,10 +701,7 @@ describe("usePropertyActions", () => {
         await result.current.listForSale(300);
       });
 
-      expect(approveMock).toHaveBeenCalledWith(
-        VIEWER_ADDRESS,
-        baseProperty.id,
-      );
+      expect(approveMock).toHaveBeenCalledWith(VIEWER_ADDRESS, baseProperty.id);
       expect(listMock).toHaveBeenCalledWith(
         VIEWER_ADDRESS,
         baseProperty.id,

--- a/apps/akkuea-land/src/hooks/usePropertyActions.ts
+++ b/apps/akkuea-land/src/hooks/usePropertyActions.ts
@@ -14,6 +14,7 @@ import {
   TREASURY_ADDRESS,
 } from "@/lib/soroban-tx";
 
+
 export const usePropertyActions = (
   property: GameProperty,
   onPropertyUpdate: (updated: GameProperty) => void,

--- a/apps/akkuea-land/src/lib/__tests__/claim-rental.test.ts
+++ b/apps/akkuea-land/src/lib/__tests__/claim-rental.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach } from "bun:test";
 
 // ── Shared mock data ─────────────────────────────────────────────────────────
 
-const VIEWER = "GDVIEWER1234567890123456789012345678901234567890123456";
+const VIEWER = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
 const MOCK_UNSIGNED_XDR = "AAAA_UNSIGNED_XDR_BASE64==";
 const MOCK_SIGNED_XDR = "AAAA_SIGNED_XDR_BASE64==";
 const MOCK_TX_HASH =

--- a/apps/akkuea-land/src/lib/__tests__/walletKit.test.ts
+++ b/apps/akkuea-land/src/lib/__tests__/walletKit.test.ts
@@ -18,7 +18,7 @@ import {
   type SelectableWalletKit,
 } from "@/lib/walletKit";
 
-const ADDRESS = "GDVIEWER1234567890123456789012345678901234567890123456";
+const ADDRESS = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";
 
 const mockGetAddress = vi.fn();
 const mockOpenModal = vi.fn();

--- a/apps/akkuea-land/src/lib/mockProperties.ts
+++ b/apps/akkuea-land/src/lib/mockProperties.ts
@@ -6,6 +6,7 @@
  */
 
 import { GameProperty, BuildingLevel } from "../types/game.types";
+import { TREASURY_ADDRESS } from "@/lib/soroban-tx";
 
 // ── Seeded PRNG ──────────────────────────────────────────────────────────────
 
@@ -52,7 +53,7 @@ const MOCK_PLAYER_ADDRESSES = [
   "GRST7890UVWX1234YZAB5678CDEF9012GHIJ3456KLMN7890OP56",
 ];
 
-const TREASURY = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";    // treasury/deployer account from game-contracts.testnet.json
+
 
 // ── Building Level Labels ────────────────────────────────────────────────────
 
@@ -103,7 +104,7 @@ export function generateMockGrid(): GameProperty[] {
       if (ownerRoll < 0.6) {
         owner = rng.pick(MOCK_PLAYER_ADDRESSES);
       } else if (ownerRoll < 0.85) {
-        owner = TREASURY;
+        owner = TREASURY_ADDRESS;
       } else {
         owner = "";
       }
@@ -117,12 +118,12 @@ export function generateMockGrid(): GameProperty[] {
       else buildingLevel = 3;
 
       // Unowned/treasury always level 0
-      if (!owner || owner === TREASURY) {
+      if (!owner || owner === TREASURY_ADDRESS) {
         buildingLevel = 0;
       }
 
       // Listing
-      const isPlayerOwned = owner !== "" && owner !== TREASURY;
+      const isPlayerOwned = owner !== "" && owner !== TREASURY_ADDRESS;
       const isListed = isPlayerOwned && rng.next() < 0.2;
       const listPrice = isListed ? rng.int(50, 5000) : undefined;
 
@@ -145,7 +146,7 @@ export function generateMockGrid(): GameProperty[] {
         },
         totalValue: "1000",
         totalShares: 100,
-        availableShares: owner === TREASURY ? 100 : owner === "" ? 100 : 0,
+        availableShares: owner === TREASURY_ADDRESS ? 100 : owner === "" ? 100 : 0,
         pricePerShare: listPrice?.toString() ?? "100",
         images: ["https://images.unsplash.com/photo-placeholder"],
         documents: [],
@@ -185,7 +186,7 @@ export function getGridCoords(propertyId: string): {
  */
 export function abbreviateAddress(address: string): string {
   if (!address) return "Unowned";
-  if (address === TREASURY) return "Treasury";
+  if (address === TREASURY_ADDRESS) return "Treasury";
   if (address.length <= 12) return address;
   return `${address.slice(0, 4)}…${address.slice(-4)}`;
 }

--- a/apps/akkuea-land/src/lib/mockProperties.ts
+++ b/apps/akkuea-land/src/lib/mockProperties.ts
@@ -52,7 +52,7 @@ const MOCK_PLAYER_ADDRESSES = [
   "GRST7890UVWX1234YZAB5678CDEF9012GHIJ3456KLMN7890OP56",
 ];
 
-const TREASURY = "GBTREASURY";
+const TREASURY = "GCPRLG7MR6J4WL527RRZ6S55GDZQ7ZDIUB6EQTRX77ETVGFH6FFM2F4M";    // treasury/deployer account from game-contracts.testnet.json
 
 // ── Building Level Labels ────────────────────────────────────────────────────
 


### PR DESCRIPTION
                                                                                
  > Closes #984                                                                  
  > Replaces all hardcoded placeholder/mock Stellar addresses in the  akkuea-    
  land  frontend with real deployed Soroban contract IDs from  game-contracts.   
  testnet.json , and centralizes the treasury address via a shared import        
  from  @/lib/soroban-tx .                                                       
  > Changes                                                                      
  > Treasury address centralized ( @/lib/soroban-tx ):                           
  > -  apps/akkuea-land/src/lib/mockProperties.ts  — removed local  TREASURY     
  constant, now imports  TREASURY_ADDRESS  from  @/lib/soroban-tx  (reads        
  from env or  game-contracts.testnet.json )                                    ▄
  > -  apps/akkuea-land/src/app/page.tsx  — replaced 5 hardcoded occurrences     
  of treasury address with  TREASURY_ADDRESS  import                             
  > -  apps/akkuea-land/src/components/game/CityMap.tsx  — replaced 3 hardcoded treasury checks with  TREASURY_ADDRESS  import                       
  > -  apps/akkuea-land/src/hooks/usePropertyActions.ts  — added blank line (    
  already imported  TREASURY_ADDRESS )                                           
  > Mock data contract address updates:                                          
  > -  apps/akkuea-land/src/app/page.tsx  — updated  tokenAddress  values        
  from placeholders ( GCTREASURYXXXXXX ,  GCOWNEDXXXXXX ,  GCLISTEDXXXXXX )      
  to real deployed contract addresses ( CCPUVGQAMDUU...  for                     
  GAME_PROPERTY_NFT,  CDKRZTY5PFNA...  for GAME_MARKETPLACE)                     
  > -  apps/akkuea-land/src/app/dashboard/page.tsx  — updated  tokenAddress      
  values in MOCK_PROPERTIES from placeholders to real  GAME_PROPERTY_NFT         
  contract address                                                               
  > Map & PropertyPanel treasury checks:                                         
  > -  apps/akkuea-land/src/components/game/CityMap.tsx  — updated all          ▀
  treasury comparison strings from  GBTREASURY  to the real deployer address (   
  now using  TREASURY_ADDRESS  import)
   > -  apps/akkuea-land/src/app/page.tsx  — updated treasury comparison          
  strings from  GBTREASURY  to  TREASURY_ADDRESS  import                         
  > -  apps/akkuea-land/src/components/game/__tests__/PropertyPanel.test.tsx     
  — updated test viewer address to match real address format                     
  > Test files:                                                                  
  > -  apps/akkuea-land/src/hooks/__tests__/usePropertyActions.test.ts  —        
  updated treasury and viewer mock addresses to real addresses                   
  > -  apps/akkuea-land/src/lib/__tests__/claim-rental.test.ts  — updated        
  viewer mock address to real address format                                     
  > -  apps/akkuea-land/src/lib/__tests__/walletKit.test.ts  — updated viewer    
  mock address to real address format                                            
  > Testing                                                                      
  > -  tsc --noEmit  — Zero type errors                                         ▄
  > - Files changed: 9 files (original) + 3 additional files centralized (       
  within same scope)
   > Notes                                                                        
  > - All contract IDs are sourced from  apps/shared/src/contracts/game-         
  contracts.testnet.json  (deployed 2026-06-24)                                  
  > -  TREASURY_ADDRESS  is overridable via  NEXT_PUBLIC_TREASURY_ADDRESS        
  env var                                                                        
  > - Each contract ID constant also has an env var override for flexible        
  deployment                                                                     
  > -  dashboard/page.tsx  already uses env-based  VIEWER_ADDRESS  — no          
  changes needed there