### PR TITLE
feat(api): KYC re-verification expiration and reminders

### DIFF
--- a/apps/api/drizzle/migrations/0007_add_kyc_expiry.sql
+++ b/apps/api/drizzle/migrations/0007_add_kyc_expiry.sql
@@ -1,0 +1,9 @@
+-- Add KYC expiry timestamp to users table
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "kyc_expires_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "users_kyc_expires_at_idx" ON "users" ("kyc_expires_at") WHERE "kyc_status" = 'approved';
+--> statement-breakpoint
+-- Add KYC expiry notification event types to the enum
+ALTER TYPE "public"."notification_event_type" ADD VALUE IF NOT EXISTS 'KYC_EXPIRY_REMINDER';
+--> statement-breakpoint
+ALTER TYPE "public"."notification_event_type" ADD VALUE IF NOT EXISTS 'KYC_EXPIRED';

--- a/apps/api/drizzle/migrations/meta/_journal.json
+++ b/apps/api/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777449700001,
       "tag": "0006_add_audit_log",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1753714873000,
+      "tag": "0007_add_kyc_expiry",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/__tests__/MarketplaceController.test.ts
+++ b/apps/api/src/__tests__/MarketplaceController.test.ts
@@ -184,6 +184,7 @@ describe('MarketplaceController.getListing', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       lastLoginAt: null,
+      kycExpiresAt: null,
     });
 
     const result = await MarketplaceController.getListing('p-1');

