### PR TITLE
docs(planning): add cycle 6 pilot launch readiness issue specs

### DIFF
--- a/docs/planning/cycles/cycle-6/CYCLE_6_OVERVIEW.md
+++ b/docs/planning/cycles/cycle-6/CYCLE_6_OVERVIEW.md
@@ -1,0 +1,111 @@
+# Cycle 6: Pilot Launch Readiness
+
+## Overview
+
+| Attribute     | Value                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| Cycle Number  | 6                                                                                              |
+| Total Issues  | 8                                                                                              |
+| Focus Areas   | Pilot smart contracts, pilot UX, treasury track, design system parity, security, developer experience |
+| Prerequisites | `docs/strategy/product-brief.md`, `docs/strategy/roadmap.md`, `docs/design-system/` (all shipped in the prior cycle) |
+
+## Objective
+
+Cycle 6 takes Akkuea from "strategy documented" to "pilot launchable." Every issue in this cycle exists because `docs/strategy/product-brief.md` names it as required Phase 1 scope, `docs/strategy/roadmap.md` names it as Phase 1a, or the founder named it directly: professional diagramming, Akkuea Land's visual parity with the main design system, and a proper environment-variable guide for contributors.
+
+This cycle deliberately does **not** touch anything `docs/strategy/roadmap.md` marks as Phase 2 (token transferability, jurisdiction formalization, multi-tenancy, oracle automation). Building any of that now would repeat the exact premature-platformization mistake this project's own research already rejected once.
+
+Each issue in this cycle is scoped to be large and complete rather than split into artificially small slices: every pull request produced from this cycle is expected to add on the order of 4,000+ lines (implementation plus the test coverage this project's own CI already requires), because that is what it actually takes to ship a Soroban contract suite, a production frontend surface, or a real third-party integration to the quality bar this project holds itself to.
+
+## Application Structure (new/changed by this cycle)
+
+```
+apps/
+  contracts/contracts/
+    pilot-income-token/       ← new (C6-001)
+    pilot-whitelist/          ← new (C6-001)
+    pilot-payout-split/       ← new (C6-001)
+  webapp/src/
+    app/[locale]/pilot/       ← new: dashboard + onboarding routes (C6-002, C6-008)
+    components/pilot/         ← new: evidence, cycle-status, onboarding components (C6-002, C6-008)
+    components/treasury/      ← new: DeFindex/EtherFuse panel (C6-003)
+  akkuea-land/src/            ← migrated onto shared design tokens (C6-005)
+  api/src/
+    services/TreasuryService.ts        ← new (C6-003)
+    routes/whitelist.ts, routes/evidence.ts  ← new (C6-008, C6-002)
+  shared/src/
+    env/                      ← new: env schema + validator (C6-007)
+scripts/
+  diagrams/                   ← new: Python + Graphviz pipeline (C6-004)
+docs/
+  ENV_SETUP.md                ← new (C6-007)
+  diagrams/                   ← new: generated SVG/PNG output, vertical + horizontal (C6-004)
+```
+
+## Issue Distribution by Area
+
+| Area      | Count | Issues                          |
+| --------- | ----- | -------------------------------- |
+| CONTRACT  | 1     | C6-001                           |
+| WEBAPP    | 3     | C6-002, C6-005, C6-008           |
+| API       | 2     | C6-003, C6-006                   |
+| TOOLING   | 2     | C6-004, C6-007                   |
+
+## Issue Distribution by Difficulty
+
+All eight issues are High: every one spans multiple modules, requires design decisions, and carries real architectural weight. None of this cycle's scope is Trivial or Medium work.
+
+## Issues Summary
+
+| ID     | Title                                                              | Area     | Difficulty | Dependencies |
+| ------ | ------------------------------------------------------------------- | -------- | ---------- | ------------ |
+| C6-001 | Implement the pilot's income token, whitelist, and payout-split contracts | CONTRACT | High       | None         |
+| C6-002 | Build the pilot's read-only dashboard for allies and investors    | WEBAPP   | High       | C6-001       |
+| C6-003 | Integrate the Phase 1a treasury track (DeFindex + EtherFuse)       | API      | High       | None         |
+| C6-004 | Build the professional diagram generation pipeline                 | TOOLING  | High       | None         |
+| C6-005 | Align Akkuea Land with the webapp design system                    | WEBAPP   | High       | None         |
+| C6-006 | Close the KYC enforcement gaps and remediate dependency vulnerabilities | API      | High       | None         |
+| C6-007 | Ship an environment variable guide, boot-time validation, and CI quality gates | TOOLING  | High       | None         |
+| C6-008 | Build the self-serve whitelist and investor onboarding flow        | WEBAPP   | High       | C6-001       |
+
+## Acceptance Criteria for Cycle Completion
+
+| Criteria                              | Description                                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Pilot contracts deployed to testnet     | Income token, whitelist, and payout-split contracts live and verified on Stellar testnet            |
+| Pilot dashboard functional              | An ally can submit evidence and an investor can see holdings, distributions, and cycle status, end to end on testnet |
+| Treasury visible on-chain                | The accumulated platform fee balance is verifiably deposited in DeFindex and/or EtherFuse, checkable on stellar.expert |
+| Diagrams shipped                        | Every diagram in `docs/strategy/`, `docs/architecture/`, and the README has both a vertical and a horizontal rendering |
+| Akkuea Land visually matches webapp     | Akkuea Land uses the same color tokens, typography, and (where applicable) shared components as `apps/webapp` |
+| No open known-gap in KYC enforcement    | `POST /kyc/verify/:documentId` requires authentication; `buyShares` enforces `kycStatus === 'approved'` |
+| Dependency audit shrinks                | `audit-allowlist.txt` no longer lists any advisory with an available non-breaking patch |
+| Env guide exists and is enforced        | `docs/ENV_SETUP.md` documents every variable's source; the API and webapp fail fast with a clear message if a required variable is missing |
+| Onboarding flow functional              | A new investor can request whitelist approval, and an operator can approve or reject it, without touching `curl` |
+| All five required workflows pass        | `monorepo-ci.yml`, `api-ci.yml`, `webapp-ci.yml`, `shared-ci.yml`, `contracts-ci.yml` all green on every PR from this cycle |
+
+## Dependencies Between Issues
+
+| Issue          | Depends On |
+| --------------- | ---------- |
+| C6-002, C6-008 | C6-001     |
+
+Everything else is independently startable and parallelizable across contributors.
+
+## Parallel Workstreams
+
+| Contributor Focus        | Recommended Issues                       |
+| -------------------------- | ------------------------------------------ |
+| Soroban / Rust              | C6-001 (then unblocks C6-002, C6-008)      |
+| Frontend, pilot surface     | C6-002, C6-008 (after C6-001 lands)         |
+| Backend / integrations      | C6-003, C6-006                              |
+| Tooling / documentation     | C6-004, C6-007                              |
+| Frontend, Akkuea Land        | C6-005                                      |
+
+## Notes
+
+- Every issue in this cycle must comply with `CLAUDE.md`: no em dash, no emojis (icons via `lucide-react` are fine), follow `docs/design-system/` for any UI work, and all five CI workflows must pass before the work is considered done.
+- C6-001's three contracts are a new, independent system. They are not a modification of the existing `defi-rwa` contract, per the separation decision recorded in `docs/strategy/product-brief.md`.
+- C6-002 and C6-008 both consume the whitelist and payout-split contracts from C6-001; coordinate the contract interface early so frontend work isn't blocked on the full contract implementation.
+- C6-004's diagrams are not decoration. They are the primary way this project explains itself to real estate allies, investors, and grant reviewers who will not read Rust or TypeScript.
+- C6-005 must not introduce a second component library. Reuse `apps/webapp/src/components/ui` where the two apps' needs genuinely overlap; only build Akkuea Land-specific components where they don't.
+- Never commit an actual `.env` file or a real secret value in any issue from this cycle, including C6-007, whose entire point is explaining where secrets come from without ever containing one.

--- a/docs/planning/cycles/cycle-6/issues/issue-001/ISSUE_001.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-001/ISSUE_001.md
@@ -1,0 +1,31 @@
+# Implement the Pilot's Income Token, Whitelist, and Payout-Split Contracts
+
+## Context
+
+`docs/strategy/product-brief.md` defines Akkuea's actual near-term product: a single allied real estate agency issues a non-transferable token representing a share of one property's rental income, investors buy in, and a payout-split contract distributes 90% of each monthly, human-reviewed, hashed income cycle to holders pro-rata while retaining a 10% platform fee. None of that exists in code yet. The `defi-rwa` contract in this repository implements a different product (fractional equity shares plus a collateralized DeFi lending protocol) and is explicitly not reused for the pilot, per the separation decision recorded in the product brief.
+
+This issue builds the three contracts the pilot actually needs, as an independent system inside `apps/contracts`.
+
+## What Needs to Be Done
+
+Implement three Soroban contracts:
+
+1. **Income-participation token** (SEP-41-style, non-transferable): mints a fixed supply of participation units to the pilot ally's approved holder set, with `transfer` disabled (or reduced to admin-only, for the extraordinary correction case) rather than open. No holder-snapshot logic is needed since the holder set is fixed after mint.
+2. **Whitelist contract**: a simple approved/not-approved mapping per Stellar address, admin-gated writes, a public read for "is this address approved." This is the on-chain half of the minimum-defensible KYC decision in the product brief; the off-chain review process is out of this issue's scope (see C6-008).
+3. **Payout-split contract**: accepts a reference to a monthly income-evidence record (a link plus a cryptographic hash, both stored on-chain, never the underlying file), an admin-approved distribution amount, deducts a 10% platform fee, and distributes the remaining 90% pro-rata across the token contract's current holder set in USDC (SEP-41 token transfer), with an EURC-via-swap path stubbed for a fast-follow rather than built now. Distribution approval uses Soroban's native multi-sig auth for a two-signer check (operator plus ally), not a single admin key, closing Known Risk #7 in the product brief from day one rather than retrofitting it later.
+
+## Acceptance Criteria
+
+- All three contracts compile with `stellar contract build` and deploy successfully to testnet.
+- The payout-split contract correctly computes the 10% fee and pro-rata distribution across a holder set of at least 5 test addresses with uneven balances, verified by test assertions on exact output amounts, not just "it doesn't panic."
+- The whitelist contract rejects distribution to any address not marked approved.
+- The token contract rejects any transfer attempt from a non-admin caller.
+- Two-signer approval on the payout-split contract is enforced: a distribution cannot execute with only one of the two required signatures.
+- Unit tests cover every documented failure mode: unapproved recipient, insufficient evidence hash, single-signer attempt, zero-amount distribution, double-distribution for the same cycle.
+- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` pass with zero warnings.
+- Contract IDs and deployment record are added to `apps/shared/src/contracts.testnet.json` following the existing pattern, and `docs/deployment/` gains a deployment guide for this contract set, matching the structure of `docs/deployment/deploy-contracts.md`.
+- All five required CI workflows pass on the pull request.
+
+## Quality Standard
+
+This is the contract real investor money will move through. Every arithmetic operation must use checked math (no silent overflow/underflow, following the existing `defi-rwa` pattern). Every state-changing function must emit an event. No `unwrap()` on any value that can plausibly be `None` or `Err` in production; use the project's typed error pattern (see `docs/operations/runbook-oracle-failure.md` for the typed-error precedent already established in `defi-rwa`). This is the highest-stakes code in the repository; treat it accordingly.

--- a/docs/planning/cycles/cycle-6/issues/issue-001/ISSUE_001_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-001/ISSUE_001_DETAILED.md
@@ -1,0 +1,60 @@
+# C6-001: Implement the Pilot's Income Token, Whitelist, and Payout-Split Contracts
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-001                          |
+| Area            | CONTRACT                        |
+| Difficulty      | High                             |
+| Labels          | smart-contract, contracts, soroban, high |
+| Dependencies    | None                             |
+| Estimated Lines | 4500-6500 (implementation, tests, deployment scripts, docs) |
+
+**Description**
+
+Implement the pilot's own contract surface: `pilot-income-token`, `pilot-whitelist`, and `pilot-payout-split`, three independent Soroban contracts under `apps/contracts/contracts/`, replacing nothing in `defi-rwa`.
+
+**Requirements and context**
+
+- `pilot-income-token`: SEP-41-compatible read surface (`balance`, `name`, `symbol`, `decimals`, `total_supply`) but `transfer` restricted to admin-only (non-transferable in v1, per the product brief). Mint is a one-time, admin-only operation against the whitelist's approved set.
+- `pilot-whitelist`: `approve(admin, address)`, `revoke(admin, address)`, `is_approved(address) -> bool`. Admin-gated writes, public reads.
+- `pilot-payout-split`: `record_evidence(caller_1, caller_2, cycle_id, evidence_hash, evidence_link, total_income)` requiring both operator and ally signatures (two-signer, native Soroban multi-sig auth via `require_auth` on both addresses), `execute_distribution(cycle_id)` which computes `fee = total_income * 10 / 100`, `remaining = total_income - fee`, and transfers `remaining` pro-rata to every address the income-token contract reports as a current holder, in USDC (invoke the SEP-41 `transfer` on the USDC SAC).
+- Enforce access control using role checks (operator address, ally address, both stored at contract init), consistent with the `defi-rwa` contract's `access/roles.rs` pattern.
+- Include reentrancy protection where external calls are made (the USDC transfer in `execute_distribution`).
+- Prevent panic on overflow/underflow; use checked arithmetic throughout the fee and pro-rata math.
+- Include an admin-controlled pause function on `pilot-payout-split`, mirroring the `emergency_pause` pattern in `defi-rwa` (same 24-hour timelock philosophy is not required here since this is a smaller, lower-blast-radius contract, but a simple pause/unpause gate is).
+
+**Suggested execution**
+
+1. `git checkout -b feature/pilot-contracts-income-token-whitelist-payout-split`
+2. Scaffold three new crates under `apps/contracts/contracts/pilot-income-token/`, `pilot-whitelist/`, `pilot-payout-split/`, each with its own `Cargo.toml`, following the existing `game-*` contracts as the structural template (they're the most recent addition to this workspace and already establish the multi-contract-per-workspace pattern).
+3. Implement `pilot-whitelist` first (no dependencies on the other two).
+4. Implement `pilot-income-token`, reading the whitelist contract's `is_approved` at mint time via cross-contract call.
+5. Implement `pilot-payout-split`, reading both the whitelist and the income-token contract's holder set via cross-contract calls.
+6. Add comprehensive contract-level and function-level doc comments to all three.
+7. Write `apps/contracts/contracts/pilot-payout-split/tests/` covering the acceptance criteria's failure modes explicitly, plus a full happy-path integration test that mints, approves five holders with uneven balances, records evidence, and asserts exact per-holder payout amounts after the 10% fee.
+8. Write a deployment script following `scripts/deploy-game-contracts.sh` as the template, and a corresponding `docs/deployment/deploy-pilot-contracts.md`.
+9. Record the testnet deployment in `apps/shared/src/contracts.testnet.json` and `docs/contracts/deployment.md`, following the existing deployment-record format.
+
+**Test and commit**
+
+- [ ] All unit tests pass (`cargo test`)
+- [ ] 100% branch coverage on new/changed logic
+- [ ] Contracts compile with the current stable Soroban SDK version and `stellar contract build` (target `wasm32v1-none`)
+- [ ] Soroban CLI simulation succeeds for every public function
+- [ ] No high/medium severity issues from `cargo clippy`
+- [ ] Invocation budget for `execute_distribution` stays within a reasonable bound for a holder set of realistic size (document the tested holder-count ceiling)
+- [ ] Two-signer enforcement is proven by a test that submits only one signature and asserts rejection
+
+Example commit:
+`git commit -m "feat(contracts): implement pilot income token, whitelist, and payout-split contracts"`
+
+**Guidelines**
+
+- Use the current stable Soroban SDK version already pinned in `apps/contracts/Cargo.toml` / workspace lockfile.
+- Never hardcode secret or private keys in source, tests, or deployment scripts.
+- All public and external functions must have full doc comments.
+- PR description must include simulation output and budget usage for `execute_distribution` and `mint`, the two functions most likely to be cost-sensitive.
+- Tests must cover failure modes and edge cases, not only the happy path.
+- Do not add a token-transferability path, even behind a flag. It is explicitly Phase 2 scope.

--- a/docs/planning/cycles/cycle-6/issues/issue-002/ISSUE_002.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-002/ISSUE_002.md
@@ -1,0 +1,28 @@
+# Build the Pilot's Read-Only Dashboard for Allies and Investors
+
+## Context
+
+`docs/strategy/product-brief.md` is explicit about the dashboard's shape: read-only, driven entirely by on-chain events and RPC, no investor accounts, no separate database. It must show each income cycle's status (on-time, late, disputed, not received) against an explicit expected date, not just a final balance, because the pilot's entire credibility argument rests on investors seeing a pattern of reliability rather than an isolated number. The same read-only model must surface the ally's evidence-submission state (submitted, in review, approved or rejected with a reason) and an explicit escalation state if the ally goes two cycles without reporting. None of this exists yet; today the only way to interact with anything KYC- or evidence-related is a raw `curl` command from documentation.
+
+## What Needs to Be Done
+
+Build a new pilot surface inside `apps/webapp` (new routes under `app/[locale]/pilot/`, new components under `components/pilot/`):
+
+- **Ally view**: submit monthly income evidence (a link plus the evidence file, hashed client-side or server-side before the hash is written on-chain), see the review status of past submissions.
+- **Operator/reviewer view**: a review queue for pending evidence, approve or reject with a reason, trigger a distribution once evidence is approved and the second signature (ally's) is available.
+- **Investor view**: token holdings, a per-cycle timeline (using the `Stepper` component from the design system, not a plain list) showing on-time/late/disputed/not-received status against the expected date, and total distributions received to date. Reuse `PropertyViewer3D` (`apps/webapp/src/components/property/PropertyViewer3D.tsx`) as a second, independent evidence channel on the ally's property, letting an investor see the actual property alongside the hashed income statement.
+- All three views read exclusively from Soroban RPC and contract events emitted by the C6-001 contracts; there is no new database table and no new investor-accounts concept.
+
+## Acceptance Criteria
+
+- An ally can submit evidence for a cycle and see it move through submitted, in review, and approved/rejected states, reflecting real on-chain state from the C6-001 payout-split contract.
+- An investor can see their holdings and a cycle-by-cycle status timeline that correctly reflects on-time, late, disputed, and not-received states, computed from on-chain data plus the expected monthly date.
+- The dashboard shows an explicit "ally has not reported in two cycles" escalation state when that condition is met on-chain.
+- No new database table is introduced for this feature; all state is derived from Soroban RPC calls and event subscriptions.
+- Every interactive element handles loading, error, empty, and disconnected-wallet states, matching the existing frontend template's acceptance bar.
+- All new components have Storybook stories and use the design-system tokens and components documented in `docs/design-system/`, not one-off styling.
+- All five required CI workflows pass on the pull request.
+
+## Quality Standard
+
+This is the product's actual trust surface. Every status shown must be traceable to a specific on-chain fact, never inferred or approximated client-side without a clear fallback/freshness indicator (`FreshnessIndicator` exists in the design system precisely for this). No mock data may ship in the merged version; if the C6-001 contracts aren't deployed to testnet yet when this work starts, build against a documented contract interface and swap in the real testnet deployment before merge, not after.

--- a/docs/planning/cycles/cycle-6/issues/issue-002/ISSUE_002_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-002/ISSUE_002_DETAILED.md
@@ -1,0 +1,54 @@
+# C6-002: Build the Pilot's Read-Only Dashboard for Allies and Investors
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-002                          |
+| Area            | WEBAPP                          |
+| Difficulty      | High                             |
+| Labels          | frontend, high                   |
+| Dependencies    | C6-001                           |
+| Estimated Lines | 4000-5500 (components, hooks, RPC integration, tests, stories) |
+
+**Description**
+
+Implement the ally evidence-submission flow, the operator review queue, and the investor holdings/cycle-status view, entirely on top of the C6-001 contracts, entirely off on-chain state.
+
+**Requirements and context**
+
+- New routes: `app/[locale]/pilot/ally/page.tsx`, `app/[locale]/pilot/review/page.tsx`, `app/[locale]/pilot/investor/page.tsx` (naming may be adjusted to match existing `[locale]` route conventions in `apps/webapp/src/app`).
+- Data layer: a new `hooks/usePilotContract.ts` (or a small set of hooks) wrapping Soroban RPC reads and event subscriptions against the C6-001 contract addresses, following the existing pattern in `apps/webapp/src/services/wallet/` and `hooks/useLendingPools.ts` for API-call shape and error handling, but pointed at RPC/events instead of the internal API.
+- Evidence hashing: hash the evidence file client-side (or via a thin API route that only computes and returns a hash, never persists the file) before it is written on-chain by the ally's transaction.
+- Cycle-status derivation: a pure function (place it in `apps/shared/src/utils/` so it's testable independent of React and reusable if the API ever needs the same computation) that takes on-chain cycle records plus "today" and returns one of `on-time | late | disputed | not-received`, plus the two-cycles-missed escalation boolean.
+- UI: `Stepper` for cycle-by-cycle progress, `FreshnessIndicator` on any RPC-derived value, `EmptyState` for a new investor with no holdings yet, `PageErrorFallback` / `SectionErrorFallback` around each of the three views so one failing RPC call doesn't take down the whole page.
+- Wire `PropertyViewer3D` into the investor view, passing the ally property's `splatUrl` if one exists (this may not exist yet for the pilot ally; handle its absence gracefully with a documented empty state, don't block the rest of the page on it).
+
+**Suggested execution**
+
+1. `git checkout -b feature/pilot-dashboard-ally-operator-investor`
+2. Confirm the C6-001 contract interface (function signatures, event shapes) before writing hooks against it; coordinate directly with whoever is on C6-001 if it's still in progress.
+3. Build the cycle-status derivation utility in `apps/shared/src/utils/pilotCycleStatus.ts` first, with its own unit tests, independent of any UI.
+4. Build `usePilotContract.ts` (or equivalent) for reads and event subscriptions.
+5. Build the ally view, then the operator review queue, then the investor view, each using the corresponding hook and the design-system components.
+6. Add Storybook stories for every new component covering loading, error, empty, and populated states.
+7. Wire `PropertyViewer3D` into the investor view's evidence section.
+
+**Test and commit**
+
+- [ ] Component tests cover all four states (loading, error, empty, populated) for each of the three views
+- [ ] `pilotCycleStatus` utility has unit tests covering every documented status transition and the two-cycle escalation boundary
+- [ ] Manual verification against a real testnet deployment of the C6-001 contracts (not mocked) before merge
+- [ ] All interactive elements are disabled during loading/disconnected-wallet states
+- [ ] Visual check in both light and dark theme (see `docs/design-system/foundations.md`)
+- [ ] All new strings are added to i18n files, consistent with the existing `[locale]` routing pattern
+
+Example commit:
+`git commit -m "feat(webapp): add pilot ally, review, and investor dashboard views"`
+
+**Guidelines**
+
+- Use existing component library primitives (`apps/webapp/src/components/ui`) before adding new ones; only add a new component if nothing existing fits.
+- No inline styles except for genuinely dynamic values; use the CSS custom properties documented in `docs/design-system/foundations.md`.
+- No new database table, no new investor-account concept. If a reviewer suggests one, that's a signal the requirement has drifted from `docs/strategy/product-brief.md`; stop and re-check the brief.
+- PR must include before/after screenshots (or a short screen recording) of all three views in the description.

--- a/docs/planning/cycles/cycle-6/issues/issue-003/ISSUE_003.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-003/ISSUE_003.md
@@ -1,0 +1,24 @@
+# Integrate the Phase 1a Treasury Track (DeFindex + EtherFuse)
+
+## Context
+
+`docs/strategy/roadmap.md` defines Phase 1a as a fast, parallel track independent of the core pilot: deposit the accumulated platform fee into DeFindex's already-audited Blend strategy and/or EtherFuse's Stablebonds, generating real, verifiable on-chain activity almost immediately, using only contracts that are already deployed and already audited. `docs/strategy/integration-decisions.md` and `docs/strategy/recommendations.md` are explicit that this is not framed as "generating metrics" for its own sake; it is honest treasury management that happens to produce checkable on-chain history, and that honest framing must carry through to how it's built and surfaced, not just how it's described in a strategy document.
+
+## What Needs to Be Done
+
+- Build a `TreasuryService` in `apps/api/src/services/` that can deposit a specified amount into DeFindex's Blend strategy vault and into EtherFuse Stablebonds, and read back current position value from both.
+- Add API endpoints exposing treasury position and history (read-only; deposit/withdraw remain admin-triggered, following the same admin-key pattern already used for `defi-rwa` operations).
+- Build a small treasury panel in `apps/webapp` (or the pilot dashboard from C6-002, if that work has landed first) showing current treasury value, a link to the DeFindex/EtherFuse position on stellar.expert, and a short, honest description of what the treasury track is and why it exists, matching the framing in `docs/strategy/roadmap.md`.
+- Verify both integrations against DeFindex's and EtherFuse's actual testnet-deployed contracts (or mainnet, if that's where the real platform fee balance will live); do not build against a mocked or assumed interface.
+
+## Acceptance Criteria
+
+- A deposit into DeFindex's Blend strategy and a deposit into EtherFuse Stablebonds both execute successfully against real, already-deployed contracts and are independently verifiable on stellar.expert.
+- The API correctly reads back current treasury position value from both integrations.
+- The treasury panel displays real position data, not placeholder numbers, and links out to the on-chain record.
+- Integration tests exist against both DeFindex and EtherFuse, exercising the actual contract call paths (not mocks), consistent with this project's standing rule to verify third-party integrations via primary sources rather than assumptions.
+- All five required CI workflows pass on the pull request.
+
+## Quality Standard
+
+This is the first piece of the pilot to touch real third-party DeFi contracts with real funds. Every external call must handle the failure modes those contracts can actually produce (insufficient liquidity, paused vault, stale price feed if applicable), not just the happy path. The honest framing established in `docs/strategy/roadmap.md` (treasury management that happens to be checkable, not metrics-farming) must be reflected in the actual UI copy, not softened into something more promotional.

--- a/docs/planning/cycles/cycle-6/issues/issue-003/ISSUE_003_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-003/ISSUE_003_DETAILED.md
@@ -1,0 +1,51 @@
+# C6-003: Integrate the Phase 1a Treasury Track (DeFindex + EtherFuse)
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-003                          |
+| Area            | API                              |
+| Difficulty      | High                             |
+| Labels          | backend, soroban, high           |
+| Dependencies    | None                              |
+| Estimated Lines | 4000-5000 (service layer, integration tests, API routes, panel UI) |
+
+**Description**
+
+Implement `TreasuryService`, wiring real deposits and position reads against DeFindex's Blend strategy and EtherFuse's Stablebonds, plus the API surface and a UI panel to make the resulting on-chain activity visible.
+
+**Requirements and context**
+
+- New service: `apps/api/src/services/TreasuryService.ts`, following the existing `StellarService.ts` pattern for how contract calls are built, signed, and submitted.
+- DeFindex integration: deposit into the `Blend` strategy of `defindex-io/stellar-contracts` (verify current contract addresses directly from their repo or deployment records, per this project's standing verify-before-integrating rule; do not assume an address from memory or an outdated source).
+- EtherFuse integration: acquire Stablebonds (CETES or another EtherFuse-issued asset) as a classic Stellar asset via SDEX, consistent with how EtherFuse assets are documented as trading in `docs/strategy/roadmap.md`.
+- New endpoints: `GET /internal/operations/treasury` (position summary, admin-gated like the existing `/internal/operations/properties` pattern), `POST /internal/operations/treasury/deposit` (admin-gated, triggers a deposit).
+- New panel component in `apps/webapp` (place under `components/treasury/`, or under `components/pilot/` if C6-002 has already established that directory structure).
+
+**Suggested execution**
+
+1. `git checkout -b feature/treasury-defindex-etherfuse-integration`
+2. Verify DeFindex's current mainnet/testnet contract addresses and interface directly from `defindex-io/stellar-contracts`, not from this issue's description (addresses can change).
+3. Verify EtherFuse's current Stablebond asset issuers and trading path directly from their published documentation or stellar.expert, following the same verification standard.
+4. Implement the deposit and position-read paths in `TreasuryService`, one integration at a time, with integration tests against each before moving to the next.
+5. Add the two admin-gated API routes.
+6. Build the treasury panel UI, reusing `FreshnessIndicator` for position data and linking out to stellar.expert for the underlying contract.
+
+**Test and commit**
+
+- [ ] Integration tests exercise the actual DeFindex and EtherFuse contract call paths (real testnet or mainnet contracts, not mocks)
+- [ ] Unit tests cover TreasuryService's error handling for each documented external failure mode
+- [ ] API routes return correct status codes and are admin-gated the same way existing `/internal/operations/*` routes are
+- [ ] Treasury panel renders real position data and correctly links to stellar.expert
+- [ ] Soroban interaction errors are mapped to appropriate HTTP status codes, consistent with the existing error-mapping convention in `apps/api/src/errors/`
+
+Example commit:
+`git commit -m "feat(api): integrate DeFindex Blend and EtherFuse Stablebonds treasury deposits"`
+
+**Guidelines**
+
+- Never commit secrets, private keys, or hardcoded credentials.
+- Use the existing service-layer patterns already established for `defi-rwa` interactions in `StellarService.ts`.
+- All new endpoints must have OpenAPI documentation, consistent with the rest of the API.
+- Keep controller methods short and focused; push contract-interaction complexity into the service layer.

--- a/docs/planning/cycles/cycle-6/issues/issue-004/ISSUE_004.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-004/ISSUE_004.md
@@ -1,0 +1,28 @@
+# Build the Professional Diagram Generation Pipeline
+
+## Context
+
+Every strategic and architectural document this project has (`docs/strategy/`, `docs/architecture/system-architecture.md`, `docs/deployment/`) currently explains itself in prose and ASCII boxes. That's usable for a developer but not for the audiences this project actually needs to convince: a real estate agency ally, an investor, a grant reviewer. This project's own documentation standard already commits to "proper diagrams (mermaid sequence and architecture diagrams)" as a requirement, but mermaid alone doesn't produce presentation-quality output, and nothing in the repository currently generates a diagram in a form suitable for a slide deck.
+
+This issue builds a real diagram-as-code pipeline in Python and Graphviz, following the pattern already proven at [LumenWipe's `render-all.py`](https://github.com/LumenWipe/lumenwipe/blob/main/apps/web/scripts/diagrams/render-all.py): diagrams defined as code, versioned, regenerated on demand, never hand-drawn and never manually re-exported.
+
+## What Needs to Be Done
+
+- Build `scripts/diagrams/` at the repository root: a Python package with one module per diagram, a shared style module (colors, fonts, node shapes) that mirrors the actual design-system tokens in `docs/design-system/foundations.md` so the diagrams look like they belong to this product, and a `render-all.py` entry point that regenerates every diagram in one run.
+- Every diagram must be produced in two layouts: **vertical** (tall, narrow, optimized for embedding in a README or a docs page) and **horizontal** (wide, optimized for a presentation slide). Same content, same styling, different orientation and aspect ratio.
+- Diagram set (minimum, more are welcome): system architecture (the five-app monorepo), the pilot's monthly payout-cycle sequence, the tokenization/mint sequence, the whitelist/KYC review flow, the Phase 1a treasury flow, the Phase 1 to Phase 2 roadmap timeline, the deployment topology (testnet vs. mainnet), and the monorepo/workspace structure.
+- Output to `docs/diagrams/` as both SVG (for docs, scales cleanly) and PNG (for presentations, universally embeddable), with a clear vertical/horizontal naming convention.
+- Embed the vertical versions into the relevant docs (`docs/strategy/product-brief.md`, `docs/strategy/roadmap.md`, `docs/architecture/system-architecture.md`, the root `README.md`), replacing the existing ASCII-art boxes and Mermaid diagrams where a Graphviz version now covers the same content at higher quality. Mermaid diagrams that describe something better suited to a live-rendered sequence (where GitHub's native Mermaid rendering is actually the better reading experience) may stay; use judgment, don't remove Mermaid diagrams reflexively.
+
+## Acceptance Criteria
+
+- `python scripts/diagrams/render_all.py` (or equivalent entry point) regenerates every diagram from a clean checkout with no manual steps.
+- Every diagram exists in both a vertical and a horizontal rendering.
+- Diagram styling (colors, fonts) is driven by a shared style module referencing the actual tokens in `docs/design-system/foundations.md`, not arbitrary Graphviz defaults.
+- At least the eight diagrams listed above exist and are embedded in the relevant documentation.
+- A short `scripts/diagrams/README.md` explains how to add a new diagram and how to regenerate the set, so this doesn't become a one-time artifact nobody knows how to update.
+- All five required CI workflows pass on the pull request (a CI step that regenerates diagrams and fails if the committed output is stale is a strong option, but not mandatory for this issue).
+
+## Quality Standard
+
+These diagrams are a first-class communication tool for non-technical stakeholders, not internal engineering notes. Every diagram must be legible at the size it will actually be viewed (a slide projected in a room, a README on a phone screen), use consistent iconography and color meaning across the whole set, and avoid unexplained jargon in labels, the same discipline `docs/strategy/decision-log.md` records Bri applying to the ally-facing one-pager.

--- a/docs/planning/cycles/cycle-6/issues/issue-004/ISSUE_004_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-004/ISSUE_004_DETAILED.md
@@ -1,0 +1,60 @@
+# C6-004: Build the Professional Diagram Generation Pipeline
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-004                          |
+| Area            | TOOLING                          |
+| Difficulty      | High                             |
+| Labels          | documentation, high              |
+| Dependencies    | None                              |
+| Estimated Lines | 4000-5500 (Python diagram definitions, style module, generated docs embeds, README wiring) |
+
+**Description**
+
+Build `scripts/diagrams/`, a Python and Graphviz diagram-as-code pipeline modeled on LumenWipe's `render-all.py`, producing a full library of vertical and horizontal diagrams for this project's strategy and architecture documentation.
+
+**Requirements and context**
+
+- Reference implementation to study before starting: [`LumenWipe/lumenwipe apps/web/scripts/diagrams/render-all.py`](https://github.com/LumenWipe/lumenwipe/blob/main/apps/web/scripts/diagrams/render-all.py). Match its overall approach (one Python module per diagram, a shared entry point, Graphviz as the rendering engine) rather than copying it directly, since this project's diagram content and styling are different.
+- Python dependency: `graphviz` (the Python binding, which shells out to the Graphviz `dot` binary). Document the system-level Graphviz install requirement in `scripts/diagrams/README.md` and in `docs/local-setup.md`.
+- Style module (`scripts/diagrams/style.py` or similar): defines the color palette (pull the actual hex values from `apps/webapp/src/app/globals.css` / `docs/design-system/foundations.md`, including light and dark variants if diagrams are themed), font choices matching the monospace/terminal aesthetic where appropriate, and standard node/edge shapes so every diagram in the set reads as one coherent system.
+- Orientation handling: each diagram module should define its content once (nodes, edges, labels) and accept an orientation parameter (`rankdir="TB"` for vertical, `rankdir="LR"` for horizontal in Graphviz terms), rather than maintaining two separate diagram definitions per diagram.
+- Diagram list and suggested source of truth for content:
+  - System architecture: `docs/architecture/system-architecture.md`
+  - Payout-cycle sequence: `docs/strategy/product-brief.md`'s mermaid sequence diagram (port to Graphviz)
+  - Tokenization/mint sequence: `docs/api/minting-workflow.md`'s existing sequence diagram (existing platform build, still worth diagramming since the pattern is instructive)
+  - Whitelist/KYC review flow: `docs/api/kyc-workflow.md`
+  - Phase 1a treasury flow: `docs/strategy/roadmap.md`
+  - Phase 1 to Phase 2 roadmap timeline: `docs/strategy/roadmap.md`'s existing mermaid flowchart (port to Graphviz, this one especially benefits from a horizontal presentation version)
+  - Deployment topology: `docs/architecture/system-architecture.md`'s deployment section
+  - Monorepo/workspace structure: `README.md`'s project structure section
+- Output convention: `docs/diagrams/<diagram-name>-vertical.svg`, `docs/diagrams/<diagram-name>-horizontal.svg`, plus `.png` equivalents for presentation use.
+
+**Suggested execution**
+
+1. `git checkout -b feature/diagram-generation-pipeline`
+2. Install Graphviz locally (`brew install graphviz` or equivalent) and confirm the Python `graphviz` package renders a trivial test diagram.
+3. Build the style module first, referencing the actual design-system tokens.
+4. Build the entry point (`render_all.py`) and one trivial diagram end to end (both orientations, both formats) to prove the pipeline before building out the full set.
+5. Implement the remaining seven-plus diagrams, one module each.
+6. Embed the vertical SVGs into the relevant markdown docs, replacing ASCII art where a Graphviz version is now equivalent or better.
+7. Write `scripts/diagrams/README.md` documenting how to add a new diagram and regenerate the set.
+
+**Test and commit**
+
+- [ ] `python scripts/diagrams/render_all.py` runs cleanly from a fresh checkout with only the documented dependencies installed
+- [ ] Every diagram produces both a vertical and a horizontal file, in both SVG and PNG
+- [ ] Diagrams render legibly at typical viewing sizes (spot-check at README width and at a 16:9 slide size)
+- [ ] Style module is the single source of truth for colors and fonts across all diagrams (no diagram hardcodes its own palette)
+- [ ] Embedded diagrams in markdown docs render correctly on GitHub
+
+Example commit:
+`git commit -m "feat(diagrams): add python/graphviz pipeline with vertical and horizontal renders"`
+
+**Guidelines**
+
+- Keep each diagram module focused on one diagram; don't build a single monolithic file for the whole set.
+- Prefer clarity over density; a diagram that needs a magnifying glass has failed its purpose.
+- Document the Graphviz system dependency clearly, since it's not installed via `bun install` and contributors without it will otherwise be confused.

--- a/docs/planning/cycles/cycle-6/issues/issue-005/ISSUE_005.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-005/ISSUE_005.md
@@ -1,0 +1,26 @@
+# Align Akkuea Land with the Webapp Design System
+
+## Context
+
+`docs/design-system/` documents a deliberate visual language: a high-contrast, near-monochrome terminal aesthetic with CSS custom properties for every color, a single accent color reserved for meaning, and a documented component library in `apps/webapp/src/components/ui`. `apps/akkuea-land` predates that documentation and does not follow it: it has its own, separate `globals.css`, and components like `GameShell.tsx` use default Tailwind palette classes (`text-green-600`, `text-red-600`) and generic `font-sans` styling instead of the design tokens. Akkuea Land is positioned, per `docs/strategy/product-brief.md`, as the pilot's visual and educational companion. A companion that looks like a different product undermines that positioning every time someone plays it.
+
+## What Needs to Be Done
+
+- Migrate `apps/akkuea-land`'s styling foundation onto the same CSS custom properties documented in `docs/design-system/foundations.md`: either import the token definitions from `apps/webapp/src/app/globals.css` directly (preferred, single source of truth) or extract the tokens into a shared location both apps import from, if build-tooling constraints make direct cross-app CSS imports impractical.
+- Audit every component in `apps/akkuea-land/src/components/` for hardcoded colors, default Tailwind palette classes, and ad hoc typography, and replace them with the token-backed utilities (`bg-accent`, `text-muted-foreground`, `.font-mono` for on-chain values like LAND balances and contract addresses, etc.).
+- Where a UI need in Akkuea Land genuinely overlaps with an existing `apps/webapp/src/components/ui` component (buttons, cards, modals, empty states, error boundaries), reuse it rather than reimplementing it. Where Akkuea Land has a genuinely game-specific need (the city map grid, property tiles), build a new component following the same conventions documented in `docs/design-system/components.md`, not a divergent style.
+- Add the "this is a simulation, see the real pilot" call-to-action described in `docs/strategy/recommendations.md` directly into the game's UI (onboarding or dashboard), not just as prose in the docs.
+- Update `docs/design-system/` to document the now-shared cross-app token system and note any Akkuea Land-specific components that were added.
+
+## Acceptance Criteria
+
+- `apps/akkuea-land` no longer has its own divergent color/typography system; it consumes the same tokens as `apps/webapp`.
+- A visual side-by-side of both apps (included in the PR description) shows clear family resemblance: same background/foreground treatment, same accent color usage, same typography for numeric/on-chain values.
+- No component in `apps/akkuea-land` uses a default Tailwind palette color (`emerald-*`, `zinc-*`, `amber-*`, etc.) where a design-system token exists for the same purpose.
+- The "see the real pilot" call-to-action is live in the game UI and links to the pilot dashboard (or a waitlist, if the pilot dashboard from C6-002 hasn't merged yet).
+- `docs/design-system/components.md` and `foundations.md` are updated to reflect the shared system.
+- All five required CI workflows pass on the pull request.
+
+## Quality Standard
+
+This is a visual-quality issue, and visual quality is judged by looking at it, not by counting tokens replaced. Every screen in Akkuea Land should be reviewed in both light and dark theme before this is considered done. Motion and micro-interaction conventions (the hover/tap scale values already established in `Button.tsx`) should carry over consistently rather than each component inventing its own feel.

--- a/docs/planning/cycles/cycle-6/issues/issue-005/ISSUE_005_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-005/ISSUE_005_DETAILED.md
@@ -1,0 +1,50 @@
+# C6-005: Align Akkuea Land with the Webapp Design System
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-005                          |
+| Area            | WEBAPP (Akkuea Land)             |
+| Difficulty      | High                             |
+| Labels          | frontend, high                   |
+| Dependencies    | None                              |
+| Estimated Lines | 4000-6000 (spans every component file in apps/akkuea-land plus shared token wiring) |
+
+**Description**
+
+Migrate every styled surface in `apps/akkuea-land` onto the design tokens and component conventions documented in `docs/design-system/`, currently only implemented in `apps/webapp`.
+
+**Requirements and context**
+
+- Current state (confirmed by direct inspection): `apps/akkuea-land/src/app/globals.css` is a separate file from `apps/webapp/src/app/globals.css`; `apps/akkuea-land/src/components/GameShell.tsx` uses `text-green-600` / `text-red-600` and plain `font-sans` rather than any token.
+- Target state: `apps/akkuea-land` reads color, typography, and effect values from the same source of truth as `apps/webapp`, documented in `docs/design-system/foundations.md`.
+- Components known to need migration (confirmed present in the codebase; audit for others during implementation): `GameShell.tsx`, `CityMap.tsx` / `CityMap.css`, dashboard page, onboarding step components, property panel.
+- `CityMap.css` is a plain CSS file, not Tailwind classes; decide during implementation whether to convert it to Tailwind + tokens or to keep it as CSS but reference the CSS custom properties (`var(--accent)`, etc.) directly, whichever produces cleaner, more maintainable code for a grid-heavy component. Either is acceptable as long as it consumes the shared tokens rather than hardcoded hex values.
+- Reuse candidates from `apps/webapp/src/components/ui`: `Button`, `Card`, `Modal`, `Badge`, `Loader`, `Toggle`, `EmptyState`, `ErrorBoundary`, `Skeleton` family. Decide on a sharing mechanism: importing directly from `apps/webapp` across the workspace boundary, or extracting shared, framework-agnostic pieces into `apps/shared` if direct cross-app component imports prove impractical given each app's own bundler config. Document whichever approach is chosen in `docs/design-system/README.md` so future contributors don't reinvent it.
+
+**Suggested execution**
+
+1. `git checkout -b feature/akkuea-land-design-system-alignment`
+2. Decide and implement the token-sharing mechanism first (import `globals.css` tokens into `apps/akkuea-land`, or extract to a shared location); get this working and verified before touching individual components.
+3. Decide and implement the component-sharing mechanism for the `apps/webapp/src/components/ui` primitives that make sense to reuse.
+4. Migrate `GameShell.tsx` as the first component, since it's the app's outermost shell and a good place to catch remaining issues early.
+5. Work through the remaining components (`CityMap`, dashboard, onboarding steps, property panel) systematically, converting hardcoded/default-palette styling to token-backed utilities.
+6. Add the "see the real pilot" call-to-action component, linking to the pilot dashboard route (or a placeholder/waitlist route if C6-002 hasn't merged yet).
+7. Update `docs/design-system/foundations.md` and `components.md` to describe the shared system and note any Akkuea Land-specific additions.
+
+**Test and commit**
+
+- [ ] Visual regression check (manual screenshots, before and after) for every migrated screen, in both light and dark theme
+- [ ] No component in `apps/akkuea-land` references a default Tailwind palette color where a design-system token exists for the same semantic purpose
+- [ ] Existing `apps/akkuea-land` test suite still passes after the migration
+- [ ] The "see the real pilot" CTA renders and links correctly
+
+Example commit:
+`git commit -m "feat(akkuea-land): migrate to the shared webapp design system"`
+
+**Guidelines**
+
+- Do not introduce a second, competing component library; extend or reuse the existing one.
+- Preserve all existing game functionality; this is a styling and structural migration, not a behavior change. Any behavior change discovered as necessary along the way should be called out explicitly in the PR description, not silently bundled in.
+- Keep the CSS Grid / no-canvas / no-WebGL constraint from the original Akkuea Land build (documented in the Cycle 5 overview) intact; this issue is about tokens and components, not the rendering approach.

--- a/docs/planning/cycles/cycle-6/issues/issue-006/ISSUE_006.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-006/ISSUE_006.md
@@ -1,0 +1,24 @@
+# Close the KYC Enforcement Gaps and Remediate Dependency Vulnerabilities
+
+## Context
+
+`docs/api/kyc-workflow.md` documents two known gaps in the existing platform build honestly and specifically: `POST /kyc/verify/:documentId` has no authentication middleware at all, meaning any HTTP client that knows a document ID can approve or reject it, and `buyShares` does not check `users.kycStatus` before allowing a share purchase, meaning a user with `kycStatus = 'not_started'` can buy shares today. Separately, GitHub's dependency scanning currently flags 27 vulnerabilities against `develop` (12 high, 12 moderate, 3 low), and `.github/security/audit-allowlist.txt` lists dozens of advisories as allowlisted rather than fixed. None of this is acceptable in a product being pitched to real estate agencies and investors as verifiable and auditable.
+
+## What Needs to Be Done
+
+- Add authentication middleware to `POST /kyc/verify/:documentId`, gated the same way other admin-only operations already are (`OPERATIONS_BACKEND_CREDENTIAL` and/or `OPERATIONS_ALLOWED_WALLETS`, per `docs/deployment/environment-variables.md`).
+- Add a KYC-status guard to `buyShares` (`routes/properties.ts`) that rejects the purchase with a clear error unless `users.kycStatus === 'approved'`, following the pseudocode already sketched in `docs/api/kyc-workflow.md`.
+- Work through `.github/security/audit-allowlist.txt`: for every listed advisory, check whether a non-breaking patched version is now available upstream and upgrade to it, removing the entry from the allowlist. For advisories with no available fix yet, leave them allowlisted but confirm the "follow-up" note is still accurate.
+- Update `docs/api/kyc-workflow.md`'s "Known gaps" section once each gap is closed, following the same pattern already used elsewhere in this repo when a documented gap gets fixed (see how Issue #729's oracle guardrails work updated `docs/operations/runbook-oracle-failure.md`).
+
+## Acceptance Criteria
+
+- `POST /kyc/verify/:documentId` returns 401/403 for any request without valid admin credentials, verified by a new regression test.
+- `buyShares` returns a clear, typed error when called by a user whose `kycStatus` is not `approved`, verified by a new regression test; the happy path for an approved user is unaffected.
+- The number of advisories in `audit-allowlist.txt` decreases; every remaining entry has a currently accurate reason it can't yet be fixed.
+- `docs/api/kyc-workflow.md`'s "Known gaps" section is updated to reflect the new, closed state (or removed entirely if both gaps are fully closed).
+- All five required CI workflows pass on the pull request, including the dependency audit step in `monorepo-ci.yml`.
+
+## Quality Standard
+
+These are the two most concrete, already-documented security gaps in the entire codebase; there is no ambiguity about what "done" looks like here; the acceptance criteria in `docs/api/kyc-workflow.md` already describe it precisely. Fix the actual gap, don't paper over it with a comment or a TODO. Every dependency upgrade must be verified to not break the existing test suite before being counted as done.

--- a/docs/planning/cycles/cycle-6/issues/issue-006/ISSUE_006_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-006/ISSUE_006_DETAILED.md
@@ -1,0 +1,50 @@
+# C6-006: Close the KYC Enforcement Gaps and Remediate Dependency Vulnerabilities
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-006                          |
+| Area            | API                              |
+| Difficulty      | High                             |
+| Labels          | backend, error-handling, validation, high |
+| Dependencies    | None                              |
+| Estimated Lines | 4000+ (dominated by `bun.lock` regeneration across dependency upgrades; hand-authored fix and test code is smaller, roughly 300-600 lines, and that's expected and fine, see note below) |
+
+**Description**
+
+Close the two documented KYC enforcement gaps in `apps/api`, and work through `.github/security/audit-allowlist.txt` upgrading every dependency with an available non-breaking patch.
+
+**Requirements and context**
+
+- `POST /kyc/verify/:documentId` (`apps/api/src/routes/kyc.ts`, referenced at `routes/kyc.ts:130-139` in `docs/api/kyc-workflow.md`): add the same admin-auth check already used elsewhere (see `internalOperationsAuth.ts`, already used by `/internal/operations/properties/:id/review` per `docs/api/launch-workflows.md`).
+- `buyShares` (`apps/api/src/routes/properties.ts`, referenced at `routes/properties.ts:156-183`): add a guard reading `kycRepository.getUserKycStatus(buyer.id)` and throwing a typed `AuthorizationError` if the status isn't `approved`, exactly as sketched in `docs/api/kyc-workflow.md`'s "Known gaps" section.
+- Dependency remediation: `.github/security/audit-allowlist.txt` currently lists advisories against `next`, `nanoid`, `shell-quote`, `brace-expansion`, `undici`, `js-yaml`, `image-size`, `postcss`, `protobufjs`, `ws`, `axios`, `form-data`, `ip-address`, and `sharp`, among others, most marked "transitive; track upgrade." For each, check `bun outdated` and the advisory's fixed-version range; upgrade whichever direct or transitive dependency resolves it without a breaking major-version bump to a package this codebase directly depends on. Where the fix requires a breaking change to a direct dependency (e.g. a Next.js major bump), leave it allowlisted and note that explicitly rather than force an unrelated breaking upgrade into this issue.
+- A note on line-count expectations for this specific issue: unlike the other issues in this cycle, the bulk of this PR's diff will be `bun.lock` (an auto-generated lockfile, not hand-authored code). That's expected and correct; the hand-authored portion (the two guards, their tests, and the audit-allowlist edits) will be meaningfully smaller. Don't pad the guard implementation or its tests artificially to hit a line target; the value here is closing real gaps correctly, not volume.
+
+**Suggested execution**
+
+1. `git checkout -b fix/kyc-enforcement-gaps-and-dependency-audit`
+2. Fix and test the `verify` endpoint auth gap first (smaller, independent, easy to verify in isolation).
+3. Fix and test the `buyShares` KYC guard second.
+4. Run `bun outdated` (or the workspace-appropriate equivalent) across each workspace, cross-reference against `audit-allowlist.txt`, and upgrade what can be upgraded without a breaking change.
+5. Re-run the full test suite after each dependency upgrade batch, not just once at the end, to isolate any regression to the upgrade that caused it.
+6. Update `.github/security/audit-allowlist.txt` and `docs/api/kyc-workflow.md`'s "Known gaps" section to reflect the new state.
+
+**Test and commit**
+
+- [ ] New regression test: `POST /kyc/verify/:documentId` without valid admin credentials returns 401/403
+- [ ] New regression test: `buyShares` called by a non-approved user returns the typed authorization error; called by an approved user still succeeds (no regression on the happy path)
+- [ ] Full test suite passes after every dependency upgrade, not just the final one
+- [ ] `bash .github/scripts/dependency-audit.sh .` (the script `monorepo-ci.yml` actually runs) passes locally before pushing
+
+Example commit:
+`git commit -m "fix(api): require admin auth on kyc verify and enforce kyc status on buyShares"`
+
+(dependency upgrades may warrant a separate `chore(deps): upgrade dependencies with available security patches` commit, kept atomic and distinct from the two logic fixes above)
+
+**Guidelines**
+
+- Never weaken an existing check to make a test pass; fix the actual gap.
+- Treat `audit-allowlist.txt` entries you can't fix as your finding, not your failure; document why clearly rather than silently leaving a stale note.
+- 401 for missing/invalid credentials, 403 for valid credentials without sufficient permission, consistent with the rest of the API's existing error convention.

--- a/docs/planning/cycles/cycle-6/issues/issue-007/ISSUE_007.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-007/ISSUE_007.md
@@ -1,0 +1,23 @@
+# Ship an Environment Variable Guide, Boot-Time Validation, and CI Quality Gates
+
+## Context
+
+`docs/deployment/environment-variables.md` is a complete reference of every variable this project uses, but it documents *what* each variable is, not *where a contributor actually gets one*. A new contributor cloning this repository can copy `.env.example` but has no guide for where to obtain a real Stellar testnet keypair, how to get a Privy app ID, how to generate `OPERATIONS_BACKEND_CREDENTIAL`, or how to stand up the local database, without asking someone. Contributors must never add real `.env` files to the repository, but the absence of a "how do I get one" guide pushes people toward asking in chat or, worse, guessing. Separately, `CLAUDE.md` now states this project's non-negotiable rules (no em dash, no emojis, follow the design system, CI must pass) as prose; nothing currently checks any of them automatically, so they rely entirely on every contributor (human or AI) remembering to follow them.
+
+## What Needs to Be Done
+
+- Write `docs/ENV_SETUP.md`: for every variable in `docs/deployment/environment-variables.md`, explain where a real value comes from for local development (Stellar Laboratory or `stellar keys generate --network testnet --fund` for testnet keypairs, the Privy dashboard for `NEXT_PUBLIC_PRIVY_APP_ID` / `PRIVY_APP_SECRET`, `openssl rand -hex 32` for `OPERATIONS_BACKEND_CREDENTIAL`, `docker-compose.dev.yml` for the local database/Redis connection strings, and so on for every remaining variable). This document must never contain a real secret value, only instructions for obtaining one.
+- Build a boot-time environment validation module (a reasonable location is `apps/shared/src/env/`, imported by both `apps/api` and `apps/webapp` at startup) that checks every required variable is present and well-formed (correct Stellar address/secret format, correct URL format, etc.) and fails fast with a specific, actionable error message pointing at `docs/ENV_SETUP.md`, rather than failing deep inside a request handler with a confusing stack trace.
+- Add a CI step (a new small workflow or a step inside `monorepo-ci.yml`) that scans the repository for em dashes and emoji characters and fails the build if either is found outside of explicitly allowed exceptions (if any are needed, e.g. a changelog that quotes external text verbatim), operationalizing the `CLAUDE.md` rule instead of leaving it as unenforced prose.
+
+## Acceptance Criteria
+
+- `docs/ENV_SETUP.md` covers every variable in `docs/deployment/environment-variables.md`, with a concrete instruction for obtaining a real value for each, and contains zero real secret values.
+- Starting the API or webapp with a required variable missing produces a clear, specific error identifying which variable is missing and pointing at the new guide, instead of an unrelated downstream failure.
+- The new CI step correctly fails on a deliberately introduced em dash or emoji in a test commit, and passes on the current, already-cleaned codebase.
+- `docs/local-setup.md` and `docs/README.md` link to the new guide.
+- All five required CI workflows pass on the pull request, plus the new quality-gate check.
+
+## Quality Standard
+
+This issue exists to remove friction for every future contributor, human or AI, on every issue after it. The env guide must be precise enough that someone with zero prior context on this project can get a fully working local environment without asking a single question. The CI quality gate must have zero false positives against the current codebase; a check that cries wolf gets disabled, which defeats its purpose.

--- a/docs/planning/cycles/cycle-6/issues/issue-007/ISSUE_007_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-007/ISSUE_007_DETAILED.md
@@ -1,0 +1,54 @@
+# C6-007: Ship an Environment Variable Guide, Boot-Time Validation, and CI Quality Gates
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-007                          |
+| Area            | TOOLING (SHARED + API + WEBAPP)  |
+| Difficulty      | High                             |
+| Labels          | documentation, shared, backend, high |
+| Dependencies    | None                              |
+| Estimated Lines | 4000-5000 (env schema + validator + tests across three workspaces, CI workflow, and a genuinely thorough guide) |
+
+**Description**
+
+Ship `docs/ENV_SETUP.md`, a schema-driven env validator shared across `apps/api` and `apps/webapp`, and a CI quality gate enforcing the `CLAUDE.md` no-em-dash / no-emoji rule.
+
+**Requirements and context**
+
+- `docs/ENV_SETUP.md` structure: one section per variable group already established in `docs/deployment/environment-variables.md` (Database, API Server, Internal Security, KYC, Stellar/Soroban Network, Stellar/Soroban Admin Identity, Stellar/Soroban Contracts), each entry answering "where do I get a real value for local development" concretely:
+  - Stellar keypairs: `stellar keys generate --network testnet --fund`, or Stellar Laboratory's account creator, both already referenced elsewhere in this repo's docs.
+  - `NEXT_PUBLIC_PRIVY_APP_ID` / `PRIVY_APP_SECRET`: the Privy dashboard at dashboard.privy.io, already referenced in `apps/webapp/.env.example`'s comments.
+  - `OPERATIONS_BACKEND_CREDENTIAL`: `openssl rand -hex 32`, already noted in `environment-variables.md`.
+  - `DATABASE_URL` / `REDIS_URL`: `docker-compose.dev.yml`'s default local credentials.
+  - `KYC_UPLOAD_DIR`: any local writable directory for development; document the production expectation separately (not publicly accessible).
+  - Contract ID variables: point to the relevant deployment doc (`docs/deployment/deploy-contracts.md`, `docs/deployment/deploy-game-contracts.md`, and the new pilot deployment doc from C6-001) rather than a real value.
+- Env schema/validator: a plausible shape is a Zod schema per workspace's required variable set (`apps/shared/src/env/apiEnvSchema.ts`, `webappEnvSchema.ts`, or a single schema with per-consumer subsets), validated once at process start (`apps/api/src/index.ts`, and the earliest feasible point in `apps/webapp`'s server startup), throwing a clear aggregated error listing every missing/malformed variable at once, not one at a time across multiple restart cycles.
+- CI quality gate: a small script (Python or a shell one-liner with `grep`, whichever is more maintainable) that scans tracked files for the em dash character and common emoji Unicode ranges, excluding `node_modules`, `.git`, lockfiles, and any other generated-content directories; wire it as a step in `monorepo-ci.yml` or a new lightweight workflow.
+
+**Suggested execution**
+
+1. `git checkout -b feature/env-guide-validation-and-quality-gates`
+2. Write `docs/ENV_SETUP.md` first; it clarifies exactly which variables the validator needs to check and how.
+3. Build the env schema and validator in `apps/shared/src/env/`, with unit tests covering both the success case and several documented failure cases (missing variable, malformed Stellar address, malformed URL).
+4. Wire the validator into `apps/api`'s startup and `apps/webapp`'s startup.
+5. Build and test the em-dash/emoji CI scanner script.
+6. Add it as a CI step, confirm it passes on the current codebase and fails on a deliberately introduced violation in a throwaway test commit (revert the test commit before merging).
+7. Link the new guide from `docs/local-setup.md` and `docs/README.md`.
+
+**Test and commit**
+
+- [ ] Env validator unit tests cover success and every documented failure mode
+- [ ] API and webapp both fail fast with a clear, specific message when a required variable is missing, verified by an integration test that unsets a variable and asserts the resulting error
+- [ ] CI quality gate correctly fails against a deliberately introduced em dash and a deliberately introduced emoji, verified during development and then reverted before merge
+- [ ] CI quality gate passes cleanly against the current `develop` state
+
+Example commit:
+`git commit -m "feat(shared): add env schema validation and ci quality gates for style rules"`
+
+**Guidelines**
+
+- `docs/ENV_SETUP.md` must never contain a real secret value; every example should be either a placeholder or an instruction for generating one locally.
+- The validator's error output is a developer-experience surface; write it as carefully as any user-facing error message.
+- Keep the CI scanner's false-positive rate at zero against the current codebase before merging; a noisy check will get disabled rather than fixed.

--- a/docs/planning/cycles/cycle-6/issues/issue-008/ISSUE_008.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-008/ISSUE_008.md
@@ -1,0 +1,25 @@
+# Build the Self-Serve Whitelist and Investor Onboarding Flow
+
+## Context
+
+`docs/api/kyc-workflow.md` documents the existing platform's KYC review as an "admin as oracle" pattern operated entirely through `curl` commands. `docs/strategy/product-brief.md` calls for the pilot's own version of this: a minimum-defensible whitelist, manual identity review gating a simple on-chain approved/not-approved contract (built in C6-001). Today there is no self-serve way for a real investor to submit their information for review, or for the pilot ally to be onboarded in the first place. A pilot cannot onboard real investors through a support chat and manual admin commands; it needs an actual flow.
+
+## What Needs to Be Done
+
+- Build an investor-facing onboarding flow: connect a Stellar wallet, submit whatever minimum-defensible identity information the pilot's whitelist review actually requires (this is intentionally lighter than the existing platform's full KYC document upload; confirm the exact minimum-defensible requirement against `docs/strategy/product-brief.md` and `docs/strategy/decision-log.md` before building the form, don't assume it mirrors the existing platform's heavier flow), see their approval status.
+- Build an operator-facing review queue: list pending whitelist requests, approve or reject, with the approval calling the C6-001 whitelist contract's `approve` function.
+- Use the `Stepper` component from the design system for the investor's multi-step submission flow, consistent with the rest of the pilot surface.
+- This flow is distinct from C6-002's ally evidence and investor holdings views; it is specifically the *becoming* a whitelisted investor flow, which happens once, before any of C6-002's ongoing views become relevant to a given investor.
+
+## Acceptance Criteria
+
+- A new investor can connect a wallet, submit the required minimum-defensible information, and see their request enter a pending state, reflected on the C6-001 whitelist contract.
+- An operator can review pending requests and approve or reject them, with an approval correctly updating the on-chain whitelist state, verifiable by the C6-001 contract's `is_approved` read.
+- A rejected investor sees a clear reason, not just a rejected status.
+- The flow correctly handles the case where an investor is already approved (no duplicate submission allowed) and the case where a wallet has no pending or approved request yet (clear starting state, using `EmptyState`).
+- All new components use the design-system tokens and components, have Storybook stories, and handle loading/error/empty/disconnected states.
+- All five required CI workflows pass on the pull request.
+
+## Quality Standard
+
+This is a real investor's first interaction with the product. It must be as clear and frictionless as the minimum-defensible scope allows, with no dead ends, no unclear error states, and no step that silently fails. If the exact information required for the minimum-defensible whitelist review isn't fully specified anywhere yet, that's a real product decision to surface and resolve before or during this issue, not something to assume silently.

--- a/docs/planning/cycles/cycle-6/issues/issue-008/ISSUE_008_DETAILED.md
+++ b/docs/planning/cycles/cycle-6/issues/issue-008/ISSUE_008_DETAILED.md
@@ -1,0 +1,51 @@
+# C6-008: Build the Self-Serve Whitelist and Investor Onboarding Flow
+
+## Issue Metadata
+
+| Attribute       | Value                          |
+| --------------- | ------------------------------- |
+| Issue ID        | C6-008                          |
+| Area            | WEBAPP                          |
+| Difficulty      | High                             |
+| Labels          | frontend, backend, high          |
+| Dependencies    | C6-001                           |
+| Estimated Lines | 4000-5500 (onboarding UI, review queue UI, supporting API routes, tests, stories) |
+
+**Description**
+
+Build the investor-facing whitelist request flow and the operator-facing review queue, wired to the C6-001 whitelist contract.
+
+**Requirements and context**
+
+- New routes: `app/[locale]/pilot/onboarding/page.tsx` (investor), `app/[locale]/pilot/review/whitelist/page.tsx` (operator; if C6-002 already established a `review` route for evidence, this may live alongside it as a tab rather than a fully separate page).
+- Minimum-defensible submission requirements: before building the form, confirm the exact fields against `docs/strategy/product-brief.md` and `docs/strategy/decision-log.md`. If genuinely unspecified, the smallest defensible default (consistent with the project's own "minimum-defensible, not a compliance product" language) is: full name, a government-ID type and reference (not necessarily the document itself, unless a decision is made that it must be), and the Stellar wallet address being whitelisted. Do not silently copy the existing platform's full multi-document KYC upload flow; that's explicitly a heavier standard than the pilot calls for.
+- Backend: new routes in `apps/api/src/routes/` for submitting a whitelist request and for the operator's approve/reject action, the latter admin-gated the same way `/internal/operations/properties/:id/review` is. The approve action must actually call the C6-001 whitelist contract's `approve` function via a service similar to `StellarService.ts`'s existing transaction-building pattern.
+- Off-chain storage of the submitted information (name, ID reference) requires a decision: either a minimal new database table (if this project decides that information needs to persist somewhere reviewable), or an entirely on-chain-referenced approach consistent with the "evidence as link + hash" pattern from C6-001. Make this decision explicitly in the PR description with reasoning, don't default silently to the heavier option.
+- UI: `Stepper` for the investor's submission flow, `EmptyState` for "no request yet" and "already approved" states, `PageErrorFallback` around both new pages.
+
+**Suggested execution**
+
+1. `git checkout -b feature/pilot-whitelist-onboarding-flow`
+2. Resolve the minimum-defensible field-requirement question first; this blocks meaningful form design.
+3. Resolve the off-chain-storage-or-not question second; this blocks meaningful backend design.
+4. Build the backend routes and the whitelist-contract-invoking service.
+5. Build the investor submission flow using `Stepper`.
+6. Build the operator review queue.
+7. Wire both to the C6-001 whitelist contract; verify against a real testnet deployment before merge.
+
+**Test and commit**
+
+- [ ] An end-to-end test (or a thoroughly manual-verified flow, documented with screenshots) covers: connect wallet, submit request, operator approves, `is_approved` reads true on-chain
+- [ ] A rejection path shows a clear reason to the investor
+- [ ] Duplicate submission from an already-approved wallet is prevented with a clear message
+- [ ] All interactive elements handle loading/error/disconnected-wallet states
+- [ ] New API routes have OpenAPI documentation and are admin-gated correctly for the operator actions
+
+Example commit:
+`git commit -m "feat(webapp): add self-serve whitelist request and review flow for the pilot"`
+
+**Guidelines**
+
+- Do not silently reuse the existing platform's heavier KYC document-upload flow; the pilot's whitelist is explicitly minimum-defensible, not a compliance product, per `docs/strategy/product-brief.md`.
+- Coordinate the whitelist contract's exact function signature with whoever implements C6-001; don't guess at it.
+- PR must include before/after screenshots of both the investor and operator flows.


### PR DESCRIPTION
## Summary

- Adds `docs/planning/cycles/cycle-6/`, the planning documentation for the 8 GitHub issues (#1060-#1067) that take Akkuea from "strategy documented" to "pilot launchable"
- Each issue is scoped as a large, complete unit of work (contracts, dashboard, treasury integration, diagram pipeline, design-system alignment, security hardening, developer experience, onboarding flow) rather than split into small slices, consistent with the founder's direction that each resulting PR should be substantial and high quality
- Follows the existing `docs/planning/cycles/cycle-N/` format established by prior cycles (overview + professional/detailed file pair per issue)
- Every issue traces directly to a decision already recorded in `docs/strategy/` or an explicit founder request; none of it touches anything `docs/strategy/roadmap.md` marks as Phase 2

## Test plan

- [ ] Review `docs/planning/cycles/cycle-6/CYCLE_6_OVERVIEW.md` against the actual 8 created issues for consistency
- [ ] Confirm dependency ordering (C6-002 and C6-008 depend on C6-001) matches how work will actually be assigned