### PR TITLE
feat(shared): add env schema validation and ci quality gates for styl…

### DIFF
--- a/.github/scripts/check-style-rules.py
+++ b/.github/scripts/check-style-rules.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+import subprocess
+
+# Directories ignored from scanning entirely (build artifacts, dependencies, etc.)
+IGNORED_DIRS = {
+    ".git",
+    ".gemini",
+    "brain",
+    "node_modules",
+    ".next",
+    "dist",
+    "out",
+    "target",
+    "build",
+    "coverage",
+    ".turbo",
+    "venv",
+    ".venv",
+}
+
+# File extensions ignored (binary assets, images, lockfiles)
+IGNORED_EXTENSIONS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".webp", ".wasm",
+    ".pdf", ".ttf", ".woff", ".woff2", ".eot", ".mp4", ".mp3",
+    ".zip", ".tar", ".gz", ".lock", ".bin", ".svg"
+}
+
+# Explicit allowed exceptions for existing pre-date codebase files or external references
+ALLOWED_EXCEPTIONS = [
+    ".github/workflows/",
+    "apps/contracts/",
+    "apps/akkuea-land/",
+    "apps/api/src/index.ts",
+    "apps/webapp/src/components/portfolio/PropertyReportCard.tsx",
+    "docs/README.md",
+    "docs/deployment/deploy-game-contracts.md",
+    "docs/planning/",
+    "packages/nextjs/",
+]
+
+EMOJI_PATTERN = re.compile(
+    r"[\U0001F300-\U0001F9FF"
+    r"\U0001FA00-\U0001FAFF"
+    r"\u2600-\u27BF"
+    r"\U0001F600-\U0001F64F"
+    r"\U0001F680-\U0001F6FF]"
+)
+
+EM_DASH_PATTERN = re.compile(r"\u2014")
+
+def is_allowed(rel_path):
+    normalized = rel_path.replace("\\", "/")
+    for allowed in ALLOWED_EXCEPTIONS:
+        if allowed.endswith("/") and normalized.startswith(allowed):
+            return True
+        if normalized == allowed:
+            return True
+    return False
+
+def get_tracked_files(root_dir):
+    try:
+        res = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=True
+        )
+        return [f.strip() for f in res.stdout.splitlines() if f.strip()]
+    except Exception:
+        # Fallback to os.walk if git is unavailable
+        files = []
+        for dirpath, dirnames, filenames in os.walk(root_dir):
+            dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+            for filename in filenames:
+                rel = os.path.relpath(os.path.join(dirpath, filename), root_dir)
+                files.append(rel.replace("\\", "/"))
+        return files
+
+def scan_repository(root_dir="."):
+    violations = []
+    tracked_files = get_tracked_files(root_dir)
+
+    for rel_path in tracked_files:
+        if is_allowed(rel_path):
+            continue
+
+        ext = os.path.splitext(rel_path)[1].lower()
+        if ext in IGNORED_EXTENSIONS:
+            continue
+
+        full_path = os.path.join(root_dir, rel_path)
+        if not os.path.isfile(full_path):
+            continue
+
+        try:
+            with open(full_path, "r", encoding="utf-8", errors="ignore") as f:
+                for line_num, line in enumerate(f, start=1):
+                    if EM_DASH_PATTERN.search(line):
+                        violations.append({
+                            "file": rel_path,
+                            "line": line_num,
+                            "type": "Em Dash (\\u2014)",
+                            "content": line.strip()
+                        })
+                    if EMOJI_PATTERN.search(line):
+                        violations.append({
+                            "file": rel_path,
+                            "line": line_num,
+                            "type": "Emoji character",
+                            "content": line.strip()
+                        })
+        except Exception:
+            pass
+
+    return violations
+
+def main():
+    root_dir = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else ".")
+    print(f"Scanning repository at {root_dir} for style non-negotiables (em dashes & emojis)...")
+
+    violations = scan_repository(root_dir)
+
+    if violations:
+        print("\nStyle Rule Violations Found:")
+        print("==============================")
+        for v in violations:
+            # Use ASCII safe formatting to avoid Windows console encoding issues
+            safe_content = v['content'].encode('ascii', errors='backslashreplace').decode('ascii')
+            print(f"  [FAIL] {v['file']}:{v['line']} [{v['type']}] -> {safe_content}")
+        print(f"\nTotal violations: {len(violations)}")
+        print("\nPlease fix the above violations (refer to CLAUDE.md non-negotiable rules: no em dashes, no emojis).")
+        sys.exit(1)
+    else:
+        print("No style rule violations found (0 em dashes, 0 emojis outside allowed exceptions). Quality gate passed!")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/check-style-rules.py
+++ b/.github/scripts/check-style-rules.py
@@ -31,13 +31,10 @@ IGNORED_EXTENSIONS = {
 # Explicit allowed exceptions for existing pre-date codebase files or external references
 ALLOWED_EXCEPTIONS = [
     ".github/workflows/",
-    "apps/contracts/",
-    "apps/akkuea-land/",
     "apps/api/src/index.ts",
     "apps/webapp/src/components/portfolio/PropertyReportCard.tsx",
     "docs/README.md",
     "docs/deployment/deploy-game-contracts.md",
-    "docs/planning/",
     "packages/nextjs/",
 ]
 

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -190,10 +190,16 @@ jobs:
         # Record build times
         START_TIME=$(date +%s)
 
-        # Build webapp
-        cd apps/webapp
+        # Build shared first (required by webapp and api)
+        cd apps/shared
         bun_install
         bun run build
+        SHARED_BUILD_TIME=$(date +%s)
+
+        # Build webapp
+        cd ../webapp
+        bun_install
+        SKIP_ENV_VALIDATION=true bun run build
         WEBAPP_BUILD_TIME=$(date +%s)
 
         # Build API
@@ -201,23 +207,17 @@ jobs:
         bun_install
         bun run build
         API_BUILD_TIME=$(date +%s)
-
-        # Build shared
-        cd ../shared
-        bun_install
-        bun run build
-        SHARED_BUILD_TIME=$(date +%s)
         
         # Calculate build times
-        WEBAPP_TOTAL=$((WEBAPP_BUILD_TIME - START_TIME))
+        SHARED_TOTAL=$((SHARED_BUILD_TIME - START_TIME))
+        WEBAPP_TOTAL=$((WEBAPP_BUILD_TIME - SHARED_BUILD_TIME))
         API_TOTAL=$((API_BUILD_TIME - WEBAPP_BUILD_TIME))
-        SHARED_TOTAL=$((SHARED_BUILD_TIME - API_BUILD_TIME))
-        TOTAL=$((SHARED_BUILD_TIME - START_TIME))
+        TOTAL=$((API_BUILD_TIME - START_TIME))
         
         echo "Build times:"
+        echo "Shared: ${SHARED_TOTAL}s"
         echo "WebApp: ${WEBAPP_TOTAL}s"
         echo "API: ${API_TOTAL}s"
-        echo "Shared: ${SHARED_TOTAL}s"
         echo "Total: ${TOTAL}s"
         
         # Alert if build is slow (>5 minutes)

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -5,19 +5,40 @@ on:
     branches: [ main, develop ]
     paths:
       - 'apps/**'
-      - '.github/workflows/monorepo-ci.yml'
+      - 'docs/**'
+      - 'scripts/**'
+      - '.github/**'
   pull_request:
     branches: [ main, develop ]
     paths:
       - 'apps/**'
-      - '.github/workflows/monorepo-ci.yml'
+      - 'docs/**'
+      - 'scripts/**'
+      - '.github/**'
 
 env:
   NODE_VERSION: '20'
   BUN_VERSION: '1.x'
 
 jobs:
+  style-quality-gate:
+    name: Codebase Style Quality Gate
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Run style quality gate scanner (em dashes and emojis)
+      run: python3 .github/scripts/check-style-rules.py .
+
   monorepo-integrity:
+
     name: Monorepo Integrity Check
     runs-on: ubuntu-latest
     

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -42,9 +42,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build shared library
+        run: |
+          cd apps/shared
+          bun run build
+
       - name: Type checking
         working-directory: apps/webapp
         run: bun run type-check
+        env:
+          SKIP_ENV_VALIDATION: "true"
 
       - name: ESLint
         working-directory: apps/webapp

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -42,10 +42,17 @@ jobs:
         run: |
           bun install --frozen-lockfile
 
+      - name: Build shared library (required for webapp type checking)
+        run: |
+          cd apps/shared
+          bun run build
+
       - name: Type checking
         run: |
           cd apps/webapp
           bun run type-check
+        env:
+          SKIP_ENV_VALIDATION: "true"
 
       - name: ESLint checking
         run: |
@@ -61,11 +68,15 @@ jobs:
         run: |
           cd apps/webapp
           bun run build
+        env:
+          SKIP_ENV_VALIDATION: "true"
 
       - name: Run unit tests
         run: |
           cd apps/webapp
           bun test --coverage --coverage-threshold=60
+        env:
+          SKIP_ENV_VALIDATION: "true"
 
       # - name: E2E tests
       #   run: |
@@ -121,6 +132,11 @@ jobs:
         run: |
           bun install --frozen-lockfile
 
+      - name: Build shared library (required for webapp security checks)
+        run: |
+          cd apps/shared
+          bun run build
+
       - name: Audit dependencies
         run: bash .github/scripts/dependency-audit.sh .
 
@@ -147,12 +163,17 @@ jobs:
           cd apps/webapp
           bunx eslint src/ --ext .ts,.tsx || true
 
+      - name: Build shared library (required for webapp build)
+        run: |
+          cd apps/shared
+          bun run build
+
       - name: Check CSP headers
         run: |
           cd apps/webapp
 
           # Build app first
-          bun run build
+          SKIP_ENV_VALIDATION=true bun run build
 
           # Check if CSP headers are configured
           if [ -f "next.config.js" ] || [ -f "next.config.ts" ]; then

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Run from the repository root:
 
 ## Environment Variables
 
-All required environment variables are documented in [`docs/deployment/environment-variables.md`](docs/deployment/environment-variables.md). The source of truth is `apps/api/.env.example`.
+All required environment variables are documented in [`docs/deployment/environment-variables.md`](docs/deployment/environment-variables.md). For step-by-step instructions on obtaining real values for local development, see the [`docs/ENV_SETUP.md`](docs/ENV_SETUP.md) guide. The source of truth for variables is `apps/api/.env.example`.
 
 Key categories:
 
@@ -275,6 +275,7 @@ akkuea/
 | [`docs/strategy/roadmap.md`](docs/strategy/roadmap.md)                                 | Phase 1a/1b/2 roadmap, jurisdiction, partnerships |
 | [`docs/design-system/README.md`](docs/design-system/README.md)                         | Visual/interaction system                         |
 | [`docs/local-setup.md`](docs/local-setup.md)                                           | Full local setup walkthrough                      |
+| [`docs/ENV_SETUP.md`](docs/ENV_SETUP.md)                                               | Local environment variable setup guide            |
 | [`docs/architecture/system-architecture.md`](docs/architecture/system-architecture.md) | System design and component breakdown             |
 | [`docs/deployment/environment-variables.md`](docs/deployment/environment-variables.md) | Complete environment variable reference           |
 | [`docs/deployment/deploy-contracts.md`](docs/deployment/deploy-contracts.md)           | Contract deployment to Stellar networks           |

--- a/apps/akkuea-land/src/components/game/CityMap.tsx
+++ b/apps/akkuea-land/src/components/game/CityMap.tsx
@@ -66,12 +66,12 @@ const PropertyTile = React.memo(function PropertyTile({
   const isUnowned = !property.owner;
 
   const tooltipLines = [
-    `📍 (${row}, ${col})`,
-    `👤 ${abbreviateAddress(property.owner)}`,
-    `🏗 ${BUILDING_NAMES[property.buildingLevel]}`,
+    `Coords: (${row}, ${col})`,
+    `Owner: ${abbreviateAddress(property.owner)}`,
+    `Level: ${BUILDING_NAMES[property.buildingLevel]}`,
   ];
   if (property.isListed) {
-    tooltipLines.push(`💰 ${property.pricePerShare} LAND`);
+    tooltipLines.push(`Price: ${property.pricePerShare} LAND`);
   }
   const tooltip = tooltipLines.join("\n");
 

--- a/apps/akkuea-land/src/components/game/onboarding/ClaimLandStep.tsx
+++ b/apps/akkuea-land/src/components/game/onboarding/ClaimLandStep.tsx
@@ -131,7 +131,7 @@ export function ClaimLandStep({
                         top: "10%",
                       }}
                     >
-                      ✦
+                      <Sparkles size={12} />
                     </motion.div>
                   ))}
                 </div>

--- a/apps/api/src/config/treasury.ts
+++ b/apps/api/src/config/treasury.ts
@@ -11,14 +11,14 @@ import { resolveNetworkKey } from './contracts';
  * Both venues are DeFindex Vaults, and both are reachable through the same
  * contract interface:
  *
- *  - `defindex-blend`       — a USDC vault whose only strategy lends into Blend.
- *  - `etherfuse-stablebond` — a CETES vault. CETES is Etherfuse's tokenized
+ *  - `defindex-blend`       (a USDC vault whose only strategy lends into Blend).
+ *  - `etherfuse-stablebond` (a CETES vault). CETES is Etherfuse's tokenized
  *                             Mexican sovereign-debt Stablebond; the vault's
  *                             strategy holds it and lends it on Blend.
  *
  * Etherfuse does not publish a direct Soroban mint/redeem interface for
- * Stablebonds — the on-chain path documented by both projects is the DeFindex
- * strategy — so that is the path used here.
+ * Stablebonds, the on-chain path documented by both projects is the DeFindex
+ * strategy, so that is the path used here.
  *
  * Addresses below are copied from the upstream deployment registry
  * (https://github.com/defindex-io/stellar-contracts/blob/main/public/testnet.contracts.json)
@@ -73,7 +73,7 @@ const VENUE_DEFAULTS: Record<
 > = {
   'defindex-blend': {
     TESTNET: {
-      // `usdc_paltalabs_vault` — strategy `USDC Blend Strategy`
+      // `usdc_paltalabs_vault`, strategy `USDC Blend Strategy`
       vaultContractId: 'CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN',
       // SAC for USDC:GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56
       assetContractId: 'CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU',
@@ -84,7 +84,7 @@ const VENUE_DEFAULTS: Record<
   },
   'etherfuse-stablebond': {
     TESTNET: {
-      // `cetes_paltalabs_vault` — strategy `CETES Blend Strategy`
+      // `cetes_paltalabs_vault`, strategy `CETES Blend Strategy`
       vaultContractId: 'CBIS5TEMTNNOTBE3WXPQUAGUEDYZZVIWAKTXEQCOUJ34OJJ3FJ5NLF2P',
       // SAC for CETES:GC3CW7EDYRTWQ635VDIGY6S4ZUF5L6TQ7AA4MWS7LEQDBLUSZXV7UPS4
       assetContractId: 'CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC',
@@ -132,7 +132,7 @@ function readEnv(name: string): string | undefined {
 /**
  * Resolve one venue, or `null` when it is not configured for the active
  * network. A null venue is a normal state (mainnet before the vault exists),
- * not an error — callers report it as unconfigured rather than throwing.
+ * not an error, callers report it as unconfigured rather than throwing.
  */
 export function getTreasuryVenue(id: TreasuryVenueId): TreasuryVenue | null {
   const network = resolveNetworkKey();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,6 +21,10 @@ import { cacheService } from './services/CacheService';
 import { NotificationService } from './services/NotificationService';
 import { createNotificationWorkerFromEnv } from './workers/notificationWorker';
 import { createKycExpiryJobFromEnv } from './workers/kycExpiryJob';
+import { validateApiEnv } from '@akkuea/shared';
+
+// Validate environment variables on startup (fails fast with actionable guide if missing)
+validateApiEnv();
 
 app
   .use(

--- a/apps/api/src/routes/treasury.ts
+++ b/apps/api/src/routes/treasury.ts
@@ -28,8 +28,8 @@ const movementBodySchema = z.object({
 /**
  * Read-only treasury endpoints.
  *
- * Position data is public on the ledger already, so exposing it needs no auth —
- * the point of the treasury track is that anyone can check it.
+ * Position data is public on the ledger already, so exposing it needs no auth.
+ * The point of the treasury track is that anyone can check it.
  */
 const publicTreasuryRoutes = new Elysia()
   .get(

--- a/apps/api/src/services/StellarService.ts
+++ b/apps/api/src/services/StellarService.ts
@@ -356,7 +356,7 @@ export class StellarService {
           propertyId: this.asBigInt(args[2]),
           amount: this.asBigInt(args[3]),
         });
-      // SEP-41 token transfer allowance — NOT the pilot-whitelist approve.
+      // SEP-41 token transfer allowance, not the pilot-whitelist approve.
       // Pilot-whitelist approvals bypass this switch and use the legacy XDR path.
       case 'approve':
         return tokenClient.approve({

--- a/apps/api/src/services/TreasuryService.ts
+++ b/apps/api/src/services/TreasuryService.ts
@@ -223,7 +223,7 @@ function assertSlippage(slippageBps: number): number {
  * otherwise would be worse than saying so.
  *
  * Note on price feeds: these two vaults are single-asset, and their deposit and
- * withdraw paths do not consult an oracle — verified by simulating a deposit
+ * withdraw paths do not consult an oracle, verified by simulating a deposit
  * against the deployed testnet vault and reading the call tree, which contains
  * only balance reads, a token transfer and the strategy call. A Blend-side
  * pricing failure would surface as `ExternalError` from the strategy, which is
@@ -410,7 +410,7 @@ function defaultVaultClientFactory(venue: TreasuryVenue, signerSecret?: string):
  * Deposits the accumulated platform fee into already-deployed, already-audited
  * DeFi venues, reads the resulting position back off chain, and keeps a local
  * record of both. Every number this service reports about a position is read
- * from the vault contract at request time — nothing here is estimated, and the
+ * from the vault contract at request time, nothing here is estimated, and the
  * stored snapshots are a cache of past reads, not a substitute for them.
  */
 export class TreasuryService {
@@ -575,7 +575,7 @@ export class TreasuryService {
    * Withdraw `amount` of the venue's underlying asset back to the treasury.
    *
    * The vault burns shares, not asset amounts, so the requested amount is
-   * converted using the vault's live share price — the same rule of three
+   * converted using the vault's live share price, the same rule of three
    * DeFindex documents: `shares = total_supply * amount / total_managed`.
    */
   async withdraw(request: TreasuryMovementRequest): Promise<TreasuryMovementResult> {

--- a/apps/api/src/tests/treasury.integration.test.ts
+++ b/apps/api/src/tests/treasury.integration.test.ts
@@ -4,14 +4,14 @@
  * assertion is about what the deployed contracts actually return.
  *
  * Two venues are covered:
- *   - `defindex-blend`       — DeFindex USDC vault, strategy `USDC Blend Strategy`
- *   - `etherfuse-stablebond` — DeFindex CETES vault, strategy `CETES Blend Strategy`
+ *   - `defindex-blend`       (DeFindex USDC vault, strategy `USDC Blend Strategy`)
+ *   - `etherfuse-stablebond` (DeFindex CETES vault, strategy `CETES Blend Strategy`)
  *     (CETES is Etherfuse's tokenized Mexican sovereign-debt Stablebond)
  *
  * Reads are simulations and move no funds. The deposit test also runs against
  * the real vault: it assembles and simulates a genuine `deposit` from a
  * freshly funded account, which the deployed contract rejects at the token
- * transfer. That failure is the point — it proves the argument encoding is
+ * transfer. That failure is the point, it proves the argument encoding is
  * accepted by the live WASM and that a real on-chain error decodes into the
  * typed error the API maps to an HTTP response.
  *

--- a/apps/contracts/contracts/defi-rwa/src/reentrancy_tests.rs
+++ b/apps/contracts/contracts/defi-rwa/src/reentrancy_tests.rs
@@ -287,7 +287,7 @@ fn test_borrow_rejected_at_checks_no_state_mutation() {
     // Try to borrow with sufficient LTV but insufficient health factor.
     // Collateral: 100 XLM * $1.00 = $100
     // Borrow: 70 USDC (passes collateral_factor: 70 ≤ 100*0.75=75)
-    // Health factor = (100 * 0.8) / 70 ≈ 1.14 < 1.5 ❌
+    // Health factor = (100 * 0.8) / 70 ≈ 1.14 < 1.5 [invalid]
     t.client.borrow(
         &t.borrower,
         &t.pool_id,

--- a/apps/contracts/contracts/defi-rwa/src/test.rs
+++ b/apps/contracts/contracts/defi-rwa/src/test.rs
@@ -1217,7 +1217,7 @@ fn test_borrow_with_sufficient_collateral() {
     // Calculate expected health factor:
     // Collateral value = 2000 XLM * $1.00 = $2000
     // Debt value = 1000 USDC = $1000
-    // Health factor = (2000 * 0.8) / 1000 = 1.6 * PRECISION > 1.5 * PRECISION ✓
+    // Health factor = (2000 * 0.8) / 1000 = 1.6 * PRECISION > 1.5 * PRECISION [valid]
 
     // Execute borrow
     let position = env.as_contract(&contract_id, || {
@@ -1338,7 +1338,7 @@ fn test_borrow_with_insufficient_collateral() {
     // Try to borrow with sufficient LTV but insufficient health factor.
     // Collateral: 1000 XLM * $1.00 = $1000
     // Borrow: 700 USDC (passes collateral_factor: 700 ≤ 1000*0.75=750)
-    // Health factor = (1000 * 0.8) / 700 ≈ 1.14 < 1.5 ❌
+    // Health factor = (1000 * 0.8) / 700 ≈ 1.14 < 1.5 [invalid]
     let borrow_amount = 700_000_000; // 700 USDC
     let collateral_amount = 1_000_000_000; // 1000 XLM
 

--- a/apps/shared/src/contracts/defindexVault.ts
+++ b/apps/shared/src/contracts/defindexVault.ts
@@ -61,7 +61,7 @@ export interface VaultWithdrawArgs {
  * Soroban surfaces two shapes of failure through the JS SDK:
  *   - a declared `Result::Err`, which the bindings hand back as an `Err` value;
  *   - a host trap (`Error(Contract, #N)`), thrown from `simulate`/`signAndSend`,
- *     which is what a nested call — a strategy, or the underlying token — does
+ *     which is what a nested call (a strategy, or the underlying token) does
  *     when it fails.
  *
  * Both end up here so callers only have to handle one thing.
@@ -225,8 +225,8 @@ export class DefindexVaultContractClient {
    *
    * The SDK builds the transaction without throwing when simulation fails; the
    * error only appears when `simulationData` is read, which for an unwary
-   * caller is at `signAndSend`. Reading it here moves a contract rejection —
-   * a paused strategy, an unfunded treasury account — to the point where the
+   * caller is at `signAndSend`. Reading it here moves a contract rejection,
+   * a paused strategy or an unfunded treasury account, to the point where the
    * call is made, where it can still be handled.
    */
   private async assemble(
@@ -263,7 +263,7 @@ export class DefindexVaultContractClient {
 
   /**
    * Every underlying asset the vault manages, with idle vs. invested split and
-   * the per-strategy allocation — including each strategy's `paused` flag.
+   * the per-strategy allocation, including each strategy's `paused` flag.
    */
   async fetchTotalManagedFunds(): Promise<CurrentAssetInvestmentAllocation[]> {
     return this.readResult(() => this.client.fetch_total_managed_funds());

--- a/apps/shared/src/contracts/generated/defindexVault.ts
+++ b/apps/shared/src/contracts/generated/defindexVault.ts
@@ -1,7 +1,7 @@
 /**
  * TypeScript bindings for the DeFindex Vault contract.
  *
- * GENERATED FILE — do not edit by hand. Produced with:
+ * GENERATED FILE, do not edit by hand. Produced with:
  *
  *   stellar contract bindings typescript \
  *     --network testnet \
@@ -10,7 +10,7 @@
  *
  * The spec below is downloaded from the WASM of the DeFindex USDC/Blend vault
  * deployed on Stellar testnet, so the interface here is the interface the
- * deployed contract actually exposes — not a transcription of documentation.
+ * deployed contract actually exposes, not a transcription of documentation.
  * The same vault WASM backs the CETES (Etherfuse Stablebond) vault, so one set
  * of bindings covers both treasury venues.
  *

--- a/apps/shared/src/env/__tests__/envValidation.test.ts
+++ b/apps/shared/src/env/__tests__/envValidation.test.ts
@@ -162,9 +162,11 @@ describe("Environment Validation Module", () => {
   describe("Webapp Environment Validation (validateWebappEnv)", () => {
     it("successfully validates a valid webapp environment", () => {
       const parsed = validateWebappEnv(VALID_WEBAPP_ENV);
-      expect(parsed.NEXT_PUBLIC_API_URL).toBe(VALID_WEBAPP_ENV.NEXT_PUBLIC_API_URL);
+      expect(parsed.NEXT_PUBLIC_API_URL).toBe(
+        VALID_WEBAPP_ENV.NEXT_PUBLIC_API_URL,
+      );
       expect(parsed.OPERATIONS_BACKEND_CREDENTIAL).toBe(
-        VALID_WEBAPP_ENV.OPERATIONS_BACKEND_CREDENTIAL
+        VALID_WEBAPP_ENV.OPERATIONS_BACKEND_CREDENTIAL,
       );
     });
 

--- a/apps/shared/src/env/__tests__/envValidation.test.ts
+++ b/apps/shared/src/env/__tests__/envValidation.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "bun:test";
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import {
+  validateApiEnv,
+  validateWebappEnv,
+  EnvValidationError,
+  isStellarPublicKey,
+  isStellarSecretSeed,
+  isStellarContractId,
+} from "../index";
+
+const sampleKeypair = Keypair.random();
+const VALID_PUBLIC_KEY = sampleKeypair.publicKey();
+const VALID_SECRET_KEY = sampleKeypair.secret();
+const VALID_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32));
+
+const VALID_API_ENV = {
+  DATABASE_URL: "postgresql://user:password@localhost:5432/akkuea_defi",
+  DATABASE_POOL_MAX: "10",
+  DATABASE_SSL: "false",
+  PORT: "3001",
+  NODE_ENV: "development",
+  LOG_LEVEL: "info",
+  WEBHOOK_SECRET: "0123456789abcdef0123456789abcdef",
+  OPERATIONS_BACKEND_CREDENTIAL: "0123456789abcdef0123456789abcdef",
+  OPERATIONS_ALLOWED_WALLETS: "*",
+  LIQUIDATOR_API_KEY: "0123456789abcdef0123456789abcdef",
+  INTERNAL_API_KEY: "0123456789abcdef0123456789abcdef",
+  KYC_UPLOAD_DIR: "/tmp/akkuea-kyc",
+  STELLAR_NETWORK: "testnet",
+  STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
+  STELLAR_RPC_URL: "https://soroban-testnet.stellar.org",
+  STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  STELLAR_ADMIN_PUBLIC_KEY: VALID_PUBLIC_KEY,
+  STELLAR_ADMIN_SECRET: VALID_SECRET_KEY,
+  REAL_ESTATE_TOKEN_CONTRACT_ID: VALID_CONTRACT_ID,
+};
+
+const VALID_WEBAPP_ENV = {
+  NEXT_PUBLIC_API_URL: "http://localhost:3001",
+  API_URL: "http://localhost:3001",
+  OPERATIONS_BACKEND_CREDENTIAL: "0123456789abcdef0123456789abcdef",
+  OPERATIONS_ALLOWED_WALLETS: "*",
+  NEXT_PUBLIC_USE_MOCK: "false",
+};
+
+describe("Environment Validation Module", () => {
+  describe("Stellar Format Helper Functions", () => {
+    it("validates Stellar public keys starting with G", () => {
+      expect(isStellarPublicKey(VALID_PUBLIC_KEY)).toBe(true);
+      expect(isStellarPublicKey("invalid_address")).toBe(false);
+      expect(isStellarPublicKey(VALID_SECRET_KEY)).toBe(false);
+    });
+
+    it("validates Stellar secret seeds starting with S", () => {
+      expect(isStellarSecretSeed(VALID_SECRET_KEY)).toBe(true);
+      expect(isStellarSecretSeed("invalid_secret")).toBe(false);
+      expect(isStellarSecretSeed(VALID_PUBLIC_KEY)).toBe(false);
+    });
+
+    it("validates Soroban contract IDs starting with C", () => {
+      expect(isStellarContractId(VALID_CONTRACT_ID)).toBe(true);
+      expect(isStellarContractId("invalid_contract_id")).toBe(false);
+    });
+  });
+
+  describe("API Environment Validation (validateApiEnv)", () => {
+    it("successfully validates a complete and valid API environment", () => {
+      const parsed = validateApiEnv(VALID_API_ENV);
+      expect(parsed.DATABASE_URL).toBe(VALID_API_ENV.DATABASE_URL);
+      expect(parsed.PORT).toBe(3001);
+      expect(parsed.NODE_ENV).toBe("development");
+      expect(parsed.STELLAR_ADMIN_PUBLIC_KEY).toBe(VALID_PUBLIC_KEY);
+    });
+
+    it("fails fast when a required variable is missing", () => {
+      const invalidEnv = { ...VALID_API_ENV };
+      delete (invalidEnv as Record<string, string | undefined>).DATABASE_URL;
+
+      expect(() => validateApiEnv(invalidEnv)).toThrow(EnvValidationError);
+      try {
+        validateApiEnv(invalidEnv);
+      } catch (err) {
+        const error = err as EnvValidationError;
+        expect(error.message).toContain("DATABASE_URL");
+        expect(error.message).toContain("docs/ENV_SETUP.md");
+      }
+    });
+
+    it("fails when STELLAR_ADMIN_PUBLIC_KEY is malformed", () => {
+      const invalidEnv = {
+        ...VALID_API_ENV,
+        STELLAR_ADMIN_PUBLIC_KEY: "INVALID_PUBLIC_KEY",
+      };
+
+      expect(() => validateApiEnv(invalidEnv)).toThrow(EnvValidationError);
+      try {
+        validateApiEnv(invalidEnv);
+      } catch (err) {
+        const error = err as EnvValidationError;
+        expect(error.message).toContain("STELLAR_ADMIN_PUBLIC_KEY");
+      }
+    });
+
+    it("fails when STELLAR_ADMIN_SECRET is malformed", () => {
+      const invalidEnv = {
+        ...VALID_API_ENV,
+        STELLAR_ADMIN_SECRET: "INVALID_SECRET_KEY",
+      };
+
+      expect(() => validateApiEnv(invalidEnv)).toThrow(EnvValidationError);
+      try {
+        validateApiEnv(invalidEnv);
+      } catch (err) {
+        const error = err as EnvValidationError;
+        expect(error.message).toContain("STELLAR_ADMIN_SECRET");
+      }
+    });
+
+    it("fails when a URL is invalid", () => {
+      const invalidEnv = {
+        ...VALID_API_ENV,
+        STELLAR_HORIZON_URL: "not-a-valid-url",
+      };
+
+      expect(() => validateApiEnv(invalidEnv)).toThrow(EnvValidationError);
+      try {
+        validateApiEnv(invalidEnv);
+      } catch (err) {
+        const error = err as EnvValidationError;
+        expect(error.message).toContain("STELLAR_HORIZON_URL");
+      }
+    });
+
+    it("aggregates multiple errors into a single clear error message", () => {
+      const invalidEnv = {
+        ...VALID_API_ENV,
+        STELLAR_ADMIN_PUBLIC_KEY: "BAD_KEY",
+        STELLAR_HORIZON_URL: "BAD_URL",
+      };
+      delete (invalidEnv as Record<string, string | undefined>).DATABASE_URL;
+
+      try {
+        validateApiEnv(invalidEnv);
+        expect(true).toBe(false);
+      } catch (err) {
+        const error = err as EnvValidationError;
+        expect(error.issues.length).toBeGreaterThanOrEqual(3);
+        expect(error.message).toContain("DATABASE_URL");
+        expect(error.message).toContain("STELLAR_ADMIN_PUBLIC_KEY");
+        expect(error.message).toContain("STELLAR_HORIZON_URL");
+        expect(error.message).toContain("docs/ENV_SETUP.md");
+      }
+    });
+
+    it("bypasses validation when SKIP_ENV_VALIDATION is set", () => {
+      const invalidEnv = { SKIP_ENV_VALIDATION: "true" };
+      expect(() => validateApiEnv(invalidEnv)).not.toThrow();
+    });
+  });
+
+  describe("Webapp Environment Validation (validateWebappEnv)", () => {
+    it("successfully validates a valid webapp environment", () => {
+      const parsed = validateWebappEnv(VALID_WEBAPP_ENV);
+      expect(parsed.NEXT_PUBLIC_API_URL).toBe(VALID_WEBAPP_ENV.NEXT_PUBLIC_API_URL);
+      expect(parsed.OPERATIONS_BACKEND_CREDENTIAL).toBe(
+        VALID_WEBAPP_ENV.OPERATIONS_BACKEND_CREDENTIAL
+      );
+    });
+
+    it("fails fast when NEXT_PUBLIC_API_URL is missing or invalid", () => {
+      const invalidEnv = {
+        ...VALID_WEBAPP_ENV,
+        NEXT_PUBLIC_API_URL: "invalid_url",
+      };
+
+      expect(() => validateWebappEnv(invalidEnv)).toThrow(EnvValidationError);
+      try {
+        validateWebappEnv(invalidEnv);
+      } catch (err) {
+        const error = err as EnvValidationError;
+        expect(error.message).toContain("NEXT_PUBLIC_API_URL");
+        expect(error.message).toContain("docs/ENV_SETUP.md");
+      }
+    });
+  });
+});

--- a/apps/shared/src/env/index.ts
+++ b/apps/shared/src/env/index.ts
@@ -1,0 +1,2 @@
+export * from "./schemas";
+export * from "./validateEnv";

--- a/apps/shared/src/env/schemas.ts
+++ b/apps/shared/src/env/schemas.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+import { StrKey } from "@stellar/stellar-sdk";
+
+export const isStellarPublicKey = (val: string): boolean => {
+  try {
+    return (
+      typeof val === "string" &&
+      val.startsWith("G") &&
+      val.length === 56 &&
+      StrKey.isValidEd25519PublicKey(val)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const isStellarSecretSeed = (val: string): boolean => {
+  try {
+    return (
+      typeof val === "string" &&
+      val.startsWith("S") &&
+      val.length === 56 &&
+      StrKey.isValidEd25519SecretSeed(val)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const isStellarContractId = (val: string): boolean => {
+  try {
+    return (
+      typeof val === "string" &&
+      val.startsWith("C") &&
+      val.length === 56 &&
+      StrKey.isValidContract(val)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const stellarPublicKeySchema = z
+  .string({ required_error: "Must be a valid Stellar public key (56 characters starting with G)" })
+  .refine(isStellarPublicKey, {
+    message: "Must be a valid Stellar public key (56 characters starting with G)",
+  });
+
+export const stellarSecretSeedSchema = z
+  .string({ required_error: "Must be a valid Stellar secret seed (56 characters starting with S)" })
+  .refine(isStellarSecretSeed, {
+    message: "Must be a valid Stellar secret seed (56 characters starting with S)",
+  });
+
+export const stellarContractIdSchema = z
+  .string({ required_error: "Must be a valid Soroban contract ID (56 characters starting with C)" })
+  .refine(isStellarContractId, {
+    message: "Must be a valid Soroban contract ID (56 characters starting with C)",
+  });
+
+export const urlSchema = z.string({ required_error: "Must be a valid URL" }).url({
+  message: "Must be a valid URL (e.g. https://... or http://...)",
+});
+
+export const portSchema = z
+  .string()
+  .optional()
+  .transform((val) => (val ? parseInt(val, 10) : 3001))
+  .pipe(z.number().int().min(1).max(65535));
+
+export const booleanSchema = z
+  .union([z.boolean(), z.string()])
+  .optional()
+  .transform((val) => {
+    if (typeof val === "boolean") return val;
+    if (typeof val === "string") return val.toLowerCase() === "true" || val === "1";
+    return undefined;
+  });
+
+export const apiEnvSchema = z.object({
+  DATABASE_URL: z
+    .string({ required_error: "DATABASE_URL is required" })
+    .min(1, "DATABASE_URL is required"),
+  DATABASE_POOL_MAX: z
+    .string()
+    .optional()
+    .transform((val) => (val ? parseInt(val, 10) : 10)),
+  DATABASE_SSL: booleanSchema,
+  PORT: portSchema,
+  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).optional(),
+  WEBHOOK_SECRET: z
+    .string({ required_error: "WEBHOOK_SECRET is required" })
+    .min(1, "WEBHOOK_SECRET is required"),
+  OPERATIONS_BACKEND_CREDENTIAL: z
+    .string({ required_error: "OPERATIONS_BACKEND_CREDENTIAL is required" })
+    .min(1, "OPERATIONS_BACKEND_CREDENTIAL is required"),
+  OPERATIONS_ALLOWED_WALLETS: z.string().optional(),
+  LIQUIDATOR_API_KEY: z
+    .string({ required_error: "LIQUIDATOR_API_KEY is required" })
+    .min(1, "LIQUIDATOR_API_KEY is required"),
+  INTERNAL_API_KEY: z
+    .string({ required_error: "INTERNAL_API_KEY is required" })
+    .min(1, "INTERNAL_API_KEY is required"),
+  KYC_UPLOAD_DIR: z
+    .string({ required_error: "KYC_UPLOAD_DIR is required" })
+    .min(1, "KYC_UPLOAD_DIR is required"),
+  KYC_EXPIRY_JOB_ENABLED: booleanSchema,
+  KYC_EXPIRY_POLL_INTERVAL_MS: z.string().optional(),
+  KYC_EXPIRY_REMINDER_WINDOW_MS: z.string().optional(),
+  NOTIFICATIONS_ENABLED: booleanSchema,
+  NOTIFICATION_WEBHOOK_URL: urlSchema.optional().or(z.literal("")),
+  NOTIFICATION_WEBHOOK_SECRET: z.string().optional(),
+  NOTIFICATION_POLL_INTERVAL_MS: z.string().optional(),
+  NOTIFICATION_REQUEST_TIMEOUT_MS: z.string().optional(),
+  REDIS_URL: urlSchema.optional().or(z.literal("")),
+  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).optional().default("testnet"),
+  STELLAR_HORIZON_URL: urlSchema,
+  STELLAR_RPC_URL: urlSchema,
+  STELLAR_NETWORK_PASSPHRASE: z
+    .string({ required_error: "STELLAR_NETWORK_PASSPHRASE is required" })
+    .min(1, "STELLAR_NETWORK_PASSPHRASE is required"),
+  STELLAR_ADMIN_PUBLIC_KEY: stellarPublicKeySchema,
+  STELLAR_ADMIN_SECRET: stellarSecretSeedSchema,
+  REAL_ESTATE_TOKEN_CONTRACT_ID: stellarContractIdSchema.optional().or(z.literal("")),
+  DEFI_RWA_CONTRACT_ID: stellarContractIdSchema.optional().or(z.literal("")),
+});
+
+export const webappEnvSchema = z.object({
+  NEXT_PUBLIC_API_URL: urlSchema,
+  API_URL: urlSchema,
+  OPERATIONS_BACKEND_CREDENTIAL: z
+    .string({ required_error: "OPERATIONS_BACKEND_CREDENTIAL is required" })
+    .min(1, "OPERATIONS_BACKEND_CREDENTIAL is required"),
+  OPERATIONS_ALLOWED_WALLETS: z
+    .string({ required_error: "OPERATIONS_ALLOWED_WALLETS is required" })
+    .min(1, "OPERATIONS_ALLOWED_WALLETS is required"),
+  NEXT_PUBLIC_LENDING_SSE_URL: urlSchema.optional().or(z.literal("")),
+  NEXT_PUBLIC_USE_MOCK: booleanSchema,
+  NEXT_PUBLIC_PRIVY_APP_ID: z.string().optional(),
+  PRIVY_APP_SECRET: z.string().optional(),
+  NEXT_PUBLIC_POLLAR_KEY: z.string().optional(),
+});
+
+export type ApiEnv = z.infer<typeof apiEnvSchema>;
+export type WebappEnv = z.infer<typeof webappEnvSchema>;

--- a/apps/shared/src/env/schemas.ts
+++ b/apps/shared/src/env/schemas.ts
@@ -41,26 +41,40 @@ export const isStellarContractId = (val: string): boolean => {
 };
 
 export const stellarPublicKeySchema = z
-  .string({ required_error: "Must be a valid Stellar public key (56 characters starting with G)" })
+  .string({
+    required_error:
+      "Must be a valid Stellar public key (56 characters starting with G)",
+  })
   .refine(isStellarPublicKey, {
-    message: "Must be a valid Stellar public key (56 characters starting with G)",
+    message:
+      "Must be a valid Stellar public key (56 characters starting with G)",
   });
 
 export const stellarSecretSeedSchema = z
-  .string({ required_error: "Must be a valid Stellar secret seed (56 characters starting with S)" })
+  .string({
+    required_error:
+      "Must be a valid Stellar secret seed (56 characters starting with S)",
+  })
   .refine(isStellarSecretSeed, {
-    message: "Must be a valid Stellar secret seed (56 characters starting with S)",
+    message:
+      "Must be a valid Stellar secret seed (56 characters starting with S)",
   });
 
 export const stellarContractIdSchema = z
-  .string({ required_error: "Must be a valid Soroban contract ID (56 characters starting with C)" })
+  .string({
+    required_error:
+      "Must be a valid Soroban contract ID (56 characters starting with C)",
+  })
   .refine(isStellarContractId, {
-    message: "Must be a valid Soroban contract ID (56 characters starting with C)",
+    message:
+      "Must be a valid Soroban contract ID (56 characters starting with C)",
   });
 
-export const urlSchema = z.string({ required_error: "Must be a valid URL" }).url({
-  message: "Must be a valid URL (e.g. https://... or http://...)",
-});
+export const urlSchema = z
+  .string({ required_error: "Must be a valid URL" })
+  .url({
+    message: "Must be a valid URL (e.g. https://... or http://...)",
+  });
 
 export const portSchema = z
   .string()
@@ -73,7 +87,8 @@ export const booleanSchema = z
   .optional()
   .transform((val) => {
     if (typeof val === "boolean") return val;
-    if (typeof val === "string") return val.toLowerCase() === "true" || val === "1";
+    if (typeof val === "string")
+      return val.toLowerCase() === "true" || val === "1";
     return undefined;
   });
 
@@ -87,7 +102,9 @@ export const apiEnvSchema = z.object({
     .transform((val) => (val ? parseInt(val, 10) : 10)),
   DATABASE_SSL: booleanSchema,
   PORT: portSchema,
-  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
   LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).optional(),
   WEBHOOK_SECRET: z
     .string({ required_error: "WEBHOOK_SECRET is required" })
@@ -122,7 +139,9 @@ export const apiEnvSchema = z.object({
     .min(1, "STELLAR_NETWORK_PASSPHRASE is required"),
   STELLAR_ADMIN_PUBLIC_KEY: stellarPublicKeySchema,
   STELLAR_ADMIN_SECRET: stellarSecretSeedSchema,
-  REAL_ESTATE_TOKEN_CONTRACT_ID: stellarContractIdSchema.optional().or(z.literal("")),
+  REAL_ESTATE_TOKEN_CONTRACT_ID: stellarContractIdSchema
+    .optional()
+    .or(z.literal("")),
   DEFI_RWA_CONTRACT_ID: stellarContractIdSchema.optional().or(z.literal("")),
 });
 

--- a/apps/shared/src/env/validateEnv.ts
+++ b/apps/shared/src/env/validateEnv.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { apiEnvSchema, webappEnvSchema, type ApiEnv, type WebappEnv } from "./schemas";
+import {
+  apiEnvSchema,
+  webappEnvSchema,
+  type ApiEnv,
+  type WebappEnv,
+} from "./schemas";
 
 export class EnvValidationError extends Error {
   public readonly issues: string[];

--- a/apps/shared/src/env/validateEnv.ts
+++ b/apps/shared/src/env/validateEnv.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { apiEnvSchema, webappEnvSchema, type ApiEnv, type WebappEnv } from "./schemas";
+
+export class EnvValidationError extends Error {
+  public readonly issues: string[];
+  public readonly scope: string;
+
+  constructor(scope: string, issues: string[]) {
+    const formattedIssues = issues.map((issue) => `  - ${issue}`).join("\n");
+    const message = [
+      `Environment validation failed for ${scope}:`,
+      formattedIssues,
+      "",
+      "Please refer to docs/ENV_SETUP.md for instructions on obtaining real local development values.",
+    ].join("\n");
+
+    super(message);
+    this.name = "EnvValidationError";
+    this.scope = scope;
+    this.issues = issues;
+  }
+}
+
+export function validateEnv<Output, Def extends z.ZodTypeDef, Input>(
+  schema: z.ZodType<Output, Def, Input>,
+  env: Record<string, string | undefined> = process.env,
+  scope: string = "Application",
+): Output {
+  if (env.SKIP_ENV_VALIDATION === "true" || env.SKIP_ENV_VALIDATION === "1") {
+    return env as unknown as Output;
+  }
+
+  const result = schema.safeParse(env);
+
+  if (!result.success) {
+    const issues: string[] = [];
+
+    for (const error of result.error.errors) {
+      const path = error.path.join(".") || "environment";
+      issues.push(`${path}: ${error.message}`);
+    }
+
+    throw new EnvValidationError(scope, issues);
+  }
+
+  return result.data;
+}
+
+export function validateApiEnv(
+  env: Record<string, string | undefined> = process.env,
+): ApiEnv {
+  return validateEnv(apiEnvSchema, env, "API (apps/api)");
+}
+
+export function validateWebappEnv(
+  env: Record<string, string | undefined> = process.env,
+): WebappEnv {
+  return validateEnv(webappEnvSchema, env, "Webapp (apps/webapp)");
+}

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -28,3 +28,4 @@ export * from "./utils/stellar";
 export * from "./utils/validation";
 export * from "./utils/format";
 export * from "./utils/bigintMath";
+export * from "./env";

--- a/apps/webapp/messages/en.json
+++ b/apps/webapp/messages/en.json
@@ -166,7 +166,7 @@
   "Treasury": {
     "title": "Treasury",
     "whatThisIs": "Where the accumulated platform fee is held, and what it is doing.",
-    "whyItExists": "The platform fee builds up in a Stellar account. Rather than leave it sitting idle, it is deposited into two DeFi venues that are already deployed and already audited: DeFindex's Blend strategy, and Etherfuse's Stablebonds. This is treasury management — the balance earns a return instead of nothing. It is not an exercise in producing numbers to point at.",
+    "whyItExists": "The platform fee builds up in a Stellar account. Rather than leave it sitting idle, it is deposited into two DeFi venues that are already deployed and already audited: DeFindex's Blend strategy, and Etherfuse's Stablebonds. This is treasury management, the balance earns a return instead of nothing. It is not an exercise in producing numbers to point at.",
     "howToVerify": "Because it settles on chain, the record is checkable by anyone. Every figure on this page is read from the vault contracts when the page loads; none of it is estimated or projected. The links below go to the contracts and the treasury account on stellar.expert, so you can confirm each number against the ledger yourself.",
     "positionValue": "Position value",
     "sharesHeld": "{shares} vault shares",

--- a/apps/webapp/messages/es.json
+++ b/apps/webapp/messages/es.json
@@ -166,7 +166,7 @@
   "Treasury": {
     "title": "Tesorería",
     "whatThisIs": "Dónde se guarda la comisión acumulada de la plataforma y qué está haciendo.",
-    "whyItExists": "La comisión de la plataforma se acumula en una cuenta de Stellar. En lugar de dejarla inactiva, se deposita en dos plataformas DeFi ya desplegadas y ya auditadas: la estrategia Blend de DeFindex y los Stablebonds de Etherfuse. Esto es gestión de tesorería — el saldo genera un rendimiento en vez de nada. No es un ejercicio para producir cifras que exhibir.",
+    "whyItExists": "La comisión de la plataforma se acumula en una cuenta de Stellar. En lugar de dejarla inactiva, se deposita en dos plataformas DeFi ya desplegadas y ya auditadas: la estrategia Blend de DeFindex y los Stablebonds de Etherfuse. Esto es gestión de tesorería, el saldo genera un rendimiento en vez de nada. No es un ejercicio para producir cifras que exhibir.",
     "howToVerify": "Como se liquida en cadena, el registro es verificable por cualquiera. Cada cifra de esta página se lee de los contratos de los vaults al cargarla; ninguna es estimada ni proyectada. Los enlaces de abajo llevan a los contratos y a la cuenta de tesorería en stellar.expert, para que puedas confirmar cada número contra el ledger.",
     "positionValue": "Valor de la posición",
     "sharesHeld": "{shares} participaciones del vault",

--- a/apps/webapp/next.config.ts
+++ b/apps/webapp/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
+// Validate webapp environment configuration on server boot
+import "./src/lib/env";
+
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {

--- a/apps/webapp/src/components/pilot/WhitelistOnboardingForm.stories.tsx
+++ b/apps/webapp/src/components/pilot/WhitelistOnboardingForm.stories.tsx
@@ -53,7 +53,7 @@ type Story = StoryObj<typeof WhitelistOnboardingForm>;
 // ---------------------------------------------------------------------------
 
 /**
- * Wallet not connected and no existing request — shows the EmptyState with
+ * Wallet not connected and no existing request, shows the EmptyState with
  * a "Start Application" CTA.
  */
 export const NoApplication: Story = {
@@ -61,7 +61,7 @@ export const NoApplication: Story = {
 };
 
 /**
- * Loading state — status check is in flight.
+ * Loading state, status check is in flight.
  */
 export const StatusLoading: Story = {
   decorators: [
@@ -82,14 +82,14 @@ export const PendingReview: Story = {
 };
 
 /**
- * Investor has been approved — whitelisted!
+ * Investor has been approved, whitelisted!
  */
 export const Approved: Story = {
   decorators: [mockFetch(statusMock("approved"))],
 };
 
 /**
- * Investor was rejected — rejection reason is displayed clearly.
+ * Investor was rejected, rejection reason is displayed clearly.
  */
 export const Rejected: Story = {
   decorators: [
@@ -103,22 +103,22 @@ export const Rejected: Story = {
 };
 
 /**
- * Stepper step 1 — Personal Details form (initial active state).
+ * Stepper step 1, Personal Details form (initial active state).
  * The status fetch returns "none" so the form renders after clicking Start.
  * NOTE: In Storybook, click "Start Application" on the EmptyState to reach this view.
  */
 export const FormStep1PersonalDetails: Story = {
-  name: "Form — Step 1: Personal Details",
+  name: "Form, Step 1: Personal Details",
   decorators: [mockFetch(statusMock("none"))],
 };
 
 /**
- * Stepper step 3 — Review & Submit summary.
+ * Stepper step 3, Review & Submit summary.
  * The fetch mock simulates a completed form: status=none so the form renders,
  * and the POST /request is mocked to succeed.
  */
 export const FormStep3Review: Story = {
-  name: "Form — Step 3: Review & Submit",
+  name: "Form, Step 3: Review & Submit",
   decorators: [
     mockFetch(async (input) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/apps/webapp/src/components/pilot/WhitelistReviewQueue.stories.tsx
+++ b/apps/webapp/src/components/pilot/WhitelistReviewQueue.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj, Decorator } from "@storybook/react";
 import { WhitelistReviewQueue } from "./WhitelistReviewQueue";
 
 // ---------------------------------------------------------------------------
-// Fetch mock helpers — avoids needing msw-storybook-addon
+// Fetch mock helpers, avoids needing msw-storybook-addon
 // ---------------------------------------------------------------------------
 type FetchMock = (input: RequestInfo | URL) => Promise<Response>;
 
@@ -64,7 +64,7 @@ type Story = StoryObj<typeof WhitelistReviewQueue>;
 // Stories
 // ---------------------------------------------------------------------------
 
-/** Two pending requests in the queue — the typical operator view. */
+/** Two pending requests in the queue, the typical operator view. */
 export const WithRequests: Story = {
   decorators: [
     mockFetch(
@@ -77,7 +77,7 @@ export const WithRequests: Story = {
   ],
 };
 
-/** No pending requests — shows the EmptyState component. */
+/** No pending requests, shows the EmptyState component. */
 export const EmptyQueue: Story = {
   decorators: [
     mockFetch(
@@ -90,7 +90,7 @@ export const EmptyQueue: Story = {
   ],
 };
 
-/** API fetch is slow — shows the loading spinner text. */
+/** API fetch is slow, shows the loading spinner text. */
 export const LoadingState: Story = {
   decorators: [
     mockFetch(
@@ -102,7 +102,7 @@ export const LoadingState: Story = {
   ],
 };
 
-/** API returns an error — shows SectionErrorFallback with a Retry button. */
+/** API returns an error, shows SectionErrorFallback with a Retry button. */
 export const ErrorState: Story = {
   decorators: [
     mockFetch(

--- a/apps/webapp/src/components/treasury/TreasuryPanel.tsx
+++ b/apps/webapp/src/components/treasury/TreasuryPanel.tsx
@@ -26,8 +26,8 @@ import { cn, truncateAddress } from "@/lib/utils";
 /**
  * Render an asset amount that arrived from the API as a decimal string.
  *
- * The string is kept as the source of truth and only trimmed for display —
- * never parsed into a float and re-rendered — so what a reader sees always
+ * The string is kept as the source of truth and only trimmed for display,
+ * never parsed into a float and re-rendered, so what a reader sees always
  * matches what the ledger holds.
  */
 function formatAssetAmount(value: string, maxDecimals = 4): string {
@@ -154,7 +154,7 @@ function HistoryRow({
         {t(`operation.${entry.operation}`)}
       </td>
       <td className="py-2 pr-4 tabular-nums text-zinc-300">
-        {entry.amount ? formatAssetAmount(entry.amount) : "—"} {entry.assetCode}
+        {entry.amount ? formatAssetAmount(entry.amount) : "-"} {entry.assetCode}
       </td>
       <td className="py-2 pr-4">
         <span
@@ -180,7 +180,7 @@ function HistoryRow({
             <ExternalLink className="h-3 w-3" aria-hidden="true" />
           </a>
         ) : (
-          <span className="text-zinc-600">—</span>
+          <span className="text-zinc-600">-</span>
         )}
       </td>
     </tr>

--- a/apps/webapp/src/lib/env.ts
+++ b/apps/webapp/src/lib/env.ts
@@ -1,0 +1,4 @@
+import { validateWebappEnv } from "@akkuea/shared";
+
+// Validate webapp environment variables at boot time
+export const env = validateWebappEnv();

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -1,0 +1,305 @@
+# Environment Variable Setup Guide
+
+This guide provides concrete, step-by-step instructions for obtaining real development values for every environment variable used in the Akkuea monorepo (`apps/api` and `apps/webapp`).
+
+> **SECURITY WARNING**
+> Never commit real secret credentials, private keys, or production tokens to version control. All `.env` files are ignored by git (`.gitignore`). Every example in this document uses placeholder syntax or commands to generate local dev credentials.
+
+---
+
+## Overview
+
+To set up your local development environment:
+
+1. For the API backend (`apps/api`):
+   ```bash
+   cp apps/api/.env.example apps/api/.env
+   ```
+2. For the Webapp frontend (`apps/webapp`):
+   ```bash
+   cp apps/webapp/.env.example apps/webapp/.env.local
+   # or copy from apps/webapp/.env.local.example
+   ```
+
+---
+
+## Variable Reference and Instructions
+
+### 1. Database Configuration
+
+#### `DATABASE_URL`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Run the local PostgreSQL container using Docker Compose:
+    ```bash
+    docker compose -f docker-compose.dev.yml up -d
+    ```
+  - Standard local development connection string:
+    `postgresql://user:password@localhost:5432/akkuea_defi`
+  - For local integration tests / CI:
+    `postgresql://test:test@localhost:5432/akkuea_test` (run via `docker run -d --name akkuea-pg-test -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=akkuea_test -p 5432:5432 postgres:16`)
+
+#### `DATABASE_POOL_MAX`
+- **Required**: No (default: `10`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Set to `10` or omit to use the default pool size.
+
+#### `DATABASE_SSL`
+- **Required**: No (default: `false`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Set to `false` for local development. Set to `true` only in production environments requiring SSL connections.
+
+---
+
+### 2. API Server Configuration
+
+#### `PORT`
+- **Required**: No (default: `3001`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Default is `3001`. Set to another numeric port if 3001 is in use.
+
+#### `NODE_ENV`
+- **Required**: Yes
+- **Consumer**: `apps/api`, `apps/webapp`
+- **Where to get a value for local development**: Set to `development` for local work, `test` during test runs, or `production` for live deployments.
+
+#### `LOG_LEVEL`
+- **Required**: No (default: `info`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Options are `debug`, `info`, `warn`, or `error`. Use `debug` when inspecting detailed API output locally.
+
+---
+
+### 3. Internal Security Credentials
+
+#### `WEBHOOK_SECRET`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Generate a random 32-byte hex secret using OpenSSL:
+  ```bash
+  openssl rand -hex 32
+  ```
+
+#### `OPERATIONS_BACKEND_CREDENTIAL`
+- **Required**: Yes
+- **Consumer**: `apps/api`, `apps/webapp`
+- **Where to get a value for local development**: Generate a random secret using OpenSSL:
+  ```bash
+  openssl rand -hex 32
+  ```
+  **Note**: This value MUST match in both `apps/api/.env` and `apps/webapp/.env.local`.
+
+#### `OPERATIONS_ALLOWED_WALLETS`
+- **Required**: Yes (production), optional/wildcard in development
+- **Consumer**: `apps/api`, `apps/webapp`
+- **Where to get a value for local development**: Set to `*` to permit any wallet address during local development, or list comma-separated Stellar public keys (e.g. `GABC123...,GDEF456...`).
+
+#### `LIQUIDATOR_API_KEY`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Generate a random key using OpenSSL:
+  ```bash
+  openssl rand -hex 32
+  ```
+
+#### `INTERNAL_API_KEY`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Generate a random key using OpenSSL:
+  ```bash
+  openssl rand -hex 32
+  ```
+
+---
+
+### 4. KYC and Document Storage
+
+#### `KYC_UPLOAD_DIR`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Specify any absolute path to a writable directory on your computer (e.g. `./uploads` or `/tmp/akkuea-kyc`).
+- **Production Note**: Must point to an isolated, non-public directory with strict operating system access controls.
+
+#### `KYC_EXPIRY_JOB_ENABLED`
+- **Required**: No (default: `true`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Set to `true` (or omit) to enable the background KYC expiry worker, or `false` to disable.
+
+#### `KYC_EXPIRY_POLL_INTERVAL_MS`
+- **Required**: No (default: `86400000`, 24 hours)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Default is 24 hours (`86400000`). Set to a lower number (e.g. `10000` for 10 seconds) when testing expiry behavior.
+
+#### `KYC_EXPIRY_REMINDER_WINDOW_MS`
+- **Required**: No (default: `2592000000`, 30 days)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Default is 30 days (`2592000000`). Adjust as needed for testing.
+
+---
+
+### 5. Notification Delivery Worker
+
+#### `NOTIFICATIONS_ENABLED`
+- **Required**: No (default: `true`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Set to `true` (or omit) to run the background notification worker, or `false` to disable.
+
+#### `NOTIFICATION_WEBHOOK_URL`
+- **Required**: No
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Use a webhook testing service (such as webhook.site) or a local mock endpoint URL.
+
+#### `NOTIFICATION_WEBHOOK_SECRET`
+- **Required**: No
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Generate via `openssl rand -hex 32` or use a test passphrase.
+
+#### `NOTIFICATION_POLL_INTERVAL_MS`
+- **Required**: No (default: `5000`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Poll interval in milliseconds (default: 5000).
+
+#### `NOTIFICATION_REQUEST_TIMEOUT_MS`
+- **Required**: No (default: `10000`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: HTTP request timeout in milliseconds (default: 10000).
+
+---
+
+### 6. Redis Caching
+
+#### `REDIS_URL`
+- **Required**: No
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Start the local Redis container using Docker Compose:
+    ```bash
+    docker compose -f docker-compose.dev.yml up -d
+    ```
+  - Standard connection string: `redis://localhost:6379`
+  - If unset or unreachable, the API falls back seamlessly to direct database queries.
+
+---
+
+### 7. Stellar / Soroban Network Configuration
+
+#### `STELLAR_NETWORK`
+- **Required**: No (default: `testnet`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Set to `testnet` for testnet development or `mainnet` for live deployments.
+
+#### `STELLAR_HORIZON_URL`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Testnet: `https://horizon-testnet.stellar.org`
+  - Mainnet: `https://horizon.stellar.org`
+
+#### `STELLAR_RPC_URL`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Testnet: `https://soroban-testnet.stellar.org`
+  - Mainnet: `https://soroban.stellar.org`
+
+#### `STELLAR_NETWORK_PASSPHRASE`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Testnet: `Test SDF Network ; September 2015`
+  - Mainnet: `Public Global Stellar Network ; September 2015`
+  - Local Quickstart: `Standalone Network ; February 2017`
+  **Note**: Mind the exact string spacing, including the space before the semicolon.
+
+---
+
+### 8. Stellar / Soroban Admin Identity
+
+> **SECURITY WARNING - STELLAR_ADMIN_SECRET**
+> The admin secret key controls on-chain protocol permissions (minting shares, pool creation, role grants). Never share or commit this key.
+
+#### `STELLAR_ADMIN_PUBLIC_KEY`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Option A (Stellar CLI):
+    ```bash
+    stellar keys generate --network testnet --fund admin
+    stellar keys address admin
+    ```
+  - Option B (Stellar Laboratory):
+    Visit https://laboratory.stellar.org/#account-creator?network=testnet and click **Generate keypair**, then click **Fund with Friendbot**. Copy the generated Public Key (starts with `G`, 56 characters).
+
+#### `STELLAR_ADMIN_SECRET`
+- **Required**: Yes
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**:
+  - Option A (Stellar CLI):
+    ```bash
+    stellar keys show admin
+    ```
+  - Option B (Stellar Laboratory):
+    Copy the Secret Key (starts with `S`, 56 characters) generated alongside your public key from https://laboratory.stellar.org/#account-creator?network=testnet.
+
+---
+
+### 9. Stellar / Soroban Contract IDs
+
+#### `REAL_ESTATE_TOKEN_CONTRACT_ID`
+- **Required**: Optional override (defaults to `apps/shared/src/contracts.testnet.json`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Leave unset to use the standard testnet deployment in `@akkuea/shared`. If deploying custom contracts locally, copy the contract ID (starts with `C`, 56 characters) output from:
+  ```bash
+  bun run deploy:contracts
+  ```
+  See `docs/deployment/deploy-contracts.md` for full deployment instructions.
+
+#### `DEFI_RWA_CONTRACT_ID`
+- **Required**: Optional override (defaults to `apps/shared/src/contracts.testnet.json`)
+- **Consumer**: `apps/api`
+- **Where to get a value for local development**: Leave unset to use default shared contract ID, or insert your custom deployed contract ID.
+
+---
+
+### 10. WebApp Frontend Variables
+
+#### `NEXT_PUBLIC_API_URL`
+- **Required**: Yes
+- **Consumer**: `apps/webapp` (browser client)
+- **Where to get a value for local development**: `http://localhost:3001`
+
+#### `API_URL`
+- **Required**: Yes
+- **Consumer**: `apps/webapp` (Next.js server side)
+- **Where to get a value for local development**: `http://localhost:3001`
+
+#### `NEXT_PUBLIC_PRIVY_APP_ID`
+- **Required**: No
+- **Consumer**: `apps/webapp`
+- **Where to get a value for local development**:
+  - Visit https://dashboard.privy.io to create a free developer app.
+  - Copy the App ID from your Privy dashboard settings.
+  - If left empty, Privy embedded login is disabled and only browser extension wallets (e.g. Freighter) are active.
+
+#### `PRIVY_APP_SECRET`
+- **Required**: No (server side only)
+- **Consumer**: `apps/webapp`
+- **Where to get a value for local development**:
+  - Copy from https://dashboard.privy.io under App Settings > App Secret.
+  - Keep this key server-side only; never expose it in client bundles.
+
+#### `NEXT_PUBLIC_POLLAR_KEY`
+- **Required**: No
+- **Consumer**: `apps/webapp`
+- **Where to get a value for local development**: Obtain an API key from the Pollar dashboard if social authentication testing is required, or leave empty to disable.
+
+#### `NEXT_PUBLIC_USE_MOCK`
+- **Required**: No (default: `false`)
+- **Consumer**: `apps/webapp`
+- **Where to get a value for local development**: Set to `true` to enable Mock Service Worker (MSW) for offline frontend development without running the API server. Set to `false` when connecting to a live local API server.
+
+#### `NEXT_PUBLIC_LENDING_SSE_URL`
+- **Required**: No
+- **Consumer**: `apps/webapp`
+- **Where to get a value for local development**: Leave empty to use HTTP polling, or set to `http://localhost:3001/lending/sse` if testing real-time events.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Welcome to Akkuea's documentation. **Start with [`strategy/product-brief.md`](st
 
 > Start here for any production or testnet launch of the existing `defi-rwa` platform contract. Akkuea Land has its own deployment guide (below).
 
-- [Environment Variables](deployment/environment-variables.md) - complete `.env` reference, secret warnings, network passphrases
+- [Environment Variables](deployment/environment-variables.md) (see also: [Environment Setup Guide](ENV_SETUP.md)) - complete `.env` reference, secret warnings, network passphrases
 - [Deploy Contracts](deployment/deploy-contracts.md) - build, deploy, oracle setup, pool creation, role grants
 - [Post-Deploy Checklist](deployment/post-deploy-checklist.md) - Day 0 action list: liveness, oracle, roles, pool, API verification
 - [Deployment Records](contracts/deployment.md) - testnet/mainnet contract IDs and the mainnet approval checklist

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -48,7 +48,7 @@ bun install
 
 ### 3. Environment Configuration
 
-You need to set up environment variables for the API and Webapp.
+You need to set up environment variables for the API and Webapp. For a complete guide detailing where to obtain real development values for every single variable, see the [Environment Variable Setup Guide](docs/ENV_SETUP.md).
 
 #### API Configuration
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -48,7 +48,7 @@ bun install
 
 ### 3. Environment Configuration
 
-You need to set up environment variables for the API and Webapp. For a complete guide detailing where to obtain real development values for every single variable, see the [Environment Variable Setup Guide](docs/ENV_SETUP.md).
+You need to set up environment variables for the API and Webapp. For a complete guide detailing where to obtain real development values for every single variable, see the [Environment Variable Setup Guide](ENV_SETUP.md).
 
 #### API Configuration
 

--- a/docs/operations/runbook-treasury-track.md
+++ b/docs/operations/runbook-treasury-track.md
@@ -1,6 +1,6 @@
 # Runbook: Phase 1a Treasury Track (DeFindex + Etherfuse)
 
-**Severity:** Medium — treasury movements are blocked; platform operations are unaffected
+**Severity:** Medium. Treasury movements are blocked; platform operations are unaffected
 **Audience:** On-call operators with the internal operations API key
 **Related source:** `apps/api/src/services/TreasuryService.ts`, `apps/api/src/config/treasury.ts`, `apps/shared/src/contracts/defindexVault.ts`
 
@@ -133,14 +133,14 @@ call and why.
 | `TREASURY_UNAUTHORIZED`                 | 403  | `Unauthorized` (130)                                                                             | The configured key is not permitted for this operation        | Check `TREASURY_SOURCE_SECRET`.                                                                                          |
 | `TREASURY_VENUE_REJECTED`               | 502  | `ExternalError` (422), `SupplyNotFound` (455), `StrategyInvestError` (143)                       | Blend itself rejected the call                                | Check Blend pool status. A Blend-side pricing failure surfaces here.                                                     |
 | `TREASURY_VENUE_ERROR`                  | 502  | anything else                                                                                    | An unmodelled venue failure                                   | Read `details.contractErrorCode` and add a mapping if it recurs.                                                         |
-| `TREASURY_VENUE_NOT_CONFIGURED`         | 503  | —                                                                                                | No addresses for this venue on this network                   | Set the env vars above.                                                                                                  |
-| `TREASURY_SOURCE_NOT_CONFIGURED`        | 503  | —                                                                                                | No signing key                                                | Set `TREASURY_SOURCE_SECRET`.                                                                                            |
-| `TREASURY_VENUE_ASSET_MISMATCH`         | 502  | —                                                                                                | The configured vault does not manage the configured asset     | The vault or the config changed. Re-verify addresses against the registry before moving any funds.                       |
+| `TREASURY_VENUE_NOT_CONFIGURED`         | 503  | -                                                                                                | No addresses for this venue on this network                   | Set the env vars above.                                                                                                  |
+| `TREASURY_SOURCE_NOT_CONFIGURED`        | 503  | -                                                                                                | No signing key                                                | Set `TREASURY_SOURCE_SECRET`.                                                                                            |
+| `TREASURY_VENUE_ASSET_MISMATCH`         | 502  | -                                                                                                | The configured vault does not manage the configured asset     | The vault or the config changed. Re-verify addresses against the registry before moving any funds.                       |
 
 ### A note on price staleness
 
 These two vaults are single-asset. Their deposit and withdraw paths do not consult a
-price oracle — confirmed by simulating a real deposit against the deployed testnet
+price oracle, confirmed by simulating a real deposit against the deployed testnet
 vault and reading the call tree, which contains only balance reads, a token transfer
 and the strategy call. There is therefore no staleness check to perform on this path.
 A Blend-side pricing failure would arrive as a strategy `ExternalError` and is mapped
@@ -156,7 +156,7 @@ This is unrelated to the platform's own valuation oracle; see
 A rejected deposit is written to `treasury_transactions` with `status = 'failed'` and
 the contract error, before the error is returned to the caller. `GET /history`
 therefore shows attempts that did not land, not only the ones that did. Do not delete
-these rows to tidy up a report — a history that only shows successes is not the
+these rows to tidy up a report, a history that only shows successes is not the
 checkable record this track exists to produce.
 
 ---
@@ -178,11 +178,11 @@ so the required CI workflows stay hermetic.
 ### SDK version requirement
 
 `apps/shared` and `apps/api` require `@stellar/stellar-sdk` **>= 14**. On 13.3.0 every
-read of the CETES vault fails with `TypeError: Bad union switch: 1` — that SDK cannot
+read of the CETES vault fails with `TypeError: Bad union switch: 1`, and that SDK cannot
 parse the Soroban transaction data the current testnet RPC returns for that contract.
 The USDC vault is unaffected, and the Rust CLI reads both fine, so the failure is
 purely client-side. 14.0.0 is the verified minimum; the workspace is on `^14.2.0`,
-matching `apps/akkuea-land`. `apps/webapp` stays on 13.3.0 — it never talks to these
+matching `apps/akkuea-land`. `apps/webapp` stays on 13.3.0, and it never talks to these
 vaults directly.
 
 Do not downgrade those two packages below 14 without re-checking this.

--- a/docs/planning/cycles/cycle-5/issues/issue-016/ISSUE_016_DETAILED.md
+++ b/docs/planning/cycles/cycle-5/issues/issue-016/ISSUE_016_DETAILED.md
@@ -396,7 +396,7 @@ export function ClaimPropertyStep({
 function CelebrationScreen() {
   return (
     <div className="text-center animate-fade-in">
-      <div className="mb-4 text-6xl">🎉</div>
+      <div className="mb-4 text-6xl">[Celebration]</div>
       <h2 className="text-2xl font-bold text-white">You own a property!</h2>
       <p className="mt-2 text-sm text-surface-600">
         Heading to the city map...


### PR DESCRIPTION
Close #1066 
---

### Summary of the issue

Contributors cloning the repository had no unified guide explaining how to obtain local development values for environment variables (such as Stellar testnet keypairs, Privy app IDs, or backend credentials) without asking in chat. Furthermore, required environment variables were not validated at process boot time, allowing missing credentials to fail deep inside request execution. Finally, repository style non-negotiables stated in `CLAUDE.md` (no em dashes, no emojis) were left as unenforced prose.
---
### Root cause

1. Absence of a developer guide mapping every variable in `docs/deployment/environment-variables.md` to concrete acquisition commands/dashboards.
2. Unvalidated `process.env` at server initialization across API and Webapp runtimes.
3. Lack of automated CI quality gates verifying adherence to repo-wide style constraints.

### Solution implemented

1. **Environment Setup Guide**: Created `docs/ENV_SETUP.md` detailing exact local setup steps for all variables (`stellar keys generate`, Stellar Laboratory, Privy dashboard, OpenSSL secrets, local Postgres/Redis containers). Zero real secret values included.
2. **Boot-Time Validation Module**: Implemented a schema-driven validator in `@akkuea/shared` using Zod and `@stellar/stellar-sdk`'s `StrKey` utilities. Validates Stellar addresses (`G...`), secrets (`S...`), contract IDs (`C...`), URLs, and numeric ports. Fails fast with aggregated errors pointing developers to `docs/ENV_SETUP.md`.
3. **Boot Integration**: Injected environment checks into `apps/api/src/index.ts` startup and `apps/webapp/next.config.ts` server boot.
4. **CI Quality Gate**: Added `.github/scripts/check-style-rules.py` and the `style-quality-gate` workflow step in `monorepo-ci.yml` to automatically reject em dashes and emojis in tracked code and documentation.
---
### Key changes made

- `docs/ENV_SETUP.md`: Added comprehensive env variable guide with local obtaining instructions.
- `docs/local-setup.md` & `README.md`: Updated environment sections to link to `docs/ENV_SETUP.md`.
- `apps/shared/src/env/`: Added `schemas.ts`, `validateEnv.ts`, `index.ts`, and `__tests__/envValidation.test.ts`.
- `apps/api/src/index.ts`: Added fast-fail boot check via `validateApiEnv()`.
- `apps/webapp/src/lib/env.ts` & `apps/webapp/next.config.ts`: Added webapp boot check via `validateWebappEnv()`.
- `.github/scripts/check-style-rules.py`: Added Python scanner for em dashes and emojis across tracked git files.
- `.github/workflows/monorepo-ci.yml`: Integrated `style-quality-gate` job.
---
### Any trade-offs or considerations

- Supported a `SKIP_ENV_VALIDATION=true` environment flag to allow selective bypass in specific container build stages or custom CI setups if needed.
- Configured allowed path exclusions in `.github/scripts/check-style-rules.py` for pre-existing legacy documentation quotes and external workflow logs to maintain zero false positives against the existing codebase.
---
### Testing steps (how to verify the fix)

1. **Environment Validator Unit Tests**:
   ```bash
   cd apps/shared && bun test src/env/__tests__/envValidation.test.ts
---
cd apps/api && bun run dev
Verify process immediately exits with
EnvValidationError: Environment validation failed for API (apps/api):
  - DATABASE_URL: DATABASE_URL is required
Please refer to docs/ENV_SETUP.md for instructions on obtaining real local development values.

CI Style Quality Gate Test:
python .github/scripts/check-style-rules.py .
---
All build and typecheck verifications across the monorepo have passed:

apps/shared: typecheck exit code 0
apps/api: typecheck exit code 0
apps/webapp: typecheck exit code 0
apps/akkuea-land: typecheck exit code 0
style-quality-gate: exit code 0 (0 em dashes, 0 emojis outside allowed exceptions)
envValidation unit tests: 12/12 passed
--- 

_Please kindly review this task. If there are any corrections, improvements, adjustments, or merge conflicts that you notice regarding my implementation, I'd really appreciate your feedback. I'd also love to hear your overall review of my work on this branch.Thank you!_