--- a/apps/api/src/__tests__/kycExpiryJob.test.ts
+++ b/apps/api/src/__tests__/kycExpiryJob.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for KycExpiryJob
+ *
+ * All tests run entirely in memory — no database required.
+ * The repository methods and NotificationService are replaced with mocks
+ * so we can simulate arbitrary date scenarios.
+ */
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { KycExpiryJob } from '../workers/kycExpiryJob';
+import { kycRepository } from '../repositories/KYCRepository';
+import type { NotificationService } from '../services/NotificationService';
+import type { Notification } from '../db/schema';
+
+// ── Date helpers ─────────────────────────────────────────────────────────────
+
+function daysFromNow(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function daysAgo(days: number): Date {
+  return daysFromNow(-days);
+}
+
+// ── Mock repository methods ───────────────────────────────────────────────────
+
+const mockUpdateUserKycStatus = mock(async (_id: string, _status: string, _exp?: Date | null) => {});
+const mockFindExpiredApprovedUsers = mock(async (): Promise<{ id: string; kycExpiresAt: Date }[]> => []);
+const mockFindUsersExpiringWithin = mock(async (_ms: number): Promise<{ id: string; kycExpiresAt: Date }[]> => []);
+
+kycRepository.findExpiredApprovedUsers = mockFindExpiredApprovedUsers;
+kycRepository.findUsersExpiringWithin = mockFindUsersExpiringWithin;
+kycRepository.updateUserKycStatus = mockUpdateUserKycStatus as typeof kycRepository.updateUserKycStatus;
+
+// ── Mock NotificationService ──────────────────────────────────────────────────
+
+const mockNotifyKycExpired = mock(async (_userId: string, _channel?: string): Promise<Notification> => ({}) as Notification);
+const mockNotifyKycExpiringSoon = mock(async (_userId: string, _exp: Date, _channel?: string): Promise<Notification> => ({}) as Notification);
+
+const mockNotificationService = {
+  notifyKycExpired: mockNotifyKycExpired,
+  notifyKycExpiringSoon: mockNotifyKycExpiringSoon,
+} as unknown as NotificationService;
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+function createJob(overrides?: { reminderWindowMs?: number }) {
+  return new KycExpiryJob({
+    pollIntervalMs: 999_999_999, // prevent auto-scheduling during tests
+    reminderWindowMs: overrides?.reminderWindowMs,
+    notificationService: mockNotificationService,
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('KycExpiryJob', () => {
+  beforeEach(() => {
+    mockUpdateUserKycStatus.mockReset();
+    mockFindExpiredApprovedUsers.mockReset();
+    mockFindUsersExpiringWithin.mockReset();
+    mockNotifyKycExpired.mockReset();
+    mockNotifyKycExpiringSoon.mockReset();
+    // Default: no users to process
+    mockFindExpiredApprovedUsers.mockImplementation(async () => []);
+    mockFindUsersExpiringWithin.mockImplementation(async () => []);
+  });
+
+  // ── Already-expired records ────────────────────────────────────────────────
+
+  describe('already expired KYC records', () => {
+    it('marks a user as expired when kycExpiresAt is in the past', async () => {
+      const userId = 'user-already-expired';
+      const expiredAt = daysAgo(1);
+
+      mockFindExpiredApprovedUsers.mockImplementation(async () => [
+        { id: userId, kycExpiresAt: expiredAt },
+      ]);
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.expired).toBe(1);
+      expect(mockUpdateUserKycStatus).toHaveBeenCalledTimes(1);
+      expect(mockUpdateUserKycStatus).toHaveBeenCalledWith(userId, 'expired', expiredAt);
+      expect(mockNotifyKycExpired).toHaveBeenCalledTimes(1);
+      expect(mockNotifyKycExpired).toHaveBeenCalledWith(userId, 'IN_APP');
+    });
+
+    it('marks multiple expired users in a single tick', async () => {
+      mockFindExpiredApprovedUsers.mockImplementation(async () => [
+        { id: 'user-a', kycExpiresAt: daysAgo(5) },
+        { id: 'user-b', kycExpiresAt: daysAgo(1) },
+      ]);
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.expired).toBe(2);
+      expect(mockUpdateUserKycStatus).toHaveBeenCalledTimes(2);
+      expect(mockNotifyKycExpired).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns expired=0 when no records are overdue', async () => {
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.expired).toBe(0);
+      expect(mockUpdateUserKycStatus).not.toHaveBeenCalled();
+      expect(mockNotifyKycExpired).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── About-to-expire reminders ──────────────────────────────────────────────
+
+  describe('about-to-expire reminders', () => {
+    it('sends a reminder for a user whose KYC expires within the default 30-day window', async () => {
+      const userId = 'user-expiring-soon';
+      const expiresAt = daysFromNow(15);
+
+      mockFindUsersExpiringWithin.mockImplementation(async () => [
+        { id: userId, kycExpiresAt: expiresAt },
+      ]);
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.reminded).toBe(1);
+      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(1);
+      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledWith(userId, expiresAt, 'IN_APP');
+    });
+
+    it('sends reminders to multiple users expiring soon', async () => {
+      mockFindUsersExpiringWithin.mockImplementation(async () => [
+        { id: 'user-c', kycExpiresAt: daysFromNow(7) },
+        { id: 'user-d', kycExpiresAt: daysFromNow(29) },
+      ]);
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.reminded).toBe(2);
+      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(2);
+    });
+
+    it('sends no reminders when no users are expiring soon', async () => {
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.reminded).toBe(0);
+      expect(mockNotifyKycExpiringSoon).not.toHaveBeenCalled();
+    });
+
+    it('respects a custom reminderWindowMs', async () => {
+      const userId = 'user-custom-window';
+      mockFindUsersExpiringWithin.mockImplementation(async () => [
+        { id: userId, kycExpiresAt: daysFromNow(3) },
+      ]);
+
+      // 7-day custom window
+      const job = createJob({ reminderWindowMs: 7 * 24 * 60 * 60 * 1_000 });
+      const result = await job.tick();
+
+      expect(result.reminded).toBe(1);
+    });
+  });
+
+  // ── Combined in one tick ───────────────────────────────────────────────────
+
+  describe('combined: expired + reminders in same tick', () => {
+    it('handles both expired records and reminder candidates simultaneously', async () => {
+      mockFindExpiredApprovedUsers.mockImplementation(async () => [
+        { id: 'expired-user', kycExpiresAt: daysAgo(2) },
+      ]);
+      mockFindUsersExpiringWithin.mockImplementation(async () => [
+        { id: 'soon-user', kycExpiresAt: daysFromNow(10) },
+      ]);
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.expired).toBe(1);
+      expect(result.reminded).toBe(1);
+      expect(mockUpdateUserKycStatus).toHaveBeenCalledTimes(1);
+      expect(mockNotifyKycExpired).toHaveBeenCalledTimes(1);
+      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  describe('start() / stop() lifecycle', () => {
+    it('starts and can be stopped cleanly', async () => {
+      const job = createJob();
+      job.start();
+      expect(job.isRunning()).toBe(true);
+      await job.stop();
+      expect(job.isRunning()).toBe(false);
+    });
+
+    it('calling start() twice is a no-op', async () => {
+      const job = createJob();
+      job.start();
+      job.start();
+      expect(job.isRunning()).toBe(true);
+      await job.stop();
+    });
+
+    it('stop() on a never-started job does not throw', async () => {
+      const job = createJob();
+      await expect(job.stop()).resolves.toBeUndefined();
+      expect(job.isRunning()).toBe(false);
+    });
+  });
+
+  // ── Error resilience ───────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('continues processing remaining users even if one throws', async () => {
+      mockFindExpiredApprovedUsers.mockImplementation(async () => [
+        { id: 'user-will-fail', kycExpiresAt: daysAgo(3) },
+        { id: 'user-will-succeed', kycExpiresAt: daysAgo(1) },
+      ]);
+
+      let callCount = 0;
+      mockUpdateUserKycStatus.mockImplementation(async (id: string) => {
+        callCount++;
+        if (id === 'user-will-fail') throw new Error('Simulated DB error');
+      });
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(callCount).toBe(2);
+      // Only the successful user increments the counter
+      expect(result.expired).toBe(1);
+    });
+
+    it('returns zero counts when the repository throws at the top level', async () => {
+      mockFindExpiredApprovedUsers.mockImplementation(async () => {
+        throw new Error('DB connection lost');
+      });
+
+      const job = createJob();
+      const result = await job.tick();
+
+      expect(result.expired).toBe(0);
+      expect(result.reminded).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/__tests__/kycExpiryJob.test.ts
+++ b/apps/api/src/__tests__/kycExpiryJob.test.ts
@@ -126,24 +126,21 @@ describe('KycExpiryJob', () => {
   // ── About-to-expire reminders ─────────────────────────────────────────────
 
   describe('about-to-expire reminders', () => {
-    it(
-      'sends a reminder for a user whose KYC expires within the default 30-day window',
-      async () => {
-        const userId = 'user-expiring-soon';
-        const expiresAt = daysFromNow(15);
+    it('sends a reminder for a user whose KYC expires within the default 30-day window', async () => {
+      const userId = 'user-expiring-soon';
+      const expiresAt = daysFromNow(15);
 
-        mockFindUsersExpiringWithin.mockImplementation(async () => [
-          { id: userId, kycExpiresAt: expiresAt },
-        ]);
+      mockFindUsersExpiringWithin.mockImplementation(async () => [
+        { id: userId, kycExpiresAt: expiresAt },
+      ]);
 
-        const job = createJob();
-        const result = await job.tick();
+      const job = createJob();
+      const result = await job.tick();
 
-        expect(result.reminded).toBe(1);
-        expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(1);
-        expect(mockNotifyKycExpiringSoon).toHaveBeenCalledWith(userId, expiresAt, 'IN_APP');
-      },
-    );
+      expect(result.reminded).toBe(1);
+      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(1);
+      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledWith(userId, expiresAt, 'IN_APP');
+    });
 
     it('sends reminders to multiple users expiring soon', async () => {
       mockFindUsersExpiringWithin.mockImplementation(async () => [

--- a/apps/api/src/__tests__/kycExpiryJob.test.ts
+++ b/apps/api/src/__tests__/kycExpiryJob.test.ts
@@ -6,7 +6,7 @@
  * so we can simulate arbitrary date scenarios.
  */
 
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { KycExpiryJob } from '../workers/kycExpiryJob';
 import { kycRepository } from '../repositories/KYCRepository';
 import type { NotificationService } from '../services/NotificationService';
@@ -33,6 +33,11 @@ const mockUpdateUserKycStatus = mock(
 );
 const mockFindExpiredApprovedUsers = mock(async (): Promise<ExpiryRow[]> => []);
 const mockFindUsersExpiringWithin = mock(async (_ms: number): Promise<ExpiryRow[]> => []);
+
+// Save originals so we can restore them after the suite finishes
+const originalUpdateUserKycStatus = kycRepository.updateUserKycStatus.bind(kycRepository);
+const originalFindExpiredApprovedUsers = kycRepository.findExpiredApprovedUsers.bind(kycRepository);
+const originalFindUsersExpiringWithin = kycRepository.findUsersExpiringWithin.bind(kycRepository);
 
 kycRepository.findExpiredApprovedUsers = mockFindExpiredApprovedUsers;
 kycRepository.findUsersExpiringWithin = mockFindUsersExpiringWithin;
@@ -67,6 +72,13 @@ function createJob(overrides?: { reminderWindowMs?: number }) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('KycExpiryJob', () => {
+  afterAll(() => {
+    // Restore real repository methods so subsequent test files are not affected
+    kycRepository.updateUserKycStatus = originalUpdateUserKycStatus;
+    kycRepository.findExpiredApprovedUsers = originalFindExpiredApprovedUsers;
+    kycRepository.findUsersExpiringWithin = originalFindUsersExpiringWithin;
+  });
+
   beforeEach(() => {
     mockUpdateUserKycStatus.mockReset();
     mockFindExpiredApprovedUsers.mockReset();

--- a/apps/api/src/__tests__/kycExpiryJob.test.ts
+++ b/apps/api/src/__tests__/kycExpiryJob.test.ts
@@ -12,7 +12,7 @@ import { kycRepository } from '../repositories/KYCRepository';
 import type { NotificationService } from '../services/NotificationService';
 import type { Notification } from '../db/schema';
 
-// ── Date helpers ─────────────────────────────────────────────────────────────
+// ── Date helpers ──────────────────────────────────────────────────────────────
 
 function daysFromNow(days: number): Date {
   const d = new Date();
@@ -26,18 +26,28 @@ function daysAgo(days: number): Date {
 
 // ── Mock repository methods ───────────────────────────────────────────────────
 
-const mockUpdateUserKycStatus = mock(async (_id: string, _status: string, _exp?: Date | null) => {});
-const mockFindExpiredApprovedUsers = mock(async (): Promise<{ id: string; kycExpiresAt: Date }[]> => []);
-const mockFindUsersExpiringWithin = mock(async (_ms: number): Promise<{ id: string; kycExpiresAt: Date }[]> => []);
+type ExpiryRow = { id: string; kycExpiresAt: Date };
+
+const mockUpdateUserKycStatus = mock(
+  async (_id: string, _status: string, _exp?: Date | null) => {},
+);
+const mockFindExpiredApprovedUsers = mock(async (): Promise<ExpiryRow[]> => []);
+const mockFindUsersExpiringWithin = mock(async (_ms: number): Promise<ExpiryRow[]> => []);
 
 kycRepository.findExpiredApprovedUsers = mockFindExpiredApprovedUsers;
 kycRepository.findUsersExpiringWithin = mockFindUsersExpiringWithin;
-kycRepository.updateUserKycStatus = mockUpdateUserKycStatus as typeof kycRepository.updateUserKycStatus;
+kycRepository.updateUserKycStatus =
+  mockUpdateUserKycStatus as typeof kycRepository.updateUserKycStatus;
 
 // ── Mock NotificationService ──────────────────────────────────────────────────
 
-const mockNotifyKycExpired = mock(async (_userId: string, _channel?: string): Promise<Notification> => ({}) as Notification);
-const mockNotifyKycExpiringSoon = mock(async (_userId: string, _exp: Date, _channel?: string): Promise<Notification> => ({}) as Notification);
+const mockNotifyKycExpired = mock(
+  async (_userId: string, _channel?: string): Promise<Notification> => ({}) as Notification,
+);
+const mockNotifyKycExpiringSoon = mock(
+  async (_userId: string, _exp: Date, _channel?: string): Promise<Notification> =>
+    ({}) as Notification,
+);
 
 const mockNotificationService = {
   notifyKycExpired: mockNotifyKycExpired,
@@ -68,7 +78,7 @@ describe('KycExpiryJob', () => {
     mockFindUsersExpiringWithin.mockImplementation(async () => []);
   });
 
-  // ── Already-expired records ────────────────────────────────────────────────
+  // ── Already-expired records ───────────────────────────────────────────────
 
   describe('already expired KYC records', () => {
     it('marks a user as expired when kycExpiresAt is in the past', async () => {
@@ -113,24 +123,27 @@ describe('KycExpiryJob', () => {
     });
   });
 
-  // ── About-to-expire reminders ──────────────────────────────────────────────
+  // ── About-to-expire reminders ─────────────────────────────────────────────
 
   describe('about-to-expire reminders', () => {
-    it('sends a reminder for a user whose KYC expires within the default 30-day window', async () => {
-      const userId = 'user-expiring-soon';
-      const expiresAt = daysFromNow(15);
+    it(
+      'sends a reminder for a user whose KYC expires within the default 30-day window',
+      async () => {
+        const userId = 'user-expiring-soon';
+        const expiresAt = daysFromNow(15);
 
-      mockFindUsersExpiringWithin.mockImplementation(async () => [
-        { id: userId, kycExpiresAt: expiresAt },
-      ]);
+        mockFindUsersExpiringWithin.mockImplementation(async () => [
+          { id: userId, kycExpiresAt: expiresAt },
+        ]);
 
-      const job = createJob();
-      const result = await job.tick();
+        const job = createJob();
+        const result = await job.tick();
 
-      expect(result.reminded).toBe(1);
-      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(1);
-      expect(mockNotifyKycExpiringSoon).toHaveBeenCalledWith(userId, expiresAt, 'IN_APP');
-    });
+        expect(result.reminded).toBe(1);
+        expect(mockNotifyKycExpiringSoon).toHaveBeenCalledTimes(1);
+        expect(mockNotifyKycExpiringSoon).toHaveBeenCalledWith(userId, expiresAt, 'IN_APP');
+      },
+    );
 
     it('sends reminders to multiple users expiring soon', async () => {
       mockFindUsersExpiringWithin.mockImplementation(async () => [
@@ -167,7 +180,7 @@ describe('KycExpiryJob', () => {
     });
   });
 
-  // ── Combined in one tick ───────────────────────────────────────────────────
+  // ── Combined in one tick ──────────────────────────────────────────────────
 
   describe('combined: expired + reminders in same tick', () => {
     it('handles both expired records and reminder candidates simultaneously', async () => {
@@ -189,7 +202,7 @@ describe('KycExpiryJob', () => {
     });
   });
 
-  // ── Lifecycle ──────────────────────────────────────────────────────────────
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   describe('start() / stop() lifecycle', () => {
     it('starts and can be stopped cleanly', async () => {
@@ -215,7 +228,7 @@ describe('KycExpiryJob', () => {
     });
   });
 
-  // ── Error resilience ───────────────────────────────────────────────────────
+  // ── Error resilience ──────────────────────────────────────────────────────
 
   describe('error handling', () => {
     it('continues processing remaining users even if one throws', async () => {

--- a/apps/api/src/__tests__/positions.test.ts
+++ b/apps/api/src/__tests__/positions.test.ts
@@ -43,6 +43,7 @@ const testUser: User = {
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
   updatedAt: new Date('2026-01-01T00:00:00.000Z'),
   lastLoginAt: null,
+  kycExpiresAt: null,
 };
 
 const testDeposit: DepositPosition = {

--- a/apps/api/src/controllers/KYCController.ts
+++ b/apps/api/src/controllers/KYCController.ts
@@ -60,7 +60,8 @@ function toKycDocumentForResponse(doc: {
 
 export class KYCController {
   static async getKYCStatus(userId: string): Promise<{
-    status: 'pending' | 'verified' | 'rejected';
+    status: 'pending' | 'verified' | 'rejected' | 'expired';
+    kycExpiresAt?: string;
     documents: (KycDocument & { documentUrl: string })[];
   }> {
     try {
@@ -72,17 +73,19 @@ export class KYCController {
       const dbStatus = await kycRepository.getUserKycStatus(userId);
       const docs = await kycRepository.findByUserId(userId);
 
+      // Surface 'expired' distinctly so clients can show a re-verification prompt
       const statusMap = {
         not_started: 'pending' as const,
         pending: 'pending' as const,
         approved: 'verified' as const,
         rejected: 'rejected' as const,
-        expired: 'rejected' as const,
+        expired: 'expired' as const,
       };
       const status = dbStatus ? statusMap[dbStatus] : 'pending';
 
       const documents = docs.map((d) => toKycDocumentForResponse(d));
-      return { status, documents };
+      const kycExpiresAt = user.kycExpiresAt ? user.kycExpiresAt.toISOString() : undefined;
+      return { status, kycExpiresAt, documents };
     } catch (e) {
       if (e instanceof ApiError) throw e;
       throw ApiError.internal(e instanceof Error ? e.message : 'Failed to fetch KYC status');
@@ -226,7 +229,10 @@ export class KYCController {
       } else if (allApproved) {
         userBeforeStatus = 'pending';
         userAfterStatus = 'approved';
-        await kycRepository.updateUserKycStatus(doc.userId, 'approved');
+        // KYC approval is valid for 1 year from today
+        const expiresAt = new Date();
+        expiresAt.setFullYear(expiresAt.getFullYear() + 1);
+        await kycRepository.updateUserKycStatus(doc.userId, 'approved', expiresAt);
         // Send verification approved notification
         await notificationService.notifyVerificationApproved(doc.userId, 'IN_APP');
       }

--- a/apps/api/src/controllers/PropertyController.ts
+++ b/apps/api/src/controllers/PropertyController.ts
@@ -586,7 +586,11 @@ export class PropertyController {
       const buyer = await userRepository.getOrCreateByWallet(data.buyer);
 
       if (buyer.kycStatus !== 'approved') {
-        throw new AuthorizationError('KYC verification must be approved before purchasing shares');
+        const msg =
+          buyer.kycStatus === 'expired'
+            ? 'Your KYC verification has expired. Please re-verify before purchasing shares.'
+            : 'KYC verification must be approved before purchasing shares';
+        throw new AuthorizationError(msg);
       }
       const pricePerShareBig = parseDecimalStringToBigInt(property.pricePerShare, 2);
       const totalPurchasePriceBig = pricePerShareBig * BigInt(data.shares);

--- a/apps/api/src/db/schema/notifications.ts
+++ b/apps/api/src/db/schema/notifications.ts
@@ -15,6 +15,8 @@ export const notificationEventTypeEnum = pgEnum('notification_event_type', [
   'SYSTEM_ALERT',
   'INVESTMENT_OPPORTUNITY',
   'PORTFOLIO_UPDATE',
+  'KYC_EXPIRY_REMINDER',
+  'KYC_EXPIRED',
 ]);
 
 export const notificationChannelEnum = pgEnum('notification_channel', ['IN_APP', 'EMAIL', 'SMS']);

--- a/apps/api/src/db/schema/users.ts
+++ b/apps/api/src/db/schema/users.ts
@@ -18,6 +18,7 @@ export const users = pgTable('users', {
   displayName: varchar('display_name', { length: 50 }),
   kycStatus: kycStatusEnum('kyc_status').notNull().default('not_started'),
   kycTier: kycTierEnum('kyc_tier').notNull().default('none'),
+  kycExpiresAt: timestamp('kyc_expires_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   lastLoginAt: timestamp('last_login_at', { withTimezone: true }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { errorHandler } from './middleware/errorHandler';
 import { cacheService } from './services/CacheService';
 import { NotificationService } from './services/NotificationService';
 import { createNotificationWorkerFromEnv } from './workers/notificationWorker';
+import { createKycExpiryJobFromEnv } from './workers/kycExpiryJob';
 
 app
   .use(
@@ -68,12 +69,17 @@ cacheService.connect();
 const notificationWorker = createNotificationWorkerFromEnv(new NotificationService());
 notificationWorker?.start();
 
+// Start the KYC expiry job (opt-out via KYC_EXPIRY_JOB_ENABLED=false)
+const kycExpiryJob = createKycExpiryJobFromEnv();
+kycExpiryJob?.start();
+
 const shutdown = async (signal: string) => {
   console.log(`\n${signal} received, closing connections...`);
   await Promise.all([
     closeDatabaseConnection(),
     cacheService.disconnect(),
     notificationWorker?.stop() ?? Promise.resolve(),
+    kycExpiryJob?.stop() ?? Promise.resolve(),
   ]);
 
   console.log('Connections closed. Exiting...');

--- a/apps/api/src/repositories/KYCRepository.ts
+++ b/apps/api/src/repositories/KYCRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, asc } from 'drizzle-orm';
+import { eq, and, asc, lte, gte, isNotNull } from 'drizzle-orm';
 import { db } from '../db';
 import { kycDocuments, users, type KycDocument, type NewKycDocument } from '../db/schema/users';
 
@@ -74,15 +74,24 @@ export class KYCRepository {
 
   /**
    * Set user KYC status (not_started | pending | approved | rejected | expired).
+   * Optionally sets or clears the expiry timestamp.
    */
   async updateUserKycStatus(
     userId: string,
     status: 'not_started' | 'pending' | 'approved' | 'rejected' | 'expired',
+    kycExpiresAt?: Date | null,
   ): Promise<void> {
-    await db
-      .update(users)
-      .set({ kycStatus: status, updatedAt: new Date() })
-      .where(eq(users.id, userId));
+    if (kycExpiresAt !== undefined) {
+      await db
+        .update(users)
+        .set({ kycStatus: status, kycExpiresAt, updatedAt: new Date() })
+        .where(eq(users.id, userId));
+    } else {
+      await db
+        .update(users)
+        .set({ kycStatus: status, updatedAt: new Date() })
+        .where(eq(users.id, userId));
+    }
   }
 
   async getUserKycStatus(
@@ -94,6 +103,49 @@ export class KYCRepository {
       .where(eq(users.id, userId))
       .limit(1);
     return results[0]?.kycStatus;
+  }
+
+  /**
+   * Find users whose approved KYC has already expired (kycExpiresAt <= now).
+   */
+  async findExpiredApprovedUsers(): Promise<{ id: string; kycExpiresAt: Date }[]> {
+    const now = new Date();
+    const results = await db
+      .select({ id: users.id, kycExpiresAt: users.kycExpiresAt })
+      .from(users)
+      .where(
+        and(
+          eq(users.kycStatus, 'approved'),
+          isNotNull(users.kycExpiresAt),
+          lte(users.kycExpiresAt, now),
+        ),
+      );
+    return results.filter(
+      (r): r is { id: string; kycExpiresAt: Date } => r.kycExpiresAt !== null,
+    );
+  }
+
+  /**
+   * Find users whose approved KYC will expire within the given window (for reminder notifications).
+   * Returns users where now <= kycExpiresAt <= now + windowMs.
+   */
+  async findUsersExpiringWithin(windowMs: number): Promise<{ id: string; kycExpiresAt: Date }[]> {
+    const now = new Date();
+    const cutoff = new Date(now.getTime() + windowMs);
+    const results = await db
+      .select({ id: users.id, kycExpiresAt: users.kycExpiresAt })
+      .from(users)
+      .where(
+        and(
+          eq(users.kycStatus, 'approved'),
+          isNotNull(users.kycExpiresAt),
+          gte(users.kycExpiresAt, now),
+          lte(users.kycExpiresAt, cutoff),
+        ),
+      );
+    return results.filter(
+      (r): r is { id: string; kycExpiresAt: Date } => r.kycExpiresAt !== null,
+    );
   }
 }
 

--- a/apps/api/src/repositories/KYCRepository.ts
+++ b/apps/api/src/repositories/KYCRepository.ts
@@ -120,9 +120,7 @@ export class KYCRepository {
           lte(users.kycExpiresAt, now),
         ),
       );
-    return results.filter(
-      (r): r is { id: string; kycExpiresAt: Date } => r.kycExpiresAt !== null,
-    );
+    return results.filter((r): r is { id: string; kycExpiresAt: Date } => r.kycExpiresAt !== null);
   }
 
   /**
@@ -143,9 +141,7 @@ export class KYCRepository {
           lte(users.kycExpiresAt, cutoff),
         ),
       );
-    return results.filter(
-      (r): r is { id: string; kycExpiresAt: Date } => r.kycExpiresAt !== null,
-    );
+    return results.filter((r): r is { id: string; kycExpiresAt: Date } => r.kycExpiresAt !== null);
   }
 }
 

--- a/apps/api/src/repositories/KYCRepository.ts
+++ b/apps/api/src/repositories/KYCRepository.ts
@@ -74,24 +74,21 @@ export class KYCRepository {
 
   /**
    * Set user KYC status (not_started | pending | approved | rejected | expired).
-   * Optionally sets or clears the expiry timestamp.
+   * Pass kycExpiresAt to set/clear the expiry timestamp; omit to leave it unchanged.
    */
   async updateUserKycStatus(
     userId: string,
     status: 'not_started' | 'pending' | 'approved' | 'rejected' | 'expired',
     kycExpiresAt?: Date | null,
   ): Promise<void> {
-    if (kycExpiresAt !== undefined) {
-      await db
-        .update(users)
-        .set({ kycStatus: status, kycExpiresAt, updatedAt: new Date() })
-        .where(eq(users.id, userId));
-    } else {
-      await db
-        .update(users)
-        .set({ kycStatus: status, updatedAt: new Date() })
-        .where(eq(users.id, userId));
-    }
+    await db
+      .update(users)
+      .set({
+        kycStatus: status,
+        ...(kycExpiresAt !== undefined ? { kycExpiresAt } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
   }
 
   async getUserKycStatus(

--- a/apps/api/src/services/NotificationService.ts
+++ b/apps/api/src/services/NotificationService.ts
@@ -428,6 +428,42 @@ export class NotificationService {
   }
 
   /**
+   * Notify KYC expiring soon (reminder)
+   */
+  async notifyKycExpiringSoon(
+    userId: string,
+    expiresAt: Date,
+    channel: NotificationChannel = 'IN_APP',
+  ): Promise<Notification> {
+    const dateStr = expiresAt.toLocaleDateString();
+    return this.createNotification({
+      userId,
+      eventType: 'KYC_EXPIRY_REMINDER',
+      title: 'KYC Verification Expiring Soon',
+      message: `Your KYC verification will expire on ${dateStr}. Please re-verify to avoid disruption to your account.`,
+      channel,
+      metadata: { expiresAt: expiresAt.toISOString() },
+    });
+  }
+
+  /**
+   * Notify KYC has expired
+   */
+  async notifyKycExpired(
+    userId: string,
+    channel: NotificationChannel = 'IN_APP',
+  ): Promise<Notification> {
+    return this.createNotification({
+      userId,
+      eventType: 'KYC_EXPIRED',
+      title: 'KYC Verification Expired',
+      message:
+        'Your KYC verification has expired. Please re-submit your documents to regain full platform access.',
+      channel,
+    });
+  }
+
+  /**
    * Notify investment opportunity
    */
   async notifyInvestmentOpportunity(

--- a/apps/api/src/workers/kycExpiryJob.ts
+++ b/apps/api/src/workers/kycExpiryJob.ts
@@ -1,0 +1,186 @@
+import { kycRepository } from '../repositories/KYCRepository';
+import { NotificationService } from '../services/NotificationService';
+import { logger } from '../services/logger';
+
+export interface KycExpiryJobConfig {
+  /** How often the job runs, in milliseconds. Default: 24 hours. */
+  pollIntervalMs?: number;
+  /**
+   * How far in advance to send the expiry reminder.
+   * Default: 30 days (in milliseconds).
+   */
+  reminderWindowMs?: number;
+  /** Injected NotificationService (useful for testing). */
+  notificationService?: NotificationService;
+}
+
+interface ResolvedConfig {
+  pollIntervalMs: number;
+  reminderWindowMs: number;
+  notificationService: NotificationService;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 24 * 60 * 60 * 1_000; // 24 hours
+const DEFAULT_REMINDER_WINDOW_MS = 30 * 24 * 60 * 60 * 1_000; // 30 days
+
+/**
+ * KycExpiryJob
+ *
+ * Periodically:
+ *  1. Marks approved KYC records as `expired` when kycExpiresAt has passed.
+ *  2. Sends a re-verification reminder to users whose KYC will expire within
+ *     the configured reminder window (default 30 days).
+ *
+ * Disable via env: KYC_EXPIRY_JOB_ENABLED=false
+ * Tune poll interval: KYC_EXPIRY_POLL_INTERVAL_MS=<ms>
+ * Tune reminder window: KYC_EXPIRY_REMINDER_WINDOW_MS=<ms>
+ */
+export class KycExpiryJob {
+  private readonly config: ResolvedConfig;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+  private processing = false;
+
+  constructor(config?: KycExpiryJobConfig) {
+    this.config = {
+      pollIntervalMs: config?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      reminderWindowMs: config?.reminderWindowMs ?? DEFAULT_REMINDER_WINDOW_MS,
+      notificationService: config?.notificationService ?? new NotificationService(),
+    };
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    logger.info('KYC expiry job started', {
+      operation: 'KYC_EXPIRY_JOB_START',
+      pollIntervalMs: this.config.pollIntervalMs,
+      reminderWindowMs: this.config.reminderWindowMs,
+    });
+    // Run immediately on start, then schedule future ticks
+    void this.tick();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    // Wait for any in-flight tick to complete
+    while (this.processing) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    logger.info('KYC expiry job stopped', { operation: 'KYC_EXPIRY_JOB_STOP' });
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Execute one cycle of the job. Public so tests can call it directly
+   * with mocked repository/service to simulate arbitrary dates.
+   */
+  async tick(): Promise<{ expired: number; reminded: number }> {
+    if (this.processing) return { expired: 0, reminded: 0 };
+    this.processing = true;
+
+    let expiredCount = 0;
+    let remindedCount = 0;
+
+    try {
+      // ── Step 1: expire overdue approved KYC records ───────────────────
+      const overdueUsers = await kycRepository.findExpiredApprovedUsers();
+
+      for (const user of overdueUsers) {
+        try {
+          await kycRepository.updateUserKycStatus(user.id, 'expired', user.kycExpiresAt);
+          await this.config.notificationService.notifyKycExpired(user.id, 'IN_APP');
+          expiredCount++;
+          logger.info('KYC record expired', {
+            operation: 'KYC_EXPIRED',
+            userId: user.id,
+            kycExpiresAt: user.kycExpiresAt,
+          });
+        } catch (err) {
+          logger.error('Failed to expire KYC for user', {
+            operation: 'KYC_EXPIRE_ERROR',
+            userId: user.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // ── Step 2: send reminders for KYC expiring soon ──────────────────
+      const soonToExpireUsers = await kycRepository.findUsersExpiringWithin(
+        this.config.reminderWindowMs,
+      );
+
+      for (const user of soonToExpireUsers) {
+        try {
+          await this.config.notificationService.notifyKycExpiringSoon(
+            user.id,
+            user.kycExpiresAt,
+            'IN_APP',
+          );
+          remindedCount++;
+          logger.info('KYC expiry reminder sent', {
+            operation: 'KYC_EXPIRY_REMINDER_SENT',
+            userId: user.id,
+            kycExpiresAt: user.kycExpiresAt,
+          });
+        } catch (err) {
+          logger.error('Failed to send KYC expiry reminder', {
+            operation: 'KYC_REMINDER_ERROR',
+            userId: user.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } catch (err) {
+      logger.error('KYC expiry job tick failed', {
+        operation: 'KYC_EXPIRY_JOB_TICK_ERROR',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.processing = false;
+      this.scheduleNext();
+    }
+
+    return { expired: expiredCount, reminded: remindedCount };
+  }
+
+  private scheduleNext(): void {
+    if (!this.running) return;
+    this.timer = setTimeout(() => {
+      void this.tick();
+    }, this.config.pollIntervalMs);
+    // Do not keep the event loop alive solely for the poll timer
+    const t = this.timer as unknown as { unref?: () => void };
+    if (typeof t.unref === 'function') t.unref();
+  }
+}
+
+/**
+ * Factory that respects the KYC_EXPIRY_JOB_ENABLED env flag (default: enabled).
+ */
+export function createKycExpiryJobFromEnv(): KycExpiryJob | null {
+  const enabled = (process.env.KYC_EXPIRY_JOB_ENABLED ?? 'true').toLowerCase() !== 'false';
+  if (!enabled) {
+    logger.info('KYC expiry job disabled via KYC_EXPIRY_JOB_ENABLED=false', {
+      operation: 'KYC_EXPIRY_JOB_DISABLED',
+    });
+    return null;
+  }
+
+  const pollIntervalMs = Number(process.env.KYC_EXPIRY_POLL_INTERVAL_MS);
+  const reminderWindowMs = Number(process.env.KYC_EXPIRY_REMINDER_WINDOW_MS);
+
+  return new KycExpiryJob({
+    pollIntervalMs:
+      Number.isFinite(pollIntervalMs) && pollIntervalMs > 0 ? pollIntervalMs : undefined,
+    reminderWindowMs:
+      Number.isFinite(reminderWindowMs) && reminderWindowMs > 0 ? reminderWindowMs : undefined,
+  });
+}

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -49,6 +49,16 @@ cp akkuea-defi-rwa/apps/api/.env.example akkuea-defi-rwa/apps/api/.env
 | ---------------- | ------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `KYC_UPLOAD_DIR` | `/var/akkuea/kyc-uploads` | Yes      | Absolute path on the server where KYC document files are stored. The API process must have read/write access to this directory |
 
+### KYC Expiry Job
+
+The KYC expiry job runs in the background to mark expired KYC records and send re-verification reminders. All three variables are optional — the defaults are suitable for production.
+
+| Variable                        | Example Value  | Required             | Description                                                                                                                                        |
+| ------------------------------- | -------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KYC_EXPIRY_JOB_ENABLED`        | `true`         | No (default: `true`) | Set to `false` to disable the KYC expiry background job entirely (e.g. in test environments)                                                       |
+| `KYC_EXPIRY_POLL_INTERVAL_MS`   | `86400000`     | No (default: 24h)    | How often the job runs, in milliseconds. Default is `86400000` (24 hours). Set lower in staging to test expiry behaviour without waiting a full day |
+| `KYC_EXPIRY_REMINDER_WINDOW_MS` | `2592000000`   | No (default: 30d)    | How far in advance to send the expiry reminder notification, in milliseconds. Default is `2592000000` (30 days)                                     |
+
 ### Stellar / Soroban - Network
 
 | Variable                     | Example Value                         | Required | Description                                                                                                                                                              |


### PR DESCRIPTION
## Summary

Implements KYC expiration and re-verification reminders as described in issue #1004.

Approved KYC documents previously stayed valid forever. This PR adds a full expiry lifecycle:

- **Schema**: `kyc_expires_at` timestamp added to the `users` table (migration `0007`).
- **Expiry on approval**: `KYCController.verifyDocument` now sets a 1-year expiry when all documents are approved.
- **KycExpiryJob** (new background worker):
  - Runs every 24 hours (configurable via `KYC_EXPIRY_POLL_INTERVAL_MS`).
  - Step 1 — marks users whose `kycExpiresAt` has passed as `expired` and sends a `KYC_EXPIRED` in-app notification.
  - Step 2 — sends a `KYC_EXPIRY_REMINDER` notification to users whose KYC will expire within the next 30 days (configurable via `KYC_EXPIRY_REMINDER_WINDOW_MS`).
  - Can be disabled via `KYC_EXPIRY_JOB_ENABLED=false`.
- **Blocking expired KYC**: `PropertyController.buyShares` returns a clear error message when `kycStatus === 'expired'`.
- **Status endpoint**: `GET /kyc/status/:userId` now returns `'expired'` as a distinct status (not collapsed into `'rejected'`) plus the `kycExpiresAt` ISO string.
- **Notifications**: `NotificationService` gains `notifyKycExpiringSoon()` and `notifyKycExpired()`.

## Files changed

| File | Change |
|------|--------|
| `src/db/schema/users.ts` | Added `kycExpiresAt` column |
| `src/db/schema/notifications.ts` | Added `KYC_EXPIRY_REMINDER`, `KYC_EXPIRED` event types |
| `drizzle/migrations/0007_add_kyc_expiry.sql` | New migration |
| `src/repositories/KYCRepository.ts` | `updateUserKycStatus` accepts optional expiry; `findExpiredApprovedUsers()`, `findUsersExpiringWithin(ms)` |
| `src/controllers/KYCController.ts` | Sets expiry on approval; exposes `expired` status + `kycExpiresAt` |
| `src/controllers/PropertyController.ts` | Clear error for expired KYC on share purchase |
| `src/services/NotificationService.ts` | `notifyKycExpiringSoon()`, `notifyKycExpired()` |
| `src/workers/kycExpiryJob.ts` | New background job (new file) |
| `src/index.ts` | Wires job into startup/shutdown |
| `src/__tests__/kycExpiryJob.test.ts` | Tests: expired, about-to-expire, combined, lifecycle, error-resilience |

## Testing

Tests run entirely in memory (no database needed):

```bash
cd apps/api
bun test src/__tests__/kycExpiryJob.test.ts
```

Closes #1004