### PR TITLE
[CONTRACT] Replace panic!/expect() with Result in access/emergency.rs

### DIFF
--- a/apps/contracts/contracts/defi-rwa/src/access/admin.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/admin.rs
@@ -23,6 +23,10 @@ pub enum ContractError {
     SupplyRateBorrowRateMulOverflow = 15,
     NewIndexMulOverflow = 16,
     PowPrecisionOverflow = 17,
+    RecoveryAlreadyScheduled = 18,
+    NoRecoveryScheduled = 19,
+    TimelockNotExpired = 20,
+    TimelockOverflow = 21,
 }
 
 pub struct AdminControl;

--- a/apps/contracts/contracts/defi-rwa/src/access/emergency.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/emergency.rs
@@ -57,8 +57,7 @@ impl TimelockControl {
     pub fn execute_recovery(env: &Env, caller: &Address) -> Result<(), ContractError> {
         AdminControl::require_admin(env, caller)?;
 
-        let record = Self::get_pending_recovery(env)
-            .ok_or(ContractError::NoRecoveryScheduled)?;
+        let record = Self::get_pending_recovery(env).ok_or(ContractError::NoRecoveryScheduled)?;
 
         let now = env.ledger().timestamp();
         if now < record.earliest_execution {

--- a/apps/contracts/contracts/defi-rwa/src/access/emergency.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/emergency.rs
@@ -1,6 +1,8 @@
-use soroban_sdk::{panic_with_error, Address, Env};
+use soroban_sdk::Address;
+use soroban_sdk::Env;
 
 use crate::access::admin::AdminControl;
+use crate::access::admin::ContractError;
 use crate::access::admin::PauseControl;
 use crate::access::roles::{PendingRecoveryData, RoleKey, TIMELOCK_DURATION};
 use crate::events::EmergencyEvents;
@@ -12,18 +14,18 @@ impl TimelockControl {
         env.storage().instance().get(&RoleKey::PendingRecovery)
     }
 
-    pub fn schedule_recovery(env: &Env, caller: &Address) {
-        AdminControl::require_admin(env, caller).unwrap_or_else(|e| panic_with_error!(env, e));
-        PauseControl::require_paused(env).unwrap_or_else(|e| panic_with_error!(env, e));
+    pub fn schedule_recovery(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        AdminControl::require_admin(env, caller)?;
+        PauseControl::require_paused(env)?;
 
         if Self::get_pending_recovery(env).is_some() {
-            panic!("Recovery already scheduled");
+            return Err(ContractError::RecoveryAlreadyScheduled);
         }
 
         let now = env.ledger().timestamp();
         let earliest_execution = now
             .checked_add(TIMELOCK_DURATION)
-            .expect("Timelock timestamp overflow");
+            .ok_or(ContractError::TimelockOverflow)?;
 
         let record = PendingRecoveryData {
             scheduled_by: caller.clone(),
@@ -36,33 +38,37 @@ impl TimelockControl {
             .set(&RoleKey::PendingRecovery, &record);
 
         EmergencyEvents::recovery_scheduled(env, caller.clone(), earliest_execution);
+        Ok(())
     }
 
-    pub fn cancel_recovery(env: &Env, caller: &Address) {
-        AdminControl::require_admin(env, caller).unwrap_or_else(|e| panic_with_error!(env, e));
+    pub fn cancel_recovery(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        AdminControl::require_admin(env, caller)?;
 
         if Self::get_pending_recovery(env).is_none() {
-            panic!("No recovery scheduled");
+            return Err(ContractError::NoRecoveryScheduled);
         }
 
         env.storage().instance().remove(&RoleKey::PendingRecovery);
 
         EmergencyEvents::recovery_cancelled(env, caller.clone());
+        Ok(())
     }
 
-    pub fn execute_recovery(env: &Env, caller: &Address) {
-        AdminControl::require_admin(env, caller).unwrap_or_else(|e| panic_with_error!(env, e));
+    pub fn execute_recovery(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        AdminControl::require_admin(env, caller)?;
 
-        let record = Self::get_pending_recovery(env).expect("No recovery scheduled");
+        let record = Self::get_pending_recovery(env)
+            .ok_or(ContractError::NoRecoveryScheduled)?;
 
         let now = env.ledger().timestamp();
         if now < record.earliest_execution {
-            panic!("Timelock not expired");
+            return Err(ContractError::TimelockNotExpired);
         }
 
         env.storage().instance().remove(&RoleKey::Paused);
         env.storage().instance().remove(&RoleKey::PendingRecovery);
 
         EmergencyEvents::recovery_executed(env, caller.clone());
+        Ok(())
     }
 }

--- a/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -629,17 +629,20 @@ impl PropertyTokenContract {
 
     pub fn schedule_recovery(env: Env, caller: Address) {
         caller.require_auth();
-        TimelockControl::schedule_recovery(&env, &caller);
+        TimelockControl::schedule_recovery(&env, &caller)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
     }
 
     pub fn cancel_recovery(env: Env, caller: Address) {
         caller.require_auth();
-        TimelockControl::cancel_recovery(&env, &caller);
+        TimelockControl::cancel_recovery(&env, &caller)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
     }
 
     pub fn execute_recovery(env: Env, caller: Address) {
         caller.require_auth();
-        TimelockControl::execute_recovery(&env, &caller);
+        TimelockControl::execute_recovery(&env, &caller)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
     }
 
     pub fn grant_emergency_role(env: Env, admin: Address, target: Address) {

--- a/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -2844,7 +2844,7 @@ fn test_emergency_pause_blocks_operations() {
 }
 
 #[test]
-#[should_panic(expected = "Timelock not expired")]
+#[should_panic(expected = "Error(Contract, #20)")]
 fn test_recovery_rejected_before_timelock() {
     let s = setup();
 
@@ -2882,7 +2882,7 @@ fn test_schedule_recovery_requires_paused() {
 }
 
 #[test]
-#[should_panic(expected = "Recovery already scheduled")]
+#[should_panic(expected = "Error(Contract, #18)")]
 fn test_double_schedule_rejected() {
     let s = setup();
 
@@ -2905,7 +2905,7 @@ fn test_cancel_recovery_keeps_contract_paused() {
 }
 
 #[test]
-#[should_panic(expected = "No recovery scheduled")]
+#[should_panic(expected = "Error(Contract, #19)")]
 fn test_cancel_no_recovery_panics() {
     let s = setup();
     s.contract_client.cancel_recovery(&s.admin);


### PR DESCRIPTION
## Overview

This PR replaces all `panic!`/`expect()` calls in the emergency recovery/timelock module with proper `Result<(), ContractError>` returns, following the same pattern used elsewhere in the codebase (see issue #13).

## Related Issue

Closes #980

## Changes

### Error Handling in `emergency.rs`
- **\[REFACTOR\]** `schedule_recovery`, `cancel_recovery`, `execute_recovery` now return `Result<(), ContractError>`
- Replaced `panic!("Recovery already scheduled")` → `ContractError::RecoveryAlreadyScheduled`
- Replaced `panic!("No recovery scheduled")` → `ContractError::NoRecoveryScheduled`
- Replaced `panic!("Timelock not expired")` → `ContractError::TimelockNotExpired`
- Replaced `.expect("Timelock timestamp overflow")` → `.ok_or(ContractError::TimelockOverflow)?`
- `unwrap_or_else(|e| panic_with_error!(env, e))` replaced with `?` operator

### New `ContractError` Variants
- `RecoveryAlreadyScheduled = 18`
- `NoRecoveryScheduled = 19`
- `TimelockNotExpired = 20`
- `TimelockOverflow = 21`

### Caller Updates
- `lib.rs` contract methods use `.unwrap_or_else(|e| panic_with_error!(&env, e))` at the ABI boundary (consistent with `emergency_pause`)

### Test Updates
- Updated `#[should_panic]` expectations to match new `ContractError` codes
- `test_recovery_rejected_before_timelock`: now correctly annotated with `#[should_panic(expected = "Error(Contract, #20)")]`

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Every failure condition returns a specific `ContractError` | ✅ |
| Recovery already scheduled case returns distinguishable error | ✅ `ContractError::RecoveryAlreadyScheduled` |
| Timelock not yet expired case returns distinguishable error | ✅ `ContractError::TimelockNotExpired` |
| No pending recovery case returns distinguishable error | ✅ `ContractError::NoRecoveryScheduled` |
| Tests cover: recovery already scheduled | ✅ `test_double_schedule_rejected` |
| Tests cover: timelock not yet expired | ✅ `test_recovery_rejected_before_timelock` |
| Tests cover: no pending recovery | ✅ `test_cancel_no_recovery_panics` |