### PR TITLE
fix(contracts): oracle price staleness with typed errors and snapshots

### DIFF
--- a/apps/contracts/contracts/defi-rwa/src/access/admin.rs
+++ b/apps/contracts/contracts/defi-rwa/src/access/admin.rs
@@ -27,6 +27,18 @@ pub enum ContractError {
     NoRecoveryScheduled = 19,
     TimelockNotExpired = 20,
     TimelockOverflow = 21,
+    /// Oracle price age exceeds the configured max_age threshold
+    StalePrice = 22,
+    /// Oracle returned no price data for the requested asset
+    PriceNotAvailable = 23,
+    /// Oracle price is zero or negative
+    InvalidPrice = 24,
+    /// Normalized price is below the configured minimum floor
+    PriceBelowFloor = 25,
+    /// Oracle contract address has not been configured
+    OracleNotConfigured = 26,
+    /// Decimal normalization overflowed or underflowed
+    PriceScalingOverflow = 27,
 }
 
 pub struct AdminControl;

--- a/apps/contracts/contracts/defi-rwa/src/lending/keys.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lending/keys.rs
@@ -1,5 +1,18 @@
 use soroban_sdk::{contracttype, Address, String};
 
+/// Last validated oracle observation for an asset: normalized price + feed timestamp.
+///
+/// Persisted after a successful guarded price fetch so price and timestamp travel
+/// together in contract storage (issue #981).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct OraclePriceSnapshot {
+    /// Price normalized to 18-decimal precision
+    pub price: i128,
+    /// Timestamp reported by the SEP-40 oracle feed
+    pub timestamp: u64,
+}
+
 /// Storage key types for the lending module
 #[derive(Clone)]
 #[contracttype]
@@ -79,6 +92,10 @@ pub enum LendingKey {
     /// Minimum acceptable normalized price (floor)
     /// Storage: Instance
     OracleMinPrice,
+
+    /// Last validated oracle price snapshot (price + timestamp) for an asset
+    /// Storage: Persistent
+    LastOraclePrice(Address),
 }
 
 /// TTL bump amounts for lending storage

--- a/apps/contracts/contracts/defi-rwa/src/lending/mod.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lending/mod.rs
@@ -10,7 +10,7 @@ mod pool;
 mod positions;
 
 pub use interest::{InterestRateModel, InterestStorage, PRECISION, SECONDS_PER_YEAR};
-pub use keys::{lending_bump, LendingKey};
+pub use keys::{lending_bump, LendingKey, OraclePriceSnapshot};
 pub use oracle::PriceOracle;
 pub use pool::{LendingPool, PoolStorage};
 pub use positions::{BorrowPosition, DepositPosition, PositionStorage};

--- a/apps/contracts/contracts/defi-rwa/src/lending/oracle.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lending/oracle.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{panic_with_error, Address, Env};
 
 use crate::access::ContractError;
 
-use super::keys::{LendingKey, OraclePriceSnapshot};
+use super::keys::{lending_bump, LendingKey, OraclePriceSnapshot};
 
 /// Default maximum age for price data (1 hour in seconds).
 const DEFAULT_MAX_AGE: u64 = 3600;
@@ -78,16 +78,28 @@ impl PriceOracle {
 
     /// Persist a validated price snapshot (price + timestamp) for `asset`.
     fn store_price_snapshot(env: &Env, asset: &Address, snapshot: &OraclePriceSnapshot) {
-        env.storage()
-            .persistent()
-            .set(&LendingKey::LastOraclePrice(asset.clone()), snapshot);
+        let key = LendingKey::LastOraclePrice(asset.clone());
+        env.storage().persistent().set(&key, snapshot);
+        env.storage().persistent().extend_ttl(
+            &key,
+            lending_bump::PERSISTENT_BUMP,
+            lending_bump::PERSISTENT_BUMP,
+        );
     }
 
     /// Read the last validated oracle snapshot for `asset`, if any.
     pub fn get_last_oracle_price(env: &Env, asset: &Address) -> Option<OraclePriceSnapshot> {
-        env.storage()
-            .persistent()
-            .get(&LendingKey::LastOraclePrice(asset.clone()))
+        let key = LendingKey::LastOraclePrice(asset.clone());
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(
+                &key,
+                lending_bump::PERSISTENT_BUMP,
+                lending_bump::PERSISTENT_BUMP,
+            );
+            env.storage().persistent().get(&key)
+        } else {
+            None
+        }
     }
 
     // ─── Guarded Price Fetch ────────────────────────

