### PR TITLE
test(shared): add versioning guard for shared schemas

### DIFF
--- a/apps/shared/src/utils/index.ts
+++ b/apps/shared/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./format";
 export * from "./pagination";
 export * from "./interest";
 export * from "./performance";
+export * from "./schema-versioning";

--- a/apps/shared/src/utils/schema-versioning.ts
+++ b/apps/shared/src/utils/schema-versioning.ts
@@ -1,0 +1,196 @@
+import { z } from "zod";
+
+/**
+ * Structural definition of a schema field for version snapshotting
+ */
+export interface SchemaFieldDefinition {
+  type: string;
+  isOptional: boolean;
+  properties?: Record<string, SchemaFieldDefinition>;
+  element?: SchemaFieldDefinition;
+}
+
+/**
+ * Metadata wrapper for a schema snapshot
+ */
+export interface SchemaSnapshot {
+  version: string;
+  schemas: Record<string, SchemaFieldDefinition>;
+}
+
+/**
+ * Result of a schema snapshot comparison
+ */
+export interface SchemaComparisonResult {
+  compatible: boolean;
+  errors: string[];
+}
+
+/**
+ * Unwraps Zod schema wrappers (optional, nullable, default, effects) to find the core schema
+ */
+function unwrapZodSchema(schema: z.ZodTypeAny): {
+  coreSchema: z.ZodTypeAny;
+  isOptional: boolean;
+} {
+  let current: z.ZodTypeAny = schema;
+  let isOptional = false;
+
+  while (current) {
+    const typeName = current._def?.typeName;
+    if (typeName === "ZodOptional" || typeName === "ZodNullable") {
+      isOptional = true;
+      current = (current._def as { innerType: z.ZodTypeAny }).innerType;
+    } else if (typeName === "ZodDefault") {
+      isOptional = true;
+      current = (current._def as { innerType: z.ZodTypeAny }).innerType;
+    } else if (typeName === "ZodEffects") {
+      current = (current._def as { schema: z.ZodTypeAny }).schema;
+    } else if (typeName === "ZodPipeline") {
+      current = (current._def as { out: z.ZodTypeAny }).out;
+    } else {
+      break;
+    }
+  }
+
+  return { coreSchema: current, isOptional };
+}
+
+/**
+ * Extracts a structural field definition from a Zod schema
+ */
+export function extractSchemaShape(
+  schema: z.ZodTypeAny,
+): SchemaFieldDefinition {
+  const { coreSchema, isOptional } = unwrapZodSchema(schema);
+  const typeName = coreSchema._def?.typeName || "Unknown";
+
+  if (typeName === "ZodObject") {
+    const shape = (coreSchema as z.ZodObject<z.ZodRawShape>).shape;
+    const properties: Record<string, SchemaFieldDefinition> = {};
+    for (const key of Object.keys(shape)) {
+      properties[key] = extractSchemaShape(shape[key]);
+    }
+    return {
+      type: "ZodObject",
+      isOptional,
+      properties,
+    };
+  }
+
+  if (typeName === "ZodArray") {
+    const elementType = (coreSchema as z.ZodArray<z.ZodTypeAny>).element;
+    return {
+      type: "ZodArray",
+      isOptional,
+      element: extractSchemaShape(elementType),
+    };
+  }
+
+  return {
+    type: typeName,
+    isOptional,
+  };
+}
+
+/**
+ * Recursively compares a current schema field definition against a snapshot definition
+ */
+function compareFieldDefinition(
+  current: SchemaFieldDefinition,
+  snapshot: SchemaFieldDefinition,
+  path: string,
+): string[] {
+  const errors: string[] = [];
+
+  // Check type compatibility
+  if (current.type !== snapshot.type) {
+    errors.push(
+      `Field '${path}' type changed from '${snapshot.type}' to '${current.type}'`,
+    );
+    return errors;
+  }
+
+  // Check optionality changes
+  if (snapshot.isOptional && !current.isOptional) {
+    errors.push(`Field '${path}' became required (was optional in snapshot)`);
+  }
+
+  if (!snapshot.isOptional && current.isOptional) {
+    errors.push(`Field '${path}' became optional (was required in snapshot)`);
+  }
+
+  // Compare ZodObject properties
+  if (current.type === "ZodObject") {
+    const snapshotProps = snapshot.properties || {};
+    const currentProps = current.properties || {};
+
+    // 1. All snapshot properties must exist in current schema and be compatible
+    for (const key of Object.keys(snapshotProps)) {
+      const fieldPath = path ? `${path}.${key}` : key;
+      if (!(key in currentProps)) {
+        errors.push(`Required field '${fieldPath}' from snapshot was removed`);
+      } else {
+        errors.push(
+          ...compareFieldDefinition(
+            currentProps[key],
+            snapshotProps[key],
+            fieldPath,
+          ),
+        );
+      }
+    }
+
+    // 2. Any new properties in current schema must be optional
+    for (const key of Object.keys(currentProps)) {
+      const fieldPath = path ? `${path}.${key}` : key;
+      if (!(key in snapshotProps)) {
+        if (!currentProps[key].isOptional) {
+          errors.push(
+            `New required field '${fieldPath}' added without updating snapshot`,
+          );
+        }
+      }
+    }
+  }
+
+  // Compare ZodArray elements
+  if (current.type === "ZodArray" && snapshot.element && current.element) {
+    errors.push(
+      ...compareFieldDefinition(current.element, snapshot.element, `${path}[]`),
+    );
+  }
+
+  return errors;
+}
+
+/**
+ * Validates a map of current Zod schemas against a versioned snapshot
+ */
+export function validateSchemaSnapshot(
+  schemas: Record<string, z.ZodTypeAny>,
+  snapshot: SchemaSnapshot,
+): SchemaComparisonResult {
+  const errors: string[] = [];
+
+  for (const [schemaName, snapshotShape] of Object.entries(snapshot.schemas)) {
+    const currentZodSchema = schemas[schemaName];
+    if (!currentZodSchema) {
+      errors.push(`Schema '${schemaName}' defined in snapshot is missing`);
+      continue;
+    }
+
+    const currentShape = extractSchemaShape(currentZodSchema);
+    const fieldErrors = compareFieldDefinition(
+      currentShape,
+      snapshotShape,
+      schemaName,
+    );
+    errors.push(...fieldErrors);
+  }
+
+  return {
+    compatible: errors.length === 0,
+    errors,
+  };
+}

--- a/apps/shared/tests/schemas/schema-versioning.test.ts
+++ b/apps/shared/tests/schemas/schema-versioning.test.ts
@@ -1,0 +1,194 @@
+/// <reference types="bun-types" />
+import { describe, it, expect } from "bun:test";
+import { z } from "zod";
+import { propertyInfoSchema, lendingPoolSchema } from "../../src/schemas";
+import {
+  validateSchemaSnapshot,
+  extractSchemaShape,
+  type SchemaSnapshot,
+} from "../../src/utils/schema-versioning";
+import schemaV1 from "../snapshots/schema-v1.json";
+
+/**
+ * Builds a single-schema snapshot so negative tests don't emit unrelated
+ * "Schema X defined in snapshot is missing" errors.
+ */
+function snapshotOf(
+  name: string,
+  schema: z.ZodTypeAny,
+  version = "test",
+): SchemaSnapshot {
+  return {
+    version,
+    schemas: { [name]: extractSchemaShape(schema) },
+  };
+}
+
+describe("Schema Versioning Guard", () => {
+  it("should pass baseline check for PropertyInfo and LendingPool against v1 snapshot", () => {
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: propertyInfoSchema,
+        LendingPool: lendingPoolSchema,
+      },
+      schemaV1 as SchemaSnapshot,
+    );
+
+    expect(result.compatible).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should fail when an existing required field is removed without a snapshot update", () => {
+    // Simulate removing a required field 'description' from PropertyInfo schema
+    const modifiedPropertySchema = z.object({
+      id: z.string().uuid(),
+      name: z.string(),
+      // description intentionally missing
+      propertyType: z.enum([
+        "residential",
+        "commercial",
+        "industrial",
+        "land",
+        "mixed",
+      ]),
+    });
+
+    const result = validateSchemaSnapshot(
+      { PropertyInfo: modifiedPropertySchema },
+      snapshotOf("PropertyInfo", propertyInfoSchema),
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("PropertyInfo.description") && err.includes("removed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should fail when an existing required field type is changed", () => {
+    const modifiedLendingSchema = z.object({
+      ...lendingPoolSchema.shape,
+      utilizationRate: z.string(), // Changed from number to string
+    });
+
+    const result = validateSchemaSnapshot(
+      { LendingPool: modifiedLendingSchema },
+      snapshotOf("LendingPool", lendingPoolSchema),
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("LendingPool.utilizationRate") &&
+          err.includes("type changed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should fail when a new required field is added without a snapshot update", () => {
+    const modifiedPropertySchema = propertyInfoSchema.extend({
+      newRequiredField: z.string(),
+    });
+
+    const result = validateSchemaSnapshot(
+      { PropertyInfo: modifiedPropertySchema },
+      snapshotOf("PropertyInfo", propertyInfoSchema),
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("PropertyInfo.newRequiredField") &&
+          err.includes("added without updating snapshot"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should fail when an existing required field becomes optional", () => {
+    // Drop the .required() on `description` to make it optional post-snapshot
+    const modifiedPropertySchema = propertyInfoSchema.extend({
+      description: z.string().min(10).optional(),
+    });
+
+    const result = validateSchemaSnapshot(
+      { PropertyInfo: modifiedPropertySchema },
+      snapshotOf("PropertyInfo", propertyInfoSchema),
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("PropertyInfo.description") &&
+          err.includes("became optional"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should fail when a snapshot schema is not provided at validation time", () => {
+    const result = validateSchemaSnapshot(
+      {}, // empty - missing both PropertyInfo and LendingPool
+      schemaV1 as SchemaSnapshot,
+    );
+
+    expect(result.compatible).toBe(false);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("PropertyInfo") && err.includes("defined in snapshot"),
+      ),
+    ).toBe(true);
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes("LendingPool") && err.includes("defined in snapshot"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should NOT break when a new optional field is added (acceptance criterion #2)", () => {
+    const modifiedPropertySchema = propertyInfoSchema.extend({
+      metadata: z.record(z.string()).optional(),
+    });
+
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: modifiedPropertySchema,
+        LendingPool: lendingPoolSchema,
+      },
+      schemaV1 as SchemaSnapshot,
+    );
+
+    expect(result.compatible).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should pass after updating snapshot for intentional schema changes", () => {
+    const updatedPropertySchema = propertyInfoSchema.extend({
+      newFeatureFlag: z.boolean(),
+    });
+
+    const updatedSnapshot: SchemaSnapshot = {
+      version: "1.1.0",
+      schemas: {
+        PropertyInfo: extractSchemaShape(updatedPropertySchema),
+        LendingPool: extractSchemaShape(lendingPoolSchema),
+      },
+    };
+
+    const result = validateSchemaSnapshot(
+      {
+        PropertyInfo: updatedPropertySchema,
+        LendingPool: lendingPoolSchema,
+      },
+      updatedSnapshot,
+    );
+
+    expect(result.compatible).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/apps/shared/tests/snapshots/schema-v1.json
+++ b/apps/shared/tests/snapshots/schema-v1.json
@@ -1,0 +1,87 @@
+{
+  "version": "1.0.0",
+  "schemas": {
+    "PropertyInfo": {
+      "type": "ZodObject",
+      "isOptional": false,
+      "properties": {
+        "id": { "type": "ZodString", "isOptional": false },
+        "name": { "type": "ZodString", "isOptional": false },
+        "description": { "type": "ZodString", "isOptional": false },
+        "propertyType": { "type": "ZodEnum", "isOptional": false },
+        "location": {
+          "type": "ZodObject",
+          "isOptional": false,
+          "properties": {
+            "address": { "type": "ZodString", "isOptional": false },
+            "city": { "type": "ZodString", "isOptional": false },
+            "country": { "type": "ZodString", "isOptional": false },
+            "postalCode": { "type": "ZodString", "isOptional": true },
+            "coordinates": {
+              "type": "ZodObject",
+              "isOptional": true,
+              "properties": {
+                "latitude": { "type": "ZodNumber", "isOptional": false },
+                "longitude": { "type": "ZodNumber", "isOptional": false }
+              }
+            }
+          }
+        },
+        "totalValue": { "type": "ZodString", "isOptional": false },
+        "tokenAddress": { "type": "ZodString", "isOptional": true },
+        "totalShares": { "type": "ZodNumber", "isOptional": false },
+        "availableShares": { "type": "ZodNumber", "isOptional": false },
+        "pricePerShare": { "type": "ZodString", "isOptional": false },
+        "expectedYield": { "type": "ZodNumber", "isOptional": true },
+        "images": {
+          "type": "ZodArray",
+          "isOptional": false,
+          "element": { "type": "ZodString", "isOptional": false }
+        },
+        "splatUrl": { "type": "ZodString", "isOptional": true },
+        "documents": {
+          "type": "ZodArray",
+          "isOptional": false,
+          "element": {
+            "type": "ZodObject",
+            "isOptional": false,
+            "properties": {
+              "id": { "type": "ZodString", "isOptional": false },
+              "type": { "type": "ZodEnum", "isOptional": false },
+              "name": { "type": "ZodString", "isOptional": false },
+              "url": { "type": "ZodString", "isOptional": false },
+              "uploadedAt": { "type": "ZodString", "isOptional": false },
+              "verified": { "type": "ZodBoolean", "isOptional": false }
+            }
+          }
+        },
+        "verified": { "type": "ZodBoolean", "isOptional": false },
+        "listedAt": { "type": "ZodString", "isOptional": false },
+        "owner": { "type": "ZodString", "isOptional": false }
+      }
+    },
+    "LendingPool": {
+      "type": "ZodObject",
+      "isOptional": false,
+      "properties": {
+        "id": { "type": "ZodString", "isOptional": false },
+        "name": { "type": "ZodString", "isOptional": false },
+        "asset": { "type": "ZodString", "isOptional": false },
+        "assetAddress": { "type": "ZodString", "isOptional": false },
+        "totalDeposits": { "type": "ZodString", "isOptional": false },
+        "totalBorrows": { "type": "ZodString", "isOptional": false },
+        "availableLiquidity": { "type": "ZodString", "isOptional": false },
+        "utilizationRate": { "type": "ZodNumber", "isOptional": false },
+        "supplyAPY": { "type": "ZodNumber", "isOptional": false },
+        "borrowAPY": { "type": "ZodNumber", "isOptional": false },
+        "collateralFactor": { "type": "ZodNumber", "isOptional": false },
+        "liquidationThreshold": { "type": "ZodNumber", "isOptional": false },
+        "liquidationPenalty": { "type": "ZodNumber", "isOptional": false },
+        "reserveFactor": { "type": "ZodNumber", "isOptional": false },
+        "isActive": { "type": "ZodBoolean", "isOptional": false },
+        "isPaused": { "type": "ZodBoolean", "isOptional": false },
+        "createdAt": { "type": "ZodString", "isOptional": false }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#Closes #1020

## Summary

Adds a versioning guard for shared schemas (`PropertyInfo` and `LendingPool`) in `apps/shared` so that breaking changes are caught at CI time instead of silently breaking the webapp or API.

## What Changed

- New `apps/shared/src/utils/schema-versioning.ts` — extracts a structural definition from a Zod schema and compares it against a versioned snapshot.
- New `apps/shared/tests/snapshots/schema-v1.json` — baseline snapshot for `PropertyInfo` and `LendingPool`.
- New `apps/shared/tests/schemas/schema-versioning.test.ts` — unit tests covering the acceptance criteria.
- Re-exported the new utilities from `apps/shared/src/utils/index.ts`.

## Acceptance Criteria

- Changing an existing required field without updating the snapshot makes the check fail.
- Adding a new optional field does not break the check.
- Additionally covers: type changes, new required fields, required-to-optional changes, and missing schemas.

## Why This Fix

PR #1043 had two failing checks:

- `shared-ci.yml` → **Build and Test Shared Library** (the `format:check` step on the two new TS files).
- **Cross-Workspace Integration** (the `bun -e "..."` import of `apps/shared/dist/index.js` from the API and webapp workspaces).

Locally after the fix:

- `bun run format:check` → all files match Prettier
- `bun run build:types` → ok
- `bun run build` → ok
- `bun test` → 149 tests pass across 10 files (8 in the new versioning suite)
- Cross-workspace import resolves `validateSchemaSnapshot` from the built shared library.

## Security Note

No secrets, keys, or sensitive environment configurations were touched or exposed.