--- a/apps/contracts/contracts/defi-rwa/src/lending/oracle.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lending/oracle.rs
@@ -1,7 +1,9 @@
 use sep_40_oracle::{Asset, PriceData, PriceFeedClient};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{panic_with_error, Address, Env};
 
-use super::keys::LendingKey;
+use crate::access::ContractError;
+
+use super::keys::{LendingKey, OraclePriceSnapshot};
 
 /// Default maximum age for price data (1 hour in seconds).
 const DEFAULT_MAX_AGE: u64 = 3600;
@@ -9,8 +11,11 @@ const DEFAULT_MAX_AGE: u64 = 3600;
 /// Oracle price consumer with production-grade guardrails.
 ///
 /// Every price-sensitive code path in the contract MUST go through
-/// [`get_price`] (or the equivalent [`get_guarded_price`] alias) so that
-/// staleness, validity, and floor checks are applied uniformly.
+/// [`try_get_price`] (or the panic wrappers [`get_price`] / [`get_guarded_price`])
+/// so that staleness, validity, and floor checks are applied uniformly.
+///
+/// On a successful fetch the contract also persists an [`OraclePriceSnapshot`]
+/// (normalized price + oracle timestamp) under [`LendingKey::LastOraclePrice`].
 pub struct PriceOracle;
 
 impl PriceOracle {
@@ -24,11 +29,11 @@ impl PriceOracle {
     }
 
     /// Retrieve the configured oracle address.
-    pub fn get_oracle_address(env: &Env) -> Address {
+    pub fn get_oracle_address(env: &Env) -> Result<Address, ContractError> {
         env.storage()
             .instance()
             .get(&LendingKey::OracleAddress)
-            .expect("Oracle address not configured")
+            .ok_or(ContractError::OracleNotConfigured)
     }
 
     // ─── Configurable Guardrail Parameters ──────────
@@ -69,48 +74,86 @@ impl PriceOracle {
             .unwrap_or(0_i128)
     }
 
+    // ─── Snapshot storage ───────────────────────────
+
+    /// Persist a validated price snapshot (price + timestamp) for `asset`.
+    fn store_price_snapshot(env: &Env, asset: &Address, snapshot: &OraclePriceSnapshot) {
+        env.storage()
+            .persistent()
+            .set(&LendingKey::LastOraclePrice(asset.clone()), snapshot);
+    }
+
+    /// Read the last validated oracle snapshot for `asset`, if any.
+    pub fn get_last_oracle_price(env: &Env, asset: &Address) -> Option<OraclePriceSnapshot> {
+        env.storage()
+            .persistent()
+            .get(&LendingKey::LastOraclePrice(asset.clone()))
+    }
+
     // ─── Guarded Price Fetch ────────────────────────
 
-    /// Fetch the price for `asset` with full production guardrails:
+    /// Fetch the price for `asset` with full production guardrails.
     ///
-    /// 1. Rejects missing prices (`None` from oracle).
-    /// 2. Rejects zero or negative raw prices.
-    /// 3. Rejects stale prices (age > configurable max age).
-    /// 4. Normalizes decimals to 18-decimal precision using checked math.
-    /// 5. Enforces the configurable minimum price floor after normalization.
-    pub fn get_price(env: &Env, asset: &Address) -> i128 {
-        let oracle_address = Self::get_oracle_address(env);
+    /// Returns `Result::Err` with a typed [`ContractError`] when any guardrail
+    /// fails (including staleness). On success, stores an
+    /// [`OraclePriceSnapshot`] alongside the normalized price and returns it.
+    ///
+    /// Guardrails:
+    /// 1. Oracle address must be configured
+    /// 2. Rejects missing prices (`None` from oracle)
+    /// 3. Rejects zero or negative raw prices
+    /// 4. Rejects stale prices (age > configurable max age)
+    /// 5. Normalizes decimals to 18-decimal precision using checked math
+    /// 6. Enforces the configurable minimum price floor after normalization
+    pub fn try_get_price(env: &Env, asset: &Address) -> Result<i128, ContractError> {
+        let oracle_address = Self::get_oracle_address(env)?;
         let price_feed_client = PriceFeedClient::new(env, &oracle_address);
 
         // 1. Fetch price - reject if missing
         let asset_enum = Asset::Stellar(asset.clone());
         let price_data: PriceData = price_feed_client
             .lastprice(&asset_enum)
-            .expect("Price not available for asset");
+            .ok_or(ContractError::PriceNotAvailable)?;
 
         // 2. Reject zero or negative raw price
         if price_data.price <= 0 {
-            panic!("Invalid price: price must be positive");
+            return Err(ContractError::InvalidPrice);
         }
 
         // 3. Staleness check - configurable max age
         let current_time = env.ledger().timestamp();
         let max_age = Self::get_max_age(env);
         if current_time > price_data.timestamp && (current_time - price_data.timestamp) > max_age {
-            panic!("Price data is stale");
+            return Err(ContractError::StalePrice);
         }
 
         // 4. Decimal normalization (target = 18 decimals, overflow-safe)
         let oracle_decimals = price_feed_client.decimals();
-        let normalized_price = Self::normalize_price(price_data.price, oracle_decimals);
+        let normalized_price = Self::normalize_price(price_data.price, oracle_decimals)?;
 
         // 5. Minimum price floor
         let min_price = Self::get_min_price(env);
         if min_price > 0 && normalized_price < min_price {
-            panic!("Price below minimum threshold");
+            return Err(ContractError::PriceBelowFloor);
         }
 
-        normalized_price
+        // 6. Persist price + timestamp together in contract storage
+        let snapshot = OraclePriceSnapshot {
+            price: normalized_price,
+            timestamp: price_data.timestamp,
+        };
+        Self::store_price_snapshot(env, asset, &snapshot);
+
+        Ok(normalized_price)
+    }
+
+    /// Fetch the price for `asset` with full production guardrails.
+    ///
+    /// Panic wrapper around [`try_get_price`] using typed [`ContractError`] codes
+    /// (via `panic_with_error`). Prefer [`try_get_price`] in new code that can
+    /// propagate `Result`.
+    pub fn get_price(env: &Env, asset: &Address) -> i128 {
+        Self::try_get_price(env, asset).unwrap_or_else(|e| panic_with_error!(env, e))
     }
 
     /// Canonical safe entry point - alias for [`get_price`].
@@ -126,13 +169,13 @@ impl PriceOracle {
     /// This still rejects missing prices but does **not** apply staleness,
     /// validity, or floor checks. Use only for informational / diagnostic
     /// purposes - never in risk-sensitive code paths.
-    pub fn get_raw_price_data(env: &Env, asset: &Address) -> PriceData {
-        let oracle_address = Self::get_oracle_address(env);
+    pub fn get_raw_price_data(env: &Env, asset: &Address) -> Result<PriceData, ContractError> {
+        let oracle_address = Self::get_oracle_address(env)?;
         let price_feed_client = PriceFeedClient::new(env, &oracle_address);
         let asset_enum = Asset::Stellar(asset.clone());
         price_feed_client
             .lastprice(&asset_enum)
-            .expect("Price not available for asset")
+            .ok_or(ContractError::PriceNotAvailable)
     }
 
     // ─── Internal Helpers ───────────────────────────
@@ -140,18 +183,18 @@ impl PriceOracle {
     /// Normalize a price from `oracle_decimals` to 18-decimal precision.
     ///
     /// Uses checked arithmetic to prevent silent overflow.
-    fn normalize_price(raw_price: i128, oracle_decimals: u32) -> i128 {
+    fn normalize_price(raw_price: i128, oracle_decimals: u32) -> Result<i128, ContractError> {
         let decimals_diff = 18_i32 - oracle_decimals as i32;
         if decimals_diff >= 0 {
             let scale_factor = 10_i128.pow(decimals_diff as u32);
             raw_price
                 .checked_mul(scale_factor)
-                .expect("Price scaling overflow")
+                .ok_or(ContractError::PriceScalingOverflow)
         } else {
             let scale_factor = 10_i128.pow((-decimals_diff) as u32);
             raw_price
                 .checked_div(scale_factor)
-                .expect("Price scaling underflow")
+                .ok_or(ContractError::PriceScalingOverflow)
         }
     }
 }

--- a/apps/contracts/contracts/defi-rwa/src/lib.rs
+++ b/apps/contracts/contracts/defi-rwa/src/lib.rs
@@ -17,7 +17,7 @@ mod storage;
 pub use lending::{
     events::{DepositEvent, PoolCreatedEvent, WithdrawEvent},
     lending_bump, BorrowPosition, DepositPosition, InterestRateModel, InterestStorage, LendingKey,
-    LendingPool, PoolStorage, PositionStorage, PRECISION, SECONDS_PER_YEAR,
+    LendingPool, OraclePriceSnapshot, PoolStorage, PositionStorage, PRECISION, SECONDS_PER_YEAR,
 };
 
 pub use access::*;

--- a/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -2337,20 +2337,32 @@ fn test_oracle_fresh_price() {
         MockOracleContract::set_price(t.env.clone(), t.asset_address.clone(), PRECISION, now);
     });
 
-    let price = t.env.as_contract(&t.contract_id, || {
-        PriceOracle::get_price(&t.env, &t.asset_address)
+    let result = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::try_get_price(&t.env, &t.asset_address)
     });
 
     assert_eq!(
-        price, PRECISION,
+        result,
+        Ok(PRECISION),
         "Fresh price should be returned as-is (18 dec oracle)"
     );
+
+    // Successful fetch persists price + timestamp together in storage
+    let snapshot = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::get_last_oracle_price(&t.env, &t.asset_address)
+    });
+    assert!(
+        snapshot.is_some(),
+        "Snapshot should be stored after fresh fetch"
+    );
+    let snapshot = snapshot.unwrap();
+    assert_eq!(snapshot.price, PRECISION);
+    assert_eq!(snapshot.timestamp, now);
 }
 
-// ─── Test 2: Stale price → panic ───────────────────────
+// ─── Test 2: Stale price → specific ContractError ──────
 
 #[test]
-#[should_panic(expected = "Price data is stale")]
 fn test_oracle_stale_price() {
     let t = setup_oracle_test();
 
@@ -2372,16 +2384,29 @@ fn test_oracle_stale_price() {
         );
     });
 
-    // Should panic
-    t.env.as_contract(&t.contract_id, || {
-        PriceOracle::get_price(&t.env, &t.asset_address);
+    let result = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::try_get_price(&t.env, &t.asset_address)
     });
+
+    assert_eq!(
+        result,
+        Err(ContractError::StalePrice),
+        "Stale price must fail with ContractError::StalePrice"
+    );
+
+    // Failed fetch must not write a snapshot
+    let snapshot = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::get_last_oracle_price(&t.env, &t.asset_address)
+    });
+    assert!(
+        snapshot.is_none(),
+        "Stale price must not persist a snapshot"
+    );
 }
 
-// ─── Test 3: Zero price → panic ────────────────────────
+// ─── Test 3: Zero price → InvalidPrice ─────────────────
 
 #[test]
-#[should_panic(expected = "Invalid price: price must be positive")]
 fn test_oracle_zero_price() {
     let t = setup_oracle_test();
     let now = t.env.ledger().timestamp();
@@ -2390,15 +2415,16 @@ fn test_oracle_zero_price() {
         MockOracleContract::set_price(t.env.clone(), t.asset_address.clone(), 0, now);
     });
 
-    t.env.as_contract(&t.contract_id, || {
-        PriceOracle::get_price(&t.env, &t.asset_address);
+    let result = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::try_get_price(&t.env, &t.asset_address)
     });
+
+    assert_eq!(result, Err(ContractError::InvalidPrice));
 }
 
-// ─── Test 4: Negative price → panic ───────────────────
+// ─── Test 4: Negative price → InvalidPrice ────────────
 
 #[test]
-#[should_panic(expected = "Invalid price: price must be positive")]
 fn test_oracle_negative_price() {
     let t = setup_oracle_test();
     let now = t.env.ledger().timestamp();
@@ -2407,22 +2433,25 @@ fn test_oracle_negative_price() {
         MockOracleContract::set_price(t.env.clone(), t.asset_address.clone(), -500, now);
     });
 
-    t.env.as_contract(&t.contract_id, || {
-        PriceOracle::get_price(&t.env, &t.asset_address);
+    let result = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::try_get_price(&t.env, &t.asset_address)
     });
+
+    assert_eq!(result, Err(ContractError::InvalidPrice));
 }
 
-// ─── Test 5: Missing price (no data set) → panic ──────
+// ─── Test 5: Missing price (no data set) ──────────────
 
 #[test]
-#[should_panic(expected = "Price not available for asset")]
 fn test_oracle_missing_price() {
     let t = setup_oracle_test();
 
     // Do NOT set any price - oracle will return None
-    t.env.as_contract(&t.contract_id, || {
-        PriceOracle::get_price(&t.env, &t.asset_address);
+    let result = t.env.as_contract(&t.contract_id, || {
+        PriceOracle::try_get_price(&t.env, &t.asset_address)
     });
+
+    assert_eq!(result, Err(ContractError::PriceNotAvailable));
 }
 
 // ─── Test 6: Decimal normalization - scale UP ──────────
@@ -2535,7 +2564,6 @@ fn test_oracle_configurable_max_age() {
 }
 
 #[test]
-#[should_panic(expected = "Price data is stale")]
 fn test_oracle_configurable_max_age_rejects_stale() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2560,15 +2588,20 @@ fn test_oracle_configurable_max_age_rejects_stale() {
         MockOracleContract::set_price(env.clone(), asset_address.clone(), PRECISION, 10_000 - 120);
     });
 
-    env.as_contract(&contract_id, || {
-        PriceOracle::get_price(&env, &asset_address);
+    let result = env.as_contract(&contract_id, || {
+        PriceOracle::try_get_price(&env, &asset_address)
     });
+
+    assert_eq!(
+        result,
+        Err(ContractError::StalePrice),
+        "Custom max age must reject stale prices with StalePrice"
+    );
 }
 
 // ─── Test 9: Minimum price floor ───────────────────────
 
 #[test]
-#[should_panic(expected = "Price below minimum threshold")]
 fn test_oracle_min_price_floor() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2595,9 +2628,11 @@ fn test_oracle_min_price_floor() {
         );
     });
 
-    env.as_contract(&contract_id, || {
-        PriceOracle::get_price(&env, &asset_address);
+    let result = env.as_contract(&contract_id, || {
+        PriceOracle::try_get_price(&env, &asset_address)
     });
+
+    assert_eq!(result, Err(ContractError::PriceBelowFloor));
 }
 fn advance_time(env: &Env, secs: u64) {
     let mut li = env.ledger().get();
@@ -2688,7 +2723,7 @@ fn test_oracle_guarded_price_alias() {
 // ─── Test 12: End-to-end borrow with stale oracle ──────
 
 #[test]
-#[should_panic(expected = "Price data is stale")]
+#[should_panic(expected = "Error(Contract, #22)")]
 fn test_borrow_with_stale_oracle() {
     use soroban_sdk::token::StellarAssetClient;
 
@@ -2773,7 +2808,7 @@ fn test_borrow_with_stale_oracle() {
 // ─── Test 13: End-to-end borrow with zero oracle price ─
 
 #[test]
-#[should_panic(expected = "Invalid price: price must be positive")]
+#[should_panic(expected = "Error(Contract, #24)")]
 fn test_borrow_with_zero_oracle_price() {
     use soroban_sdk::token::StellarAssetClient;
 

--- a/docs/operations/runbook-oracle-failure.md
+++ b/docs/operations/runbook-oracle-failure.md
@@ -8,19 +8,22 @@
 
 ## Symptoms
 
-An oracle incident manifests as one of four panics in the Soroban contract (Issue #729 merged - `oracle.rs` updated):
+An oracle incident manifests as a typed `ContractError` from the Soroban contract (Issues #729 / #981 - `oracle.rs`). Public entry points panic via `panic_with_error` so the host surfaces the error code/name below:
 
-| Panic message                             | Location                           | Meaning                                                        |
-| ----------------------------------------- | ---------------------------------- | -------------------------------------------------------------- |
-| `"Oracle address not configured"`         | `oracle.rs` - `get_oracle_address` | `set_oracle` was never called, or the oracle address was wiped |
-| `"Price not available for asset"`         | `oracle.rs` - `get_price`          | Oracle returned `None` for the requested asset                 |
-| `"Invalid price: price must be positive"` | `oracle.rs` - `get_price`          | Oracle returned a zero or negative raw price                   |
-| `"Price data is stale"`                   | `oracle.rs` - `get_price`          | Price timestamp exceeds the configured `max_age` threshold     |
-| `"Price below minimum threshold"`         | `oracle.rs` - `get_price`          | Normalized price is below the configured `min_price` floor     |
+| ContractError           | Code | Meaning                                                        |
+| ----------------------- | ---- | -------------------------------------------------------------- |
+| `OracleNotConfigured`   | 26   | `set_oracle` was never called, or the oracle address was wiped |
+| `PriceNotAvailable`     | 23   | Oracle returned `None` for the requested asset                 |
+| `InvalidPrice`          | 24   | Oracle returned a zero or negative raw price                   |
+| `StalePrice`            | 22   | Price timestamp exceeds the configured `max_age` threshold     |
+| `PriceBelowFloor`       | 25   | Normalized price is below the configured `min_price` floor     |
+| `PriceScalingOverflow`  | 27   | Decimal normalization overflowed or underflowed                |
 
-All five panics terminate every `borrow()` call. `deposit()`, `withdraw()`, and `repay()` are **not** affected - existing depositors and borrowers can still exit positions. Only new borrowing is blocked.
+All of these terminate every `borrow()` / `liquidate()` call that needs a price. `deposit()`, `withdraw()`, and `repay()` are **not** affected - existing depositors and borrowers can still exit positions. Only new borrowing and liquidations that reprice collateral are blocked.
 
-> **Issue #729 - merged.** The staleness threshold is now **configurable** via `set_oracle_config(caller, max_age, min_price)`. The default is `DEFAULT_MAX_AGE = 3600` seconds if `set_oracle_config` has not been called. Run `get_oracle_config()` on your deployed contract to confirm the active values before citing any specific threshold in an incident report.
+On each **successful** guarded fetch the contract also stores an `OraclePriceSnapshot` `{ price, timestamp }` under `LastOraclePrice(asset)` for observability. Stale or invalid prices are never persisted.
+
+> **Issue #729 / #981.** The staleness threshold is **configurable** via `set_oracle_config(caller, max_age, min_price)`. The default is `DEFAULT_MAX_AGE = 3600` seconds if `set_oracle_config` has not been called. Run `get_oracle_config()` on your deployed contract to confirm the active values before citing any specific threshold in an incident report.
 
 ---
 
@@ -43,13 +46,14 @@ stellar contract invoke \
   --collateral_amount 1
 ```
 
-Read the error:
+Read the error (variant name or contract error code):
 
-- `"Oracle address not configured"` → go to **Scenario A**
-- `"Price not available for asset"` → go to **Scenario B1** (oracle outage)
-- `"Invalid price: price must be positive"` → go to **Scenario C** (bad price feed)
-- `"Price data is stale"` → go to **Scenario B** (staleness)
-- `"Price below minimum threshold"` → go to **Scenario C** (price floor breach)
+- `OracleNotConfigured` / `#26` → go to **Scenario A**
+- `PriceNotAvailable` / `#23` → go to **Scenario B1** (oracle outage)
+- `InvalidPrice` / `#24` → go to **Scenario C** (bad price feed)
+- `StalePrice` / `#22` → go to **Scenario B** (staleness)
+- `PriceBelowFloor` / `#25` → go to **Scenario C** (price floor breach)
+- `PriceScalingOverflow` / `#27` → go to **Scenario C** (bad decimals / feed scale)
 - Any other error → oracle is not the root cause; check pool status and contract pause state
 
 ### 2. Check active guardrail configuration


### PR DESCRIPTION
## Summary

Closes #981

Lending collateral paths already rejected stale SEP-40 prices after #729, but rejection used plain `panic!` strings and the contract never persisted price together with its feed timestamp. This PR closes the remaining acceptance criteria for #981:

1. **Store price + timestamp in contract storage** after every successful guarded fetch
2. **Reject with `Result::Err` / typed `ContractError`** when age exceeds the configurable `max_age`
3. Keep collateral-sensitive entry points fail-closed (borrow, liquidate, health factor)

## Problem

Using a stale oracle price for collateral math enables undercollateralized borrows and unfair liquidations. The issue required:

- Timestamp stored alongside price
- Explicit `Result::Err` when the observation is older than N seconds
- Tests for fresh (pass) and stale (specific error)

## Changes

### `oracle.rs`
- Added `try_get_price` → `Result<i128, ContractError>` as the canonical guarded path
- Stale observations return `Err(ContractError::StalePrice)` (configurable `max_age`, default 3600s)
- On success, persists `OraclePriceSnapshot { price, timestamp }` under `LendingKey::LastOraclePrice(asset)`
- `get_price` / `get_guarded_price` remain panic wrappers via `panic_with_error` (Soroban host error codes)
- Other guardrails mapped to typed errors: `PriceNotAvailable`, `InvalidPrice`, `PriceBelowFloor`, `OracleNotConfigured`, `PriceScalingOverflow`

### Storage (`keys.rs`)
- `OraclePriceSnapshot` contract type
- `LendingKey::LastOraclePrice(Address)` (persistent)

### `ContractError` (`admin.rs`)
| Variant | Code |
|---------|------|
| `StalePrice` | 22 |
| `PriceNotAvailable` | 23 |
| `InvalidPrice` | 24 |
| `PriceBelowFloor` | 25 |
| `OracleNotConfigured` | 26 |
| `PriceScalingOverflow` | 27 |

### Tests
- Fresh price → `Ok(price)` and snapshot stored with matching timestamp
- Stale price → `Err(ContractError::StalePrice)` (no snapshot written)
- Configurable max age, zero/negative/missing prices, min floor → typed errors
- E2E borrow with stale/zero oracle → host `Error(Contract, #22)` / `#24`

### Docs
- Runbook updated for typed `ContractError` codes instead of string panics

## Design notes

- **No dual price path**: risk decisions always re-fetch SEP-40; the snapshot is observational only (never used as a stale local cache for LTV/liquidation)
- **No public API break**: `borrow` / `liquidate` still panic at the entry boundary with typed codes (same pattern as admin/pause)
- Builds on #729 guardrails rather than reimplementing them

## Acceptance criteria

- [x] Collateral calculation fails explicitly if the price is older than N seconds
- [x] Tests cover a fresh price (passes) and a stale price (fails with a specific error)
- [x] Timestamp stored alongside the price in storage
- [x] Rejection via `Result::Err` (`try_get_price`)

## Verification

```text
cargo fmt --all -- --check
cargo clippy --package rwa-defi-contract --all-targets --all-features -- -D warnings
cargo test --package rwa-defi-contract --lib
# 138 passed
```

## Test plan

- [x] Unit: fresh price returns `Ok` and stores snapshot
- [x] Unit: stale price returns `Err(StalePrice)` and does not store snapshot
- [x] Unit: custom `max_age` enforces staleness
- [x] E2E: `borrow` fails with contract error `#22` on stale oracle
- [x] E2E: `borrow` fails with contract error `#24` on zero oracle price
- [x] Full `rwa-defi-contract` lib suite green (138 tests)
- [ ] CI: Smart Contracts workflow on this PR