### PR TITLE
feat(api): integrate the Phase 1a treasury track (DeFindex + Etherfuse)

### DIFF
--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -307,7 +307,10 @@ jobs:
         
         # Check for unsafe eval usage
         echo "3. Checking for unsafe eval usage..."
-        if grep -r "eval\|Function(" apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.next | grep -v "//.*eval\|//.*Function("; then
+        # Match real call sites only. A bare "eval" substring also matches
+        # ordinary words like "retrieval" and "evaluation", which is not unsafe
+        # dynamic code and previously failed this job on a doc comment.
+        if grep -rE "\beval\(|\bnew Function\(" apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.next | grep -v "//.*eval\|//.*Function("; then
           echo "Warning: Unsafe eval usage found"
           exit 1
         fi

--- a/apps/api/drizzle/migrations/0009_treasury_track.sql
+++ b/apps/api/drizzle/migrations/0009_treasury_track.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "treasury_transactions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"venue" varchar(64) NOT NULL,
+	"operation" varchar(16) NOT NULL,
+	"status" varchar(16) NOT NULL,
+	"vault_contract_id" varchar(56) NOT NULL,
+	"source_account" varchar(56) NOT NULL,
+	"asset_code" varchar(12) NOT NULL,
+	"amount" numeric(30, 7),
+	"shares" numeric(30, 7),
+	"tx_hash" varchar(64),
+	"error_name" varchar(64),
+	"error_code" varchar(16),
+	"requested_by" varchar(128) NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "treasury_position_snapshots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"venue" varchar(64) NOT NULL,
+	"vault_contract_id" varchar(56) NOT NULL,
+	"asset_code" varchar(12) NOT NULL,
+	"shares" numeric(30, 7) NOT NULL,
+	"position_value" numeric(30, 7) NOT NULL,
+	"vault_total_managed" numeric(30, 7) NOT NULL,
+	"captured_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "treasury_transactions_venue_created_at_idx" ON "treasury_transactions" ("venue", "created_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "treasury_transactions_status_idx" ON "treasury_transactions" ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "treasury_snapshots_venue_captured_at_idx" ON "treasury_position_snapshots" ("venue", "captured_at");

--- a/apps/api/drizzle/migrations/meta/_journal.json
+++ b/apps/api/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777449700002,
       "tag": "0008_idempotency_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777449700003,
+      "tag": "0009_treasury_track",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/jwt": "^1.4.2",
     "@elysiajs/swagger": "^1.3.1",
-    "@stellar/stellar-sdk": "^13.3.0",
+    "@stellar/stellar-sdk": "^14.2.0",
     "bun": "^1.3.9",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.26",

--- a/apps/api/src/__tests__/TreasuryService.test.ts
+++ b/apps/api/src/__tests__/TreasuryService.test.ts
@@ -1,0 +1,595 @@
+/**
+ * Unit tests for the treasury track's pure logic: amount scaling, slippage,
+ * share math, contract-error mapping, and position assembly.
+ *
+ * These do not talk to a network. The contract call paths themselves are
+ * covered against the real deployed vaults in
+ * `src/tests/treasury.integration.test.ts`; what is faked here is only the
+ * seam between the service and the vault client, so the arithmetic and the
+ * failure handling can be driven through every branch deterministically.
+ */
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import {
+  applySlippageFloor,
+  fromSmallestUnit,
+  mapVaultErrorToApiError,
+  toSmallestUnit,
+  TreasuryService,
+  type VaultClient,
+} from '../services/TreasuryService';
+import { DefindexVaultError, toDefindexVaultError } from '@akkuea/shared';
+import { ApiError } from '../errors/ApiError';
+import type { TreasuryVenue } from '../config/treasury';
+import { TreasuryRepository } from '../repositories/TreasuryRepository';
+import type { AuditService } from '../services/AuditService';
+import type { CacheService } from '../services/CacheService';
+
+const TESTNET_USDC_ASSET = 'CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU';
+const TESTNET_USDC_VAULT = 'CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN';
+const TREASURY_ACCOUNT = 'GCNBMXP33TL2QPYMRTHVZOWNINZOGFJQEOPWVCYU3XDGOCH3TICREXLM';
+const STRATEGY = 'CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY';
+
+interface FakeVaultOptions {
+  shares?: bigint;
+  totalSupply?: bigint;
+  totalAmount?: bigint;
+  idleAmount?: bigint;
+  investedAmount?: bigint;
+  paused?: boolean;
+  assetAddress?: string;
+  onDeposit?: (args: unknown) => Promise<unknown>;
+  onWithdraw?: (args: unknown) => Promise<unknown>;
+}
+
+function fakeVaultClient(options: FakeVaultOptions = {}): VaultClient {
+  const {
+    shares = 0n,
+    totalSupply = 1_000_0000000n,
+    totalAmount = 1_000_0000000n,
+    idleAmount = 0n,
+    investedAmount = totalAmount,
+    paused = false,
+    assetAddress = TESTNET_USDC_ASSET,
+  } = options;
+
+  return {
+    balance: async () => shares,
+    totalSupply: async () => totalSupply,
+    fetchTotalManagedFunds: async () => [
+      {
+        asset: assetAddress,
+        total_amount: totalAmount,
+        idle_amount: idleAmount,
+        invested_amount: investedAmount,
+        strategy_allocations: [{ strategy_address: STRATEGY, amount: investedAmount, paused }],
+      },
+    ],
+    // Share price of exactly 1.0 keeps the arithmetic under test readable.
+    getAssetAmountsPerShares: async (vaultShares: bigint) => [vaultShares],
+    getFees: async () => [100, 2000] as [number, number],
+    deposit:
+      options.onDeposit ??
+      (async () => {
+        throw new Error('deposit not stubbed for this test');
+      }),
+    withdraw:
+      options.onWithdraw ??
+      (async () => {
+        throw new Error('withdraw not stubbed for this test');
+      }),
+  } as unknown as VaultClient;
+}
+
+function noopAudit(): AuditService {
+  return { logAction: mock(() => Promise.resolve()) } as unknown as AuditService;
+}
+
+describe('toSmallestUnit', () => {
+  it('scales whole and fractional amounts without floating-point drift', () => {
+    expect(toSmallestUnit(10, 7)).toBe(100_000_000n);
+    expect(toSmallestUnit(0.1, 7)).toBe(1_000_000n);
+    expect(toSmallestUnit('0.0000001', 7)).toBe(1n);
+    expect(toSmallestUnit('1234.5678901', 7)).toBe(12_345_678_901n);
+    // `(0.0000005).toString()` is "5e-7"; exponential form must still scale.
+    expect(toSmallestUnit(0.0000005, 7)).toBe(5n);
+  });
+
+  it('rejects more precision than the asset can hold rather than truncating', () => {
+    expect(() => toSmallestUnit('0.12345678', 7)).toThrow(ApiError);
+  });
+
+  it('rejects zero, negative and non-numeric amounts', () => {
+    expect(() => toSmallestUnit(0, 7)).toThrow(ApiError);
+    expect(() => toSmallestUnit(-5, 7)).toThrow(ApiError);
+    expect(() => toSmallestUnit('abc', 7)).toThrow(ApiError);
+  });
+});
+
+describe('fromSmallestUnit', () => {
+  it('round-trips with toSmallestUnit', () => {
+    expect(fromSmallestUnit(toSmallestUnit('25.5', 7), 7)).toBe('25.5000000');
+    expect(fromSmallestUnit(0n, 7)).toBe('0.0000000');
+    expect(fromSmallestUnit(1n, 7)).toBe('0.0000001');
+  });
+});
+
+describe('applySlippageFloor', () => {
+  it('reduces the amount by the given basis points, rounding down', () => {
+    expect(applySlippageFloor(100_000_000n, 50)).toBe(99_500_000n);
+    expect(applySlippageFloor(100_000_000n, 0)).toBe(100_000_000n);
+    expect(applySlippageFloor(3n, 50)).toBe(2n);
+  });
+});
+
+describe('mapVaultErrorToApiError', () => {
+  const cases: Array<[string, number, number, string]> = [
+    ['StrategyPaused', 144, 503, 'TREASURY_VENUE_PAUSED'],
+    ['StrategyPausedOrNotFound', 141, 503, 'TREASURY_VENUE_PAUSED'],
+    ['InsufficientManagedFunds', 114, 409, 'TREASURY_INSUFFICIENT_VENUE_LIQUIDITY'],
+    ['UnwindMoreThanAvailable', 128, 409, 'TREASURY_INSUFFICIENT_VENUE_LIQUIDITY'],
+    ['BalanceError', 10, 409, 'TREASURY_INSUFFICIENT_BALANCE'],
+    ['TrustlineMissingError', 13, 409, 'TREASURY_TRUSTLINE_MISSING'],
+    ['BalanceDeauthorizedError', 11, 409, 'TREASURY_ASSET_NOT_AUTHORIZED'],
+    ['AmountBelowMinDust', 451, 422, 'TREASURY_AMOUNT_REJECTED'],
+    ['UnderlyingAmountBelowMin', 452, 409, 'TREASURY_SLIPPAGE_EXCEEDED'],
+    ['DeadlineExpired', 421, 409, 'TREASURY_DEADLINE_EXPIRED'],
+    ['Unauthorized', 130, 403, 'TREASURY_UNAUTHORIZED'],
+    ['ExternalError', 422, 502, 'TREASURY_VENUE_REJECTED'],
+  ];
+
+  for (const [errorName, code, expectedStatus, expectedCode] of cases) {
+    it(`maps ${errorName} (#${code}) to ${expectedStatus} ${expectedCode}`, () => {
+      const apiError = mapVaultErrorToApiError(
+        new DefindexVaultError(errorName, code, 'vault', 'boom'),
+      );
+
+      expect(apiError.statusCode).toBe(expectedStatus);
+      expect(apiError.code).toBe(expectedCode);
+      expect(apiError.details).toMatchObject({ venueError: errorName, contractErrorCode: code });
+    });
+  }
+
+  it('falls through to 502 for an unmodelled venue failure', () => {
+    const apiError = mapVaultErrorToApiError(
+      new DefindexVaultError('Unknown', 9999, 'unknown', 'something new broke'),
+    );
+
+    expect(apiError.statusCode).toBe(502);
+    expect(apiError.code).toBe('TREASURY_VENUE_ERROR');
+  });
+});
+
+describe('toDefindexVaultError', () => {
+  it('decodes a host trap into the vault error name', () => {
+    const decoded = toDefindexVaultError(
+      new Error('transaction simulation failed: HostError: Error(Contract, #144)'),
+    );
+
+    expect(decoded.errorName).toBe('StrategyPaused');
+    expect(decoded.errorCode).toBe(144);
+    expect(decoded.source).toBe('vault');
+  });
+
+  it('decodes a Stellar Asset Contract trap surfaced through the vault', () => {
+    const decoded = toDefindexVaultError(
+      new Error('transaction simulation failed: HostError: Error(Contract, #13)'),
+    );
+
+    expect(decoded.errorName).toBe('TrustlineMissingError');
+    expect(decoded.source).toBe('token');
+  });
+
+  it('decodes a strategy error code', () => {
+    const decoded = toDefindexVaultError(new Error('Error(Contract, #455)'));
+
+    expect(decoded.errorName).toBe('SupplyNotFound');
+    expect(decoded.source).toBe('strategy');
+  });
+
+  it('keeps the original message when no contract code is present', () => {
+    const decoded = toDefindexVaultError(new Error('connection refused'));
+
+    expect(decoded.errorName).toBe('Unknown');
+    expect(decoded.errorCode).toBeUndefined();
+    expect(decoded.message).toBe('connection refused');
+  });
+});
+
+describe('TreasuryService.getPosition', () => {
+  const originalEnv = { ...process.env };
+  const recordSnapshot = TreasuryRepository.recordSnapshot;
+
+  beforeEach(() => {
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.TREASURY_SOURCE_PUBLIC_KEY = TREASURY_ACCOUNT;
+    // The snapshot write is best-effort; stub it so these tests need no DB.
+    TreasuryRepository.recordSnapshot = mock(() =>
+      Promise.resolve({} as Awaited<ReturnType<typeof recordSnapshot>>),
+    );
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    TreasuryRepository.recordSnapshot = recordSnapshot;
+  });
+
+  it('reports shares, position value and vault totals as decimal strings', async () => {
+    const service = new TreasuryService(
+      () =>
+        fakeVaultClient({
+          shares: 25_0000000n,
+          totalAmount: 100_0000000n,
+          idleAmount: 10_0000000n,
+          investedAmount: 90_0000000n,
+        }),
+      noopAudit(),
+    );
+
+    const position = await service.getPosition('defindex-blend');
+
+    expect(position.venue).toBe('defindex-blend');
+    expect(position.assetCode).toBe('USDC');
+    expect(position.shares).toBe('25.0000000');
+    expect(position.positionValue).toBe('25.0000000');
+    expect(position.vaultTotalManaged).toBe('100.0000000');
+    expect(position.vaultIdleAmount).toBe('10.0000000');
+    expect(position.vaultInvestedAmount).toBe('90.0000000');
+    expect(position.fees).toEqual({ vaultBps: 100, protocolBps: 2000 });
+    expect(position.paused).toBe(false);
+  });
+
+  it('links the vault, the asset and the treasury account on stellar.expert', async () => {
+    const service = new TreasuryService(() => fakeVaultClient(), noopAudit());
+    const position = await service.getPosition('defindex-blend');
+
+    expect(position.explorer.vault).toBe(
+      `https://stellar.expert/explorer/testnet/contract/${TESTNET_USDC_VAULT}`,
+    );
+    expect(position.explorer.asset).toBe(
+      `https://stellar.expert/explorer/testnet/contract/${TESTNET_USDC_ASSET}`,
+    );
+    expect(position.explorer.account).toBe(
+      `https://stellar.expert/explorer/testnet/account/${TREASURY_ACCOUNT}`,
+    );
+  });
+
+  it('flags the venue as paused when every strategy is paused', async () => {
+    const service = new TreasuryService(
+      () =>
+        fakeVaultClient({
+          paused: true,
+          assetAddress: 'CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC',
+        }),
+      noopAudit(),
+    );
+
+    const position = await service.getPosition('etherfuse-stablebond');
+    expect(position.paused).toBe(true);
+    expect(position.strategies[0]!.paused).toBe(true);
+  });
+
+  it('captures at most one snapshot per venue within the throttle window', async () => {
+    const service = new TreasuryService(() => fakeVaultClient(), noopAudit());
+
+    await service.getPosition('defindex-blend');
+    await service.getPosition('defindex-blend');
+
+    // Reads are public and unauthenticated, so repeated page loads must not
+    // turn into a row per request.
+    expect(TreasuryRepository.recordSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a cached position without hitting the chain again', async () => {
+    const store = new Map<string, unknown>();
+    const cache = {
+      get: async (key: string) => (store.get(key) ?? null) as never,
+      set: async (key: string, value: unknown) => {
+        store.set(key, value);
+      },
+    } as unknown as CacheService;
+
+    let vaultReads = 0;
+    const service = new TreasuryService(
+      () => {
+        vaultReads += 1;
+        return fakeVaultClient();
+      },
+      noopAudit(),
+      cache,
+    );
+
+    const first = await service.getPosition('defindex-blend');
+    const second = await service.getPosition('defindex-blend');
+
+    expect(vaultReads).toBe(1);
+    expect(second).toEqual(first);
+  });
+
+  it('fails loudly when the vault does not manage the configured asset', async () => {
+    const service = new TreasuryService(
+      () => fakeVaultClient({ assetAddress: 'CDIFFERENTASSETADDRESS' }),
+      noopAudit(),
+    );
+
+    await expect(service.getPosition('defindex-blend')).rejects.toMatchObject({
+      statusCode: 502,
+      code: 'TREASURY_VENUE_ASSET_MISMATCH',
+    });
+  });
+
+  it('reports the venue as unconfigured rather than guessing on mainnet', async () => {
+    process.env.STELLAR_NETWORK = 'mainnet';
+    const service = new TreasuryService(() => fakeVaultClient(), noopAudit());
+
+    await expect(service.getPosition('defindex-blend')).rejects.toMatchObject({
+      statusCode: 503,
+      code: 'TREASURY_VENUE_NOT_CONFIGURED',
+    });
+  });
+});
+
+describe('TreasuryService.getPortfolio', () => {
+  const originalEnv = { ...process.env };
+  const recordSnapshot = TreasuryRepository.recordSnapshot;
+
+  beforeEach(() => {
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.TREASURY_SOURCE_PUBLIC_KEY = TREASURY_ACCOUNT;
+    TreasuryRepository.recordSnapshot = mock(() =>
+      Promise.resolve({} as Awaited<ReturnType<typeof recordSnapshot>>),
+    );
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    TreasuryRepository.recordSnapshot = recordSnapshot;
+  });
+
+  it('surfaces a venue that could not be read instead of dropping it', async () => {
+    const service = new TreasuryService((venue) => {
+      if (venue.id === 'etherfuse-stablebond') {
+        return {
+          balance: async () => {
+            throw new Error('Error(Contract, #100)');
+          },
+          totalSupply: async () => 0n,
+          fetchTotalManagedFunds: async () => [],
+          getAssetAmountsPerShares: async () => [],
+          getFees: async () => [0, 0] as [number, number],
+        } as unknown as VaultClient;
+      }
+      return fakeVaultClient();
+    }, noopAudit());
+
+    const portfolio = await service.getPortfolio();
+
+    expect(portfolio.positions.map((p) => p.venue)).toEqual(['defindex-blend']);
+    expect(portfolio.unavailable.map((entry) => entry.venue)).toEqual(['etherfuse-stablebond']);
+    expect(portfolio.sourceAccount).toBe(TREASURY_ACCOUNT);
+  });
+});
+
+describe('TreasuryService movements', () => {
+  const originalEnv = { ...process.env };
+  const recordTransaction = TreasuryRepository.recordTransaction;
+  const recordSnapshot = TreasuryRepository.recordSnapshot;
+
+  beforeEach(() => {
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.TREASURY_SOURCE_PUBLIC_KEY = TREASURY_ACCOUNT;
+    process.env.TREASURY_SOURCE_SECRET = 'SDNBSVFTCEXAXHFTBFHQKLVLGT6IPHDHNPUSXSPGZKBFN2C4RIPCEKAP';
+    TreasuryRepository.recordTransaction = mock((entry) =>
+      Promise.resolve({
+        id: '11111111-1111-4111-8111-111111111111',
+        ...entry,
+      } as Awaited<ReturnType<typeof recordTransaction>>),
+    );
+    TreasuryRepository.recordSnapshot = mock(() =>
+      Promise.resolve({} as Awaited<ReturnType<typeof recordSnapshot>>),
+    );
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    TreasuryRepository.recordTransaction = recordTransaction;
+    TreasuryRepository.recordSnapshot = recordSnapshot;
+  });
+
+  it('deposits with a slippage floor derived from the requested amount', async () => {
+    let capturedArgs:
+      { amountsDesired: bigint[]; amountsMin: bigint[]; invest: boolean } | undefined;
+
+    const service = new TreasuryService(
+      () =>
+        fakeVaultClient({
+          onDeposit: async (args: unknown) => {
+            capturedArgs = args as NonNullable<typeof capturedArgs>;
+            return {
+              signAndSend: async () => ({ sendTransactionResponse: { hash: 'abc123' } }),
+            };
+          },
+        }),
+      noopAudit(),
+    );
+
+    const result = await service.deposit({
+      venue: 'defindex-blend',
+      amount: 10,
+      requestedBy: 'ops@akkuea',
+    });
+
+    expect(capturedArgs).toMatchObject({
+      amountsDesired: [100_000_000n],
+      amountsMin: [99_500_000n],
+      invest: true,
+    });
+    expect(result.txHash).toBe('abc123');
+    expect(result.amount).toBe('10.0000000');
+    expect(result.explorerUrl).toBe('https://stellar.expert/explorer/testnet/tx/abc123');
+  });
+
+  it('records a failed deposit with the contract error before rethrowing', async () => {
+    const service = new TreasuryService(
+      () =>
+        fakeVaultClient({
+          onDeposit: async () => {
+            throw new Error('HostError: Error(Contract, #144)');
+          },
+        }),
+      noopAudit(),
+    );
+
+    await expect(
+      service.deposit({ venue: 'defindex-blend', amount: 10, requestedBy: 'ops@akkuea' }),
+    ).rejects.toMatchObject({ statusCode: 503, code: 'TREASURY_VENUE_PAUSED' });
+
+    const calls = (TreasuryRepository.recordTransaction as ReturnType<typeof mock>).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![0]).toMatchObject({
+      status: 'failed',
+      operation: 'deposit',
+      errorName: 'StrategyPaused',
+      errorCode: '144',
+    });
+  });
+
+  it('converts a withdrawal amount into shares using the live share price', async () => {
+    let capturedShares: bigint | undefined;
+
+    const service = new TreasuryService(
+      () =>
+        fakeVaultClient({
+          // 200 shares back 400 units of the asset: share price 2.0.
+          totalSupply: 200_0000000n,
+          totalAmount: 400_0000000n,
+          investedAmount: 400_0000000n,
+          onWithdraw: async (args: unknown) => {
+            capturedShares = (args as { withdrawShares: bigint }).withdrawShares;
+            return {
+              signAndSend: async () => ({ getTransactionResponse: { txHash: 'def456' } }),
+            };
+          },
+        }),
+      noopAudit(),
+    );
+
+    const result = await service.withdraw({
+      venue: 'defindex-blend',
+      amount: 100,
+      requestedBy: 'ops@akkuea',
+    });
+
+    // 100 USDC at a share price of 2.0 is 50 shares.
+    expect(capturedShares).toBe(50_0000000n);
+    expect(result.txHash).toBe('def456');
+  });
+
+  it('rounds shares up so a withdrawal is never short of the requested amount', async () => {
+    let capturedShares: bigint | undefined;
+
+    const service = new TreasuryService(
+      () =>
+        fakeVaultClient({
+          totalSupply: 3n,
+          totalAmount: 7n,
+          investedAmount: 7n,
+          onWithdraw: async (args: unknown) => {
+            capturedShares = (args as { withdrawShares: bigint }).withdrawShares;
+            return { signAndSend: async () => ({ sendTransactionResponse: { hash: 'h' } }) };
+          },
+        }),
+      noopAudit(),
+    );
+
+    await service.withdraw({
+      venue: 'defindex-blend',
+      amount: 0.0000005,
+      requestedBy: 'ops@akkuea',
+    });
+
+    // 3 * 5 / 7 = 2.14…, which must round up to 3 rather than down to 2.
+    expect(capturedShares).toBe(3n);
+  });
+
+  it('refuses a withdrawal larger than the venue holds', async () => {
+    const service = new TreasuryService(
+      () => fakeVaultClient({ totalSupply: 10_0000000n, totalAmount: 10_0000000n }),
+      noopAudit(),
+    );
+
+    await expect(
+      service.withdraw({ venue: 'defindex-blend', amount: 500, requestedBy: 'ops@akkuea' }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'TREASURY_INSUFFICIENT_VENUE_LIQUIDITY',
+    });
+  });
+
+  it('rejects an out-of-range slippage tolerance before touching the chain', async () => {
+    const service = new TreasuryService(() => fakeVaultClient(), noopAudit());
+
+    await expect(
+      service.deposit({
+        venue: 'defindex-blend',
+        amount: 10,
+        slippageBps: 5000,
+        requestedBy: 'ops@akkuea',
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('refuses to move funds when no treasury signing key is configured', async () => {
+    delete process.env.TREASURY_SOURCE_SECRET;
+    delete process.env.STELLAR_ADMIN_SECRET;
+    const service = new TreasuryService(() => fakeVaultClient(), noopAudit());
+
+    await expect(
+      service.deposit({ venue: 'defindex-blend', amount: 10, requestedBy: 'ops@akkuea' }),
+    ).rejects.toMatchObject({
+      statusCode: 503,
+      code: 'TREASURY_SOURCE_NOT_CONFIGURED',
+    });
+  });
+});
+
+describe('treasury venue registry', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('lists both venues with configuration status for the active network', async () => {
+    process.env.STELLAR_NETWORK = 'testnet';
+    const service = new TreasuryService(() => fakeVaultClient(), noopAudit());
+
+    expect(service.listVenues()).toEqual([
+      {
+        venue: 'defindex-blend',
+        configured: true,
+        label: 'DeFindex Blend strategy',
+        provider: 'DeFindex',
+        strategy: 'Lends the deposited USDC into Blend',
+      },
+      {
+        venue: 'etherfuse-stablebond',
+        configured: true,
+        label: 'Etherfuse Stablebonds',
+        provider: 'DeFindex / Etherfuse',
+        strategy: 'Holds CETES, Etherfuse tokenized Mexican sovereign debt, and lends it on Blend',
+      },
+    ]);
+  });
+
+  it('honours an environment override for a vault address', async () => {
+    process.env.STELLAR_NETWORK = 'mainnet';
+    process.env.TREASURY_DEFINDEX_BLEND_VAULT_ID = 'CMAINNETVAULT';
+    process.env.TREASURY_DEFINDEX_BLEND_ASSET_ID = 'CMAINNETASSET';
+
+    const { getTreasuryVenue } = await import('../config/treasury');
+    const venue = getTreasuryVenue('defindex-blend') as TreasuryVenue;
+
+    expect(venue.vaultContractId).toBe('CMAINNETVAULT');
+    expect(venue.assetContractId).toBe('CMAINNETASSET');
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,7 @@ import { notificationDlqRoutes } from './routes/notificationDlq';
 import { authRoutes } from './routes/auth';
 import { adminRoutes } from './routes/admin';
 import { ledgerRoutes } from './routes/ledger';
+import { treasuryRoutes } from './routes/treasury';
 import { errorHandler } from './middleware/errorHandler';
 import { requestLogger } from './middleware';
 
@@ -32,6 +33,7 @@ const app = new Elysia()
   .use(internalOperationsRoutes)
   .use(notificationDlqRoutes)
   .use(adminRoutes)
-  .use(ledgerRoutes);
+  .use(ledgerRoutes)
+  .use(treasuryRoutes);
 
 export default app;

--- a/apps/api/src/config/treasury.ts
+++ b/apps/api/src/config/treasury.ts
@@ -1,0 +1,209 @@
+import { resolveNetworkKey } from './contracts';
+
+/**
+ * Configuration for the Phase 1a treasury track.
+ *
+ * The platform fee sits idle in a Stellar account. Rather than leave it there,
+ * it is deposited into DeFi venues that are already deployed and already
+ * audited, so the balance earns yield and the whole position stays checkable on
+ * a block explorer by anyone. This file is the registry of those venues.
+ *
+ * Both venues are DeFindex Vaults, and both are reachable through the same
+ * contract interface:
+ *
+ *  - `defindex-blend`       — a USDC vault whose only strategy lends into Blend.
+ *  - `etherfuse-stablebond` — a CETES vault. CETES is Etherfuse's tokenized
+ *                             Mexican sovereign-debt Stablebond; the vault's
+ *                             strategy holds it and lends it on Blend.
+ *
+ * Etherfuse does not publish a direct Soroban mint/redeem interface for
+ * Stablebonds — the on-chain path documented by both projects is the DeFindex
+ * strategy — so that is the path used here.
+ *
+ * Addresses below are copied from the upstream deployment registry
+ * (https://github.com/defindex-io/stellar-contracts/blob/main/public/testnet.contracts.json)
+ * and were verified against the live testnet contracts on 2026-08-18 by reading
+ * `get_assets`, `fetch_total_managed_funds` and `decimals` off-chain. See
+ * `docs/operations/runbook-treasury-track.md` for the verification transcript.
+ *
+ * Mainnet has no committed defaults: DeFindex vaults on mainnet are deployed
+ * per-partner through the factory, so akkuea's mainnet vault addresses must be
+ * supplied through environment variables once that vault exists.
+ */
+
+export const TREASURY_VENUE_IDS = ['defindex-blend', 'etherfuse-stablebond'] as const;
+
+export type TreasuryVenueId = (typeof TREASURY_VENUE_IDS)[number];
+
+export interface TreasuryVenue {
+  id: TreasuryVenueId;
+  /** Short label for API responses and UI. */
+  label: string;
+  /** Protocol operating the vault. */
+  provider: string;
+  /** What the vault's strategy actually does with the deposit. */
+  strategy: string;
+  /** DeFindex Vault contract (the dfToken). */
+  vaultContractId: string;
+  /** Underlying asset the vault accepts, as a Soroban token contract. */
+  assetContractId: string;
+  /** Ticker of the underlying asset. */
+  assetCode: string;
+  /**
+   * Decimal precision of the underlying asset and the dfToken.
+   *
+   * Held in config rather than read per-request to avoid an extra RPC round
+   * trip on every position read. `treasury.integration.test.ts` asserts this
+   * matches what the deployed contract reports, so a drift fails CI rather
+   * than silently mis-scaling a balance.
+   */
+  assetDecimals: number;
+}
+
+interface VenueDefaults {
+  vaultContractId: string;
+  assetContractId: string;
+  assetCode: string;
+  assetDecimals: number;
+}
+
+const VENUE_DEFAULTS: Record<
+  TreasuryVenueId,
+  Record<'TESTNET' | 'MAINNET', VenueDefaults | null>
+> = {
+  'defindex-blend': {
+    TESTNET: {
+      // `usdc_paltalabs_vault` — strategy `USDC Blend Strategy`
+      vaultContractId: 'CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN',
+      // SAC for USDC:GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56
+      assetContractId: 'CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU',
+      assetCode: 'USDC',
+      assetDecimals: 7,
+    },
+    MAINNET: null,
+  },
+  'etherfuse-stablebond': {
+    TESTNET: {
+      // `cetes_paltalabs_vault` — strategy `CETES Blend Strategy`
+      vaultContractId: 'CBIS5TEMTNNOTBE3WXPQUAGUEDYZZVIWAKTXEQCOUJ34OJJ3FJ5NLF2P',
+      // SAC for CETES:GC3CW7EDYRTWQ635VDIGY6S4ZUF5L6TQ7AA4MWS7LEQDBLUSZXV7UPS4
+      assetContractId: 'CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC',
+      assetCode: 'CETES',
+      assetDecimals: 7,
+    },
+    MAINNET: null,
+  },
+};
+
+const VENUE_METADATA: Record<
+  TreasuryVenueId,
+  Pick<TreasuryVenue, 'label' | 'provider' | 'strategy'>
+> = {
+  'defindex-blend': {
+    label: 'DeFindex Blend strategy',
+    provider: 'DeFindex',
+    strategy: 'Lends the deposited USDC into Blend',
+  },
+  'etherfuse-stablebond': {
+    label: 'Etherfuse Stablebonds',
+    provider: 'DeFindex / Etherfuse',
+    strategy: 'Holds CETES, Etherfuse tokenized Mexican sovereign debt, and lends it on Blend',
+  },
+};
+
+const ENV_KEYS: Record<TreasuryVenueId, { vault: string; asset: string; decimals: string }> = {
+  'defindex-blend': {
+    vault: 'TREASURY_DEFINDEX_BLEND_VAULT_ID',
+    asset: 'TREASURY_DEFINDEX_BLEND_ASSET_ID',
+    decimals: 'TREASURY_DEFINDEX_BLEND_ASSET_DECIMALS',
+  },
+  'etherfuse-stablebond': {
+    vault: 'TREASURY_ETHERFUSE_VAULT_ID',
+    asset: 'TREASURY_ETHERFUSE_ASSET_ID',
+    decimals: 'TREASURY_ETHERFUSE_ASSET_DECIMALS',
+  },
+};
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+/**
+ * Resolve one venue, or `null` when it is not configured for the active
+ * network. A null venue is a normal state (mainnet before the vault exists),
+ * not an error — callers report it as unconfigured rather than throwing.
+ */
+export function getTreasuryVenue(id: TreasuryVenueId): TreasuryVenue | null {
+  const network = resolveNetworkKey();
+  const defaults = VENUE_DEFAULTS[id][network];
+  const envKeys = ENV_KEYS[id];
+
+  const vaultContractId = readEnv(envKeys.vault) ?? defaults?.vaultContractId;
+  const assetContractId = readEnv(envKeys.asset) ?? defaults?.assetContractId;
+  const assetCode = defaults?.assetCode ?? id.toUpperCase();
+  const decimalsFromEnv = readEnv(envKeys.decimals);
+  const assetDecimals = decimalsFromEnv
+    ? Number.parseInt(decimalsFromEnv, 10)
+    : (defaults?.assetDecimals ?? 7);
+
+  if (!vaultContractId || !assetContractId || !Number.isInteger(assetDecimals)) {
+    return null;
+  }
+
+  return {
+    id,
+    ...VENUE_METADATA[id],
+    vaultContractId,
+    assetContractId,
+    assetCode,
+    assetDecimals,
+  };
+}
+
+/** Every venue configured for the active network, in a stable order. */
+export function getConfiguredTreasuryVenues(): TreasuryVenue[] {
+  return TREASURY_VENUE_IDS.map(getTreasuryVenue).filter(
+    (venue): venue is TreasuryVenue => venue !== null,
+  );
+}
+
+export function isTreasuryVenueId(value: string): value is TreasuryVenueId {
+  return (TREASURY_VENUE_IDS as readonly string[]).includes(value);
+}
+
+export interface TreasurySourceAccount {
+  publicKey: string;
+  secret: string;
+}
+
+/**
+ * The account holding the accumulated platform fee, which is what deposits are
+ * drawn from and what withdrawals return to.
+ *
+ * Falls back to the existing Soroban admin credentials so a deployment that
+ * already has them configured does not need a second keypair, but a dedicated
+ * treasury key is preferred and takes precedence.
+ */
+export function getTreasurySourceAccount(): TreasurySourceAccount | null {
+  const publicKey = readEnv('TREASURY_SOURCE_PUBLIC_KEY') ?? readEnv('STELLAR_ADMIN_PUBLIC_KEY');
+  const secret = readEnv('TREASURY_SOURCE_SECRET') ?? readEnv('STELLAR_ADMIN_SECRET');
+
+  if (!publicKey || !secret) {
+    return null;
+  }
+
+  return { publicKey, secret };
+}
+
+/** Read-only endpoints work without a signing key; only the address is needed. */
+export function getTreasurySourcePublicKey(): string | null {
+  return readEnv('TREASURY_SOURCE_PUBLIC_KEY') ?? readEnv('STELLAR_ADMIN_PUBLIC_KEY') ?? null;
+}
+
+/** Base URL for the explorer links surfaced alongside every position. */
+export function getStellarExpertBaseUrl(): string {
+  return resolveNetworkKey() === 'MAINNET'
+    ? 'https://stellar.expert/explorer/public'
+    : 'https://stellar.expert/explorer/testnet';
+}

--- a/apps/api/src/controllers/TreasuryController.ts
+++ b/apps/api/src/controllers/TreasuryController.ts
@@ -1,0 +1,57 @@
+import { isTreasuryVenueId, type TreasuryVenueId } from '../config/treasury';
+import { ApiError } from '../errors/ApiError';
+import { treasuryService, type TreasuryService } from '../services/TreasuryService';
+
+export interface TreasuryMovementBody {
+  venue: string;
+  amount: number;
+  slippageBps?: number;
+  requestedBy?: string;
+}
+
+export class TreasuryController {
+  constructor(private readonly service: TreasuryService = treasuryService) {}
+
+  async getPortfolio() {
+    return this.service.getPortfolio();
+  }
+
+  async getPosition(venue: string) {
+    return this.service.getPosition(this.parseVenue(venue));
+  }
+
+  async getHistory(params: { venue?: string; limit: number; offset: number }) {
+    return this.service.getHistory({
+      venue: params.venue ? this.parseVenue(params.venue) : undefined,
+      limit: params.limit,
+      offset: params.offset,
+    });
+  }
+
+  async deposit(body: TreasuryMovementBody, actor: string) {
+    return this.service.deposit({
+      venue: this.parseVenue(body.venue),
+      amount: body.amount,
+      slippageBps: body.slippageBps,
+      requestedBy: body.requestedBy ?? actor,
+    });
+  }
+
+  async withdraw(body: TreasuryMovementBody, actor: string) {
+    return this.service.withdraw({
+      venue: this.parseVenue(body.venue),
+      amount: body.amount,
+      slippageBps: body.slippageBps,
+      requestedBy: body.requestedBy ?? actor,
+    });
+  }
+
+  private parseVenue(venue: string): TreasuryVenueId {
+    if (!isTreasuryVenueId(venue)) {
+      throw ApiError.notFound(`Unknown treasury venue '${venue}'`);
+    }
+    return venue;
+  }
+}
+
+export const treasuryController = new TreasuryController();

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -7,3 +7,4 @@ export * from './valuations';
 export * from './notificationDlq';
 export * from './auditLog';
 export * from './idempotency';
+export * from './treasury';

--- a/apps/api/src/db/schema/treasury.ts
+++ b/apps/api/src/db/schema/treasury.ts
@@ -1,0 +1,69 @@
+import { pgTable, uuid, varchar, numeric, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+
+export const treasuryOperationEnum = ['deposit', 'withdraw'] as const;
+export const treasuryOperationStatusEnum = ['submitted', 'confirmed', 'failed'] as const;
+
+/**
+ * Every treasury movement the platform has attempted, successful or not.
+ *
+ * Failures are kept deliberately: the point of the treasury track is that the
+ * record is checkable, and a history that only shows the deposits that worked
+ * is not a full record. `errorName`/`errorCode` carry the contract error as it
+ * came back from chain.
+ */
+export const treasuryTransactions = pgTable(
+  'treasury_transactions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    venue: varchar('venue', { length: 64 }).notNull(),
+    operation: varchar('operation', { length: 16 }).notNull(),
+    status: varchar('status', { length: 16 }).notNull(),
+    vaultContractId: varchar('vault_contract_id', { length: 56 }).notNull(),
+    sourceAccount: varchar('source_account', { length: 56 }).notNull(),
+    assetCode: varchar('asset_code', { length: 12 }).notNull(),
+    /** Underlying asset amount, in whole units (not stroops). */
+    amount: numeric('amount', { precision: 30, scale: 7 }),
+    /** dfToken shares minted (deposit) or burned (withdraw). */
+    shares: numeric('shares', { precision: 30, scale: 7 }),
+    txHash: varchar('tx_hash', { length: 64 }),
+    errorName: varchar('error_name', { length: 64 }),
+    errorCode: varchar('error_code', { length: 16 }),
+    requestedBy: varchar('requested_by', { length: 128 }).notNull(),
+    metadata: jsonb('metadata'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('treasury_transactions_venue_created_at_idx').on(t.venue, t.createdAt),
+    index('treasury_transactions_status_idx').on(t.status),
+  ],
+);
+
+/**
+ * Point-in-time reads of a venue position, captured whenever the API reads one.
+ *
+ * These are what the treasury panel charts. They are derived entirely from
+ * on-chain reads, so a snapshot can always be re-derived from the ledger; the
+ * table is a cache of history, never the source of truth.
+ */
+export const treasuryPositionSnapshots = pgTable(
+  'treasury_position_snapshots',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    venue: varchar('venue', { length: 64 }).notNull(),
+    vaultContractId: varchar('vault_contract_id', { length: 56 }).notNull(),
+    assetCode: varchar('asset_code', { length: 12 }).notNull(),
+    /** dfToken shares the platform holds. */
+    shares: numeric('shares', { precision: 30, scale: 7 }).notNull(),
+    /** Underlying asset those shares are currently worth. */
+    positionValue: numeric('position_value', { precision: 30, scale: 7 }).notNull(),
+    /** Underlying asset under management across all holders of this vault. */
+    vaultTotalManaged: numeric('vault_total_managed', { precision: 30, scale: 7 }).notNull(),
+    capturedAt: timestamp('captured_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index('treasury_snapshots_venue_captured_at_idx').on(t.venue, t.capturedAt)],
+);
+
+export type TreasuryTransaction = typeof treasuryTransactions.$inferSelect;
+export type NewTreasuryTransaction = typeof treasuryTransactions.$inferInsert;
+export type TreasuryPositionSnapshot = typeof treasuryPositionSnapshots.$inferSelect;
+export type NewTreasuryPositionSnapshot = typeof treasuryPositionSnapshots.$inferInsert;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import { notificationRoutes } from './routes/notifications';
 import { internalOperationsRoutes } from './routes/internalOperations';
 import { notificationDlqRoutes } from './routes/notificationDlq';
 import { ledgerRoutes } from './routes/ledger';
+import { treasuryRoutes } from './routes/treasury';
 import { errorHandler } from './middleware/errorHandler';
 import { cacheService } from './services/CacheService';
 import { NotificationService } from './services/NotificationService';
@@ -43,6 +44,11 @@ app
           { name: 'Internal Operations', description: 'Internal property review and operations' },
           { name: 'Notification DLQ', description: 'Dead letter queue for failed notifications' },
           { name: 'Ledger', description: 'Stellar ledger streaming via SSE' },
+          {
+            name: 'Treasury',
+            description:
+              'Phase 1a treasury track: platform fee deposited into DeFindex and Etherfuse venues',
+          },
         ],
         components: {
           securitySchemes: {
@@ -77,6 +83,7 @@ app
   .use(internalOperationsRoutes)
   .use(notificationDlqRoutes)
   .use(ledgerRoutes)
+  .use(treasuryRoutes)
   .get('/health', async () => {
     const dbHealth = await checkDatabaseHealth();
 

--- a/apps/api/src/repositories/TreasuryRepository.ts
+++ b/apps/api/src/repositories/TreasuryRepository.ts
@@ -1,0 +1,58 @@
+import { desc, eq } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  treasuryPositionSnapshots,
+  treasuryTransactions,
+  type NewTreasuryPositionSnapshot,
+  type NewTreasuryTransaction,
+  type TreasuryPositionSnapshot,
+  type TreasuryTransaction,
+} from '../db/schema/treasury';
+
+export interface TreasuryHistoryQuery {
+  venue?: string;
+  limit: number;
+  offset: number;
+}
+
+export class TreasuryRepository {
+  static async recordTransaction(entry: NewTreasuryTransaction): Promise<TreasuryTransaction> {
+    const [row] = await db.insert(treasuryTransactions).values(entry).returning();
+    if (!row) {
+      throw new Error('Failed to persist treasury transaction: no row returned');
+    }
+    return row;
+  }
+
+  static async listTransactions(query: TreasuryHistoryQuery): Promise<TreasuryTransaction[]> {
+    const base = db.select().from(treasuryTransactions);
+    const filtered = query.venue ? base.where(eq(treasuryTransactions.venue, query.venue)) : base;
+
+    return filtered
+      .orderBy(desc(treasuryTransactions.createdAt))
+      .limit(query.limit)
+      .offset(query.offset);
+  }
+
+  static async recordSnapshot(
+    snapshot: NewTreasuryPositionSnapshot,
+  ): Promise<TreasuryPositionSnapshot> {
+    const [row] = await db.insert(treasuryPositionSnapshots).values(snapshot).returning();
+    if (!row) {
+      throw new Error('Failed to persist treasury snapshot: no row returned');
+    }
+    return row;
+  }
+
+  static async listSnapshots(query: TreasuryHistoryQuery): Promise<TreasuryPositionSnapshot[]> {
+    const base = db.select().from(treasuryPositionSnapshots);
+    const filtered = query.venue
+      ? base.where(eq(treasuryPositionSnapshots.venue, query.venue))
+      : base;
+
+    return filtered
+      .orderBy(desc(treasuryPositionSnapshots.capturedAt))
+      .limit(query.limit)
+      .offset(query.offset);
+  }
+}

--- a/apps/api/src/routes/treasury.ts
+++ b/apps/api/src/routes/treasury.ts
@@ -1,0 +1,168 @@
+import { Elysia, t } from 'elysia';
+import { z } from 'zod';
+import { validateBody, validateQuery } from '../middleware/validation';
+import { treasuryController, type TreasuryMovementBody } from '../controllers/TreasuryController';
+import { TREASURY_VENUE_IDS } from '../config/treasury';
+import { handleError } from '../utils/errors';
+import { isInternalOperationsAuthorized } from '../utils/internalOperationsAuth';
+
+const venueEnum = z.enum(TREASURY_VENUE_IDS);
+
+const historyQuerySchema = z.object({
+  venue: venueEnum.optional(),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const movementBodySchema = z.object({
+  venue: venueEnum,
+  /**
+   * Whole units of the venue's underlying asset. Bounded so a fat-fingered
+   * operator request is rejected here rather than on chain.
+   */
+  amount: z.number().positive().max(1_000_000_000),
+  slippageBps: z.number().int().min(0).max(1000).optional(),
+  requestedBy: z.string().min(1).max(128).optional(),
+});
+
+/**
+ * Read-only treasury endpoints.
+ *
+ * Position data is public on the ledger already, so exposing it needs no auth —
+ * the point of the treasury track is that anyone can check it.
+ */
+const publicTreasuryRoutes = new Elysia()
+  .get(
+    '/',
+    async ({ set }) => {
+      try {
+        const data = await treasuryController.getPortfolio();
+        return { success: true, data };
+      } catch (error) {
+        const errorResponse = handleError(error);
+        set.status = errorResponse.statusCode;
+        return errorResponse;
+      }
+    },
+    {
+      detail: {
+        summary: 'Get treasury portfolio',
+        description:
+          'Current treasury position across every configured venue, read live from the vault contracts',
+        tags: ['Treasury'],
+      },
+    },
+  )
+  .get(
+    '/venues/:venue',
+    async ({ params, set }) => {
+      try {
+        const data = await treasuryController.getPosition(params.venue);
+        return { success: true, data };
+      } catch (error) {
+        const errorResponse = handleError(error);
+        set.status = errorResponse.statusCode;
+        return errorResponse;
+      }
+    },
+    {
+      params: t.Object({ venue: t.String() }),
+      detail: {
+        summary: 'Get treasury position for one venue',
+        description: 'Live position for a single treasury venue, read from its vault contract',
+        tags: ['Treasury'],
+      },
+    },
+  );
+
+const treasuryHistoryRoute = new Elysia().use(validateQuery(historyQuerySchema)).get(
+  '/history',
+  async ({ validatedQuery, set }) => {
+    try {
+      const data = await treasuryController.getHistory({
+        venue: validatedQuery!.venue,
+        limit: validatedQuery!.limit,
+        offset: validatedQuery!.offset,
+      });
+      return { success: true, data };
+    } catch (error) {
+      const errorResponse = handleError(error);
+      set.status = errorResponse.statusCode;
+      return errorResponse;
+    }
+  },
+  {
+    detail: {
+      summary: 'Get treasury history',
+      description: 'Recorded treasury movements (including failed attempts) and position snapshots',
+      tags: ['Treasury'],
+    },
+  },
+);
+
+/**
+ * Admin guard for treasury movements, using the same internal API key as the
+ * other privileged defi-rwa operations.
+ */
+const treasuryAdminAuth = new Elysia({ name: 'treasury-admin-auth' }).onBeforeHandle(
+  ({ headers, set }) => {
+    if (!isInternalOperationsAuthorized(headers as Record<string, string | undefined>)) {
+      set.status = 403;
+      return {
+        success: false,
+        error: 'FORBIDDEN',
+        message: 'Treasury operations access denied',
+        timestamp: new Date().toISOString(),
+      };
+    }
+  },
+);
+
+function movementRoute(
+  path: '/deposit' | '/withdraw',
+  operation: 'deposit' | 'withdraw',
+  summary: string,
+  description: string,
+) {
+  return new Elysia()
+    .use(treasuryAdminAuth)
+    .use(validateBody(movementBodySchema))
+    .post(
+      path,
+      async ({ validatedBody, set }) => {
+        try {
+          const body = validatedBody! as TreasuryMovementBody;
+          const data =
+            operation === 'deposit'
+              ? await treasuryController.deposit(body, 'internal-operations')
+              : await treasuryController.withdraw(body, 'internal-operations');
+          return { success: true, data };
+        } catch (error) {
+          const errorResponse = handleError(error);
+          set.status = errorResponse.statusCode;
+          return errorResponse;
+        }
+      },
+      { detail: { summary, description, tags: ['Treasury'] } },
+    );
+}
+
+export const treasuryRoutes = new Elysia({ prefix: '/api/v1/treasury' })
+  .use(publicTreasuryRoutes)
+  .use(treasuryHistoryRoute)
+  .use(
+    movementRoute(
+      '/deposit',
+      'deposit',
+      'Deposit into a treasury venue',
+      'Admin-only. Deposits platform fee balance into the venue vault and records the movement.',
+    ),
+  )
+  .use(
+    movementRoute(
+      '/withdraw',
+      'withdraw',
+      'Withdraw from a treasury venue',
+      'Admin-only. Burns vault shares to return the requested amount to the treasury account.',
+    ),
+  );

--- a/apps/api/src/services/TreasuryService.ts
+++ b/apps/api/src/services/TreasuryService.ts
@@ -1,0 +1,910 @@
+import { Networks } from '@stellar/stellar-sdk';
+import {
+  createNodeContractSigner,
+  DefindexVaultContractClient,
+  DefindexVaultError,
+  toDefindexVaultError,
+  type CurrentAssetInvestmentAllocation,
+} from '@akkuea/shared';
+import { ApiError } from '../errors/ApiError';
+import {
+  getConfiguredTreasuryVenues,
+  getStellarExpertBaseUrl,
+  getTreasurySourceAccount,
+  getTreasurySourcePublicKey,
+  getTreasuryVenue,
+  TREASURY_VENUE_IDS,
+  type TreasuryVenue,
+  type TreasuryVenueId,
+} from '../config/treasury';
+import { TreasuryRepository } from '../repositories/TreasuryRepository';
+import { auditService, type AuditService } from './AuditService';
+import { cacheService, type CacheService } from './CacheService';
+import { logger } from './logger';
+
+/** Default slippage floor applied to deposits and withdrawals: 0.5%. */
+const DEFAULT_SLIPPAGE_BPS = 50;
+/**
+ * How long a position read is served from cache. The position endpoints are
+ * public and unauthenticated, so without this every request would be an
+ * uncached round trip to Soroban RPC.
+ */
+const POSITION_CACHE_TTL_SECONDS = 30;
+/**
+ * Minimum gap between stored snapshots for a venue. Snapshots are captured on
+ * read, so this keeps a busy page from writing a row per request while still
+ * building usable history.
+ */
+const SNAPSHOT_MIN_INTERVAL_MS = 5 * 60 * 1000;
+const MAX_SLIPPAGE_BPS = 1_000;
+const BPS_DENOMINATOR = 10_000n;
+
+export interface TreasuryStrategyView {
+  address: string;
+  /** Amount of the underlying asset this strategy currently holds. */
+  amount: string;
+  /**
+   * A paused strategy still holds funds but accepts no new investment, and the
+   * vault will not route deposits into it.
+   */
+  paused: boolean;
+}
+
+export interface TreasuryPosition {
+  venue: TreasuryVenueId;
+  label: string;
+  provider: string;
+  strategy: string;
+  assetCode: string;
+  vaultContractId: string;
+  assetContractId: string;
+  /** dfToken shares the platform treasury holds in this vault. */
+  shares: string;
+  /** What those shares are worth right now, in the underlying asset. */
+  positionValue: string;
+  /** Underlying asset under management in the vault across all holders. */
+  vaultTotalManaged: string;
+  /** Portion of the vault sitting as idle funds rather than in a strategy. */
+  vaultIdleAmount: string;
+  /** Portion of the vault deployed into strategies. */
+  vaultInvestedAmount: string;
+  strategies: TreasuryStrategyView[];
+  /** True when every strategy backing this venue is paused. */
+  paused: boolean;
+  /** Vault performance fee and DeFindex protocol fee, in basis points. */
+  fees: { vaultBps: number; protocolBps: number };
+  explorer: {
+    vault: string;
+    asset: string;
+    /** Account whose position this is; null when no treasury key is configured. */
+    account: string | null;
+  };
+  readAt: string;
+}
+
+export interface TreasuryVenueStatus {
+  venue: TreasuryVenueId;
+  configured: boolean;
+  label: string;
+  provider: string;
+  strategy: string;
+}
+
+export interface TreasuryPortfolio {
+  positions: TreasuryPosition[];
+  /** Venues that exist in the registry but have no address for this network. */
+  unconfigured: TreasuryVenueStatus[];
+  /** Read failures, so a broken venue is visible rather than silently missing. */
+  unavailable: Array<{ venue: TreasuryVenueId; reason: string }>;
+  sourceAccount: string | null;
+  network: string;
+}
+
+export interface TreasuryMovementRequest {
+  venue: TreasuryVenueId;
+  /** Underlying asset amount in whole units, e.g. `25.5` USDC. */
+  amount: number;
+  /** Slippage tolerance in basis points. Defaults to 50 (0.5%). */
+  slippageBps?: number;
+  /** Identifier of the operator who triggered this, for the audit trail. */
+  requestedBy: string;
+}
+
+export interface TreasuryMovementResult {
+  id: string;
+  venue: TreasuryVenueId;
+  operation: 'deposit' | 'withdraw';
+  status: 'submitted';
+  amount: string;
+  assetCode: string;
+  txHash: string;
+  explorerUrl: string;
+}
+
+/** Minimal surface TreasuryService needs from a vault, for injection in tests. */
+export type VaultClient = Pick<
+  DefindexVaultContractClient,
+  | 'balance'
+  | 'totalSupply'
+  | 'fetchTotalManagedFunds'
+  | 'getAssetAmountsPerShares'
+  | 'getFees'
+  | 'deposit'
+  | 'withdraw'
+>;
+
+export type VaultClientFactory = (venue: TreasuryVenue, signerSecret?: string) => VaultClient;
+
+/**
+ * Convert a whole-unit decimal amount into the asset's smallest unit.
+ *
+ * Done with string arithmetic rather than `Number` so a value like `0.1` is not
+ * bent by binary floating point before it reaches the contract. Throws on more
+ * precision than the asset can represent instead of silently truncating funds.
+ */
+export function toSmallestUnit(amount: number | string, decimals: number): bigint {
+  const raw = typeof amount === 'number' ? normalizeNumericAmount(amount, decimals) : amount.trim();
+
+  if (!/^\d+(\.\d+)?$/.test(raw)) {
+    throw ApiError.badRequest('Amount must be a positive decimal number');
+  }
+
+  const [whole, fraction = ''] = raw.split('.');
+  if (fraction.length > decimals) {
+    throw ApiError.badRequest(
+      `Amount has more than ${decimals} decimal places, which this asset cannot represent`,
+    );
+  }
+
+  const scaled = BigInt(`${whole}${fraction.padEnd(decimals, '0')}`);
+  if (scaled <= 0n) {
+    throw ApiError.badRequest('Amount must be greater than zero');
+  }
+
+  return scaled;
+}
+
+/**
+ * Render a JS number as plain decimal notation.
+ *
+ * `Number.prototype.toString` switches to exponential form below 1e-6, so a
+ * legitimate seven-decimal amount like `0.0000005` arrives as `"5e-7"` and
+ * would otherwise be rejected as malformed. `toFixed` gives the plain form;
+ * comparing back catches a value carrying more precision than the asset can
+ * represent, which is still rejected rather than quietly rounded.
+ */
+function normalizeNumericAmount(amount: number, decimals: number): string {
+  if (!Number.isFinite(amount) || Math.abs(amount) >= 1e21) {
+    throw ApiError.badRequest('Amount must be a finite decimal number');
+  }
+
+  const fixed = amount.toFixed(decimals);
+  if (Number(fixed) !== amount) {
+    throw ApiError.badRequest(
+      `Amount has more than ${decimals} decimal places, which this asset cannot represent`,
+    );
+  }
+
+  return fixed;
+}
+
+/** Render a smallest-unit integer back as a whole-unit decimal string. */
+export function fromSmallestUnit(value: bigint, decimals: number): string {
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const divisor = 10n ** BigInt(decimals);
+  const whole = abs / divisor;
+  const fraction = (abs % divisor).toString().padStart(decimals, '0');
+
+  return `${negative ? '-' : ''}${whole}.${fraction}`;
+}
+
+/** Apply a slippage floor: `value * (10000 - bps) / 10000`, rounded down. */
+export function applySlippageFloor(value: bigint, slippageBps: number): bigint {
+  return (value * (BPS_DENOMINATOR - BigInt(slippageBps))) / BPS_DENOMINATOR;
+}
+
+function assertSlippage(slippageBps: number): number {
+  if (!Number.isInteger(slippageBps) || slippageBps < 0 || slippageBps > MAX_SLIPPAGE_BPS) {
+    throw ApiError.badRequest(`slippageBps must be an integer between 0 and ${MAX_SLIPPAGE_BPS}`);
+  }
+  return slippageBps;
+}
+
+/**
+ * Map a contract-level failure onto an HTTP response that says what actually
+ * went wrong on chain.
+ *
+ * The codes here are the ones a treasury movement can realistically hit, taken
+ * from the deployed contracts' error enums (vault `ContractError`, DeFindex
+ * `StrategyError`, and the Stellar Asset Contract codes reached through the
+ * vault's `transfer` call). Anything unrecognised falls through as a 502: the
+ * external venue failed in a way this service does not model, and pretending
+ * otherwise would be worse than saying so.
+ *
+ * Note on price feeds: these two vaults are single-asset, and their deposit and
+ * withdraw paths do not consult an oracle — verified by simulating a deposit
+ * against the deployed testnet vault and reading the call tree, which contains
+ * only balance reads, a token transfer and the strategy call. A Blend-side
+ * pricing failure would surface as `ExternalError` from the strategy, which is
+ * mapped below; there is no separate staleness check to make here.
+ */
+export function mapVaultErrorToApiError(error: DefindexVaultError): ApiError {
+  const details = {
+    venueError: error.errorName,
+    contractErrorCode: error.errorCode ?? null,
+    contractErrorSource: error.source,
+  };
+
+  switch (error.errorName) {
+    // The venue is not accepting funds right now.
+    case 'StrategyPaused':
+    case 'StrategyPausedOrNotFound':
+      return new ApiError(
+        503,
+        'TREASURY_VENUE_PAUSED',
+        'The venue strategy is paused and is not accepting treasury movements right now',
+        details,
+      );
+
+    // The venue cannot service a movement of this size.
+    case 'InsufficientManagedFunds':
+    case 'UnwindMoreThanAvailable':
+    case 'AmountOverTotalSupply':
+    case 'InsufficientLiquidity':
+      return new ApiError(
+        409,
+        'TREASURY_INSUFFICIENT_VENUE_LIQUIDITY',
+        'The venue does not currently hold enough liquidity to service this movement',
+        details,
+      );
+
+    // The treasury account itself cannot fund the movement.
+    case 'BalanceError':
+    case 'InsufficientBalance':
+      return new ApiError(
+        409,
+        'TREASURY_INSUFFICIENT_BALANCE',
+        'The treasury account does not hold enough of this asset for the requested amount',
+        details,
+      );
+
+    case 'TrustlineMissingError':
+      return new ApiError(
+        409,
+        'TREASURY_TRUSTLINE_MISSING',
+        'The treasury account has no trustline for this asset; establish one before depositing',
+        details,
+      );
+
+    case 'BalanceDeauthorizedError':
+      return new ApiError(
+        409,
+        'TREASURY_ASSET_NOT_AUTHORIZED',
+        'The asset issuer has not authorized the treasury account to hold this asset',
+        details,
+      );
+
+    // Amount is below what the venue will process, or slippage was not met.
+    case 'AmountBelowMinDust':
+    case 'InsufficientAmount':
+    case 'AmountNotAllowed':
+    case 'OnlyPositiveAmountAllowed':
+      return new ApiError(
+        422,
+        'TREASURY_AMOUNT_REJECTED',
+        'The venue rejected this amount as too small or otherwise not permitted',
+        details,
+      );
+
+    case 'UnderlyingAmountBelowMin':
+    case 'BTokensAmountBelowMin':
+    case 'InsufficientOutputAmount':
+      return new ApiError(
+        409,
+        'TREASURY_SLIPPAGE_EXCEEDED',
+        'The movement would settle below the requested slippage floor; retry with a wider tolerance',
+        details,
+      );
+
+    case 'DeadlineExpired':
+      return new ApiError(
+        409,
+        'TREASURY_DEADLINE_EXPIRED',
+        'The venue rejected the movement because its deadline had passed; retry',
+        details,
+      );
+
+    case 'Unauthorized':
+    case 'NotAuthorized':
+      return new ApiError(
+        403,
+        'TREASURY_UNAUTHORIZED',
+        'The configured treasury account is not authorized for this operation on the venue',
+        details,
+      );
+
+    // The strategy's own underlying protocol (Blend) rejected the call.
+    case 'ExternalError':
+    case 'SupplyNotFound':
+    case 'StrategyInvestError':
+    case 'StrategyWithdrawError':
+      return new ApiError(
+        502,
+        'TREASURY_VENUE_REJECTED',
+        'The underlying lending protocol rejected the movement',
+        details,
+      );
+
+    default:
+      return new ApiError(502, 'TREASURY_VENUE_ERROR', error.message, details);
+  }
+}
+
+/** Shape of the SDK's `SentTransaction` that this service depends on. */
+interface SentMovement {
+  sendTransactionResponse?: { hash?: string };
+  getTransactionResponse?: { txHash?: string };
+  result?: unknown;
+}
+
+/**
+ * Pull the share delta out of a submitted movement's return value.
+ *
+ * `deposit` returns `(amounts, shares_minted, allocations)`; `withdraw` returns
+ * the amounts withdrawn and no share count, since the caller already knows how
+ * many shares it burned. Returns `null` when the value is not in the expected
+ * shape, which keeps an unrecognised result from failing a landed transaction.
+ */
+function readSharesFromResult(
+  sent: SentMovement,
+  operation: 'deposit' | 'withdraw',
+): bigint | null {
+  if (operation !== 'deposit') {
+    return null;
+  }
+
+  try {
+    const raw = sent.result;
+    const value =
+      raw && typeof raw === 'object' && 'unwrap' in raw
+        ? (raw as { unwrap(): unknown }).unwrap()
+        : raw;
+
+    if (Array.isArray(value) && typeof value[1] === 'bigint') {
+      return value[1];
+    }
+  } catch {
+    // Result parsing is a convenience, never a reason to fail a landed movement.
+  }
+
+  return null;
+}
+
+function defaultVaultClientFactory(venue: TreasuryVenue, signerSecret?: string): VaultClient {
+  const networkPassphrase = process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
+  const rpcUrl = process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
+
+  if (!signerSecret) {
+    return DefindexVaultContractClient.fromConfig({
+      contractId: venue.vaultContractId,
+      networkPassphrase,
+      rpcUrl,
+      publicKey: getTreasurySourcePublicKey() ?? undefined,
+    });
+  }
+
+  const signer = createNodeContractSigner(signerSecret, networkPassphrase);
+  return DefindexVaultContractClient.fromConfig({
+    contractId: venue.vaultContractId,
+    networkPassphrase,
+    rpcUrl,
+    publicKey: signer.publicKey,
+    signTransaction: signer.signTransaction,
+  });
+}
+
+/**
+ * Treasury track (roadmap Phase 1a).
+ *
+ * Deposits the accumulated platform fee into already-deployed, already-audited
+ * DeFi venues, reads the resulting position back off chain, and keeps a local
+ * record of both. Every number this service reports about a position is read
+ * from the vault contract at request time — nothing here is estimated, and the
+ * stored snapshots are a cache of past reads, not a substitute for them.
+ */
+export class TreasuryService {
+  /** Last snapshot write per venue, to rate-limit read-triggered captures. */
+  private readonly lastSnapshotAt = new Map<TreasuryVenueId, number>();
+
+  constructor(
+    private readonly vaultClientFactory: VaultClientFactory = defaultVaultClientFactory,
+    private readonly audit: AuditService = auditService,
+    private readonly cache: CacheService = cacheService,
+  ) {}
+
+  /** Every venue in the registry, with whether it is usable on this network. */
+  listVenues(): TreasuryVenueStatus[] {
+    return TREASURY_VENUE_IDS.map((id) => {
+      const venue = getTreasuryVenue(id);
+      return {
+        venue: id,
+        configured: venue !== null,
+        label: venue?.label ?? id,
+        provider: venue?.provider ?? 'unknown',
+        strategy: venue?.strategy ?? 'unknown',
+      };
+    });
+  }
+
+  /**
+   * Read the platform's position in one venue directly from the vault.
+   *
+   * Four contract reads are needed and they are independent, so they run
+   * together: share balance, total supply, total managed funds, and fees.
+   */
+  async getPosition(venueId: TreasuryVenueId): Promise<TreasuryPosition> {
+    const venue = this.requireVenue(venueId);
+    const sourceAccount = getTreasurySourcePublicKey();
+    const cacheKey = `treasury:position:${venue.id}:${venue.vaultContractId}:${sourceAccount ?? 'none'}`;
+
+    const cached = await this.cache.get<TreasuryPosition>(cacheKey).catch(() => null);
+    if (cached) {
+      return cached;
+    }
+
+    const client = this.vaultClientFactory(venue);
+
+    try {
+      const [shares, managedFunds, fees] = await Promise.all([
+        sourceAccount ? client.balance(sourceAccount) : Promise.resolve(0n),
+        client.fetchTotalManagedFunds(),
+        client.getFees(),
+      ]);
+
+      const allocation = this.selectAllocation(managedFunds, venue);
+      const positionValue = shares > 0n ? await this.valueOfShares(client, shares) : 0n;
+
+      const strategies: TreasuryStrategyView[] = allocation.strategy_allocations.map((entry) => ({
+        address: entry.strategy_address,
+        amount: fromSmallestUnit(entry.amount, venue.assetDecimals),
+        paused: entry.paused,
+      }));
+
+      const position: TreasuryPosition = {
+        venue: venue.id,
+        label: venue.label,
+        provider: venue.provider,
+        strategy: venue.strategy,
+        assetCode: venue.assetCode,
+        vaultContractId: venue.vaultContractId,
+        assetContractId: venue.assetContractId,
+        shares: fromSmallestUnit(shares, venue.assetDecimals),
+        positionValue: fromSmallestUnit(positionValue, venue.assetDecimals),
+        vaultTotalManaged: fromSmallestUnit(allocation.total_amount, venue.assetDecimals),
+        vaultIdleAmount: fromSmallestUnit(allocation.idle_amount, venue.assetDecimals),
+        vaultInvestedAmount: fromSmallestUnit(allocation.invested_amount, venue.assetDecimals),
+        strategies,
+        paused: strategies.length > 0 && strategies.every((entry) => entry.paused),
+        fees: { vaultBps: fees[0], protocolBps: fees[1] },
+        explorer: {
+          vault: this.explorerContractUrl(venue.vaultContractId),
+          asset: this.explorerContractUrl(venue.assetContractId),
+          account: sourceAccount ? this.explorerAccountUrl(sourceAccount) : null,
+        },
+        readAt: new Date().toISOString(),
+      };
+
+      // Neither the cache write nor the snapshot may fail a read that already
+      // succeeded against the chain: both are conveniences layered on top of it.
+      await this.cache.set(cacheKey, position, POSITION_CACHE_TTL_SECONDS).catch(() => {});
+
+      await this.persistSnapshot(position).catch((error: unknown) => {
+        logger.warn('Failed to persist treasury position snapshot', {
+          venue: venue.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+      return position;
+    } catch (error) {
+      throw this.toApiError(error);
+    }
+  }
+
+  /** Positions across every configured venue, plus what could not be read. */
+  async getPortfolio(): Promise<TreasuryPortfolio> {
+    const configured = getConfiguredTreasuryVenues();
+    const configuredIds = new Set(configured.map((venue) => venue.id));
+
+    const results = await Promise.allSettled(configured.map((venue) => this.getPosition(venue.id)));
+
+    const positions: TreasuryPosition[] = [];
+    const unavailable: TreasuryPortfolio['unavailable'] = [];
+
+    results.forEach((result, index) => {
+      const venue = configured[index]!;
+      if (result.status === 'fulfilled') {
+        positions.push(result.value);
+      } else {
+        const reason =
+          result.reason instanceof Error ? result.reason.message : String(result.reason);
+        logger.warn('Treasury venue read failed', { venue: venue.id, error: reason });
+        unavailable.push({ venue: venue.id, reason });
+      }
+    });
+
+    return {
+      positions,
+      unconfigured: this.listVenues().filter((venue) => !configuredIds.has(venue.venue)),
+      unavailable,
+      sourceAccount: getTreasurySourcePublicKey(),
+      network: process.env.STELLAR_NETWORK ?? 'testnet',
+    };
+  }
+
+  /** Deposit `amount` of the venue's underlying asset into its vault. */
+  async deposit(request: TreasuryMovementRequest): Promise<TreasuryMovementResult> {
+    const venue = this.requireVenue(request.venue);
+    const source = this.requireSourceAccount();
+    const slippageBps = assertSlippage(request.slippageBps ?? DEFAULT_SLIPPAGE_BPS);
+    const amount = toSmallestUnit(request.amount, venue.assetDecimals);
+
+    const client = this.vaultClientFactory(venue, source.secret);
+
+    return this.executeMovement({
+      venue,
+      operation: 'deposit',
+      amount,
+      requestedBy: request.requestedBy,
+      sourceAccount: source.publicKey,
+      metadata: { slippageBps, invest: true },
+      send: async () => {
+        const transaction = await client.deposit({
+          amountsDesired: [amount],
+          amountsMin: [applySlippageFloor(amount, slippageBps)],
+          from: source.publicKey,
+          invest: true,
+        });
+        return this.signAndSend(transaction, 'deposit');
+      },
+    });
+  }
+
+  /**
+   * Withdraw `amount` of the venue's underlying asset back to the treasury.
+   *
+   * The vault burns shares, not asset amounts, so the requested amount is
+   * converted using the vault's live share price — the same rule of three
+   * DeFindex documents: `shares = total_supply * amount / total_managed`.
+   */
+  async withdraw(request: TreasuryMovementRequest): Promise<TreasuryMovementResult> {
+    const venue = this.requireVenue(request.venue);
+    const source = this.requireSourceAccount();
+    const slippageBps = assertSlippage(request.slippageBps ?? DEFAULT_SLIPPAGE_BPS);
+    const amount = toSmallestUnit(request.amount, venue.assetDecimals);
+
+    const client = this.vaultClientFactory(venue, source.secret);
+
+    return this.executeMovement({
+      venue,
+      operation: 'withdraw',
+      amount,
+      requestedBy: request.requestedBy,
+      sourceAccount: source.publicKey,
+      metadata: { slippageBps },
+      send: async () => {
+        const shares = await this.sharesForAmount(client, venue, amount);
+        const transaction = await client.withdraw({
+          withdrawShares: shares,
+          minAmountsOut: [applySlippageFloor(amount, slippageBps)],
+          from: source.publicKey,
+        });
+        const sent = await this.signAndSend(transaction, 'withdraw');
+        // The caller chose the share count, so record that rather than guess.
+        return { ...sent, shares };
+      },
+    });
+  }
+
+  /**
+   * Run a movement, recording it either way.
+   *
+   * A failed movement is written to `treasury_transactions` with the contract
+   * error before the error is re-thrown, so the history endpoint shows attempts
+   * that did not land rather than only the ones that did.
+   */
+  private async executeMovement(params: {
+    venue: TreasuryVenue;
+    operation: 'deposit' | 'withdraw';
+    amount: bigint;
+    requestedBy: string;
+    sourceAccount: string;
+    metadata: Record<string, unknown>;
+    send: () => Promise<{ txHash: string; shares: bigint | null }>;
+  }): Promise<TreasuryMovementResult> {
+    const { venue, operation, amount, requestedBy, sourceAccount, metadata } = params;
+    const amountLabel = fromSmallestUnit(amount, venue.assetDecimals);
+
+    let sent: { txHash: string; shares: bigint | null };
+    try {
+      sent = await params.send();
+    } catch (error) {
+      const apiError = this.toApiError(error);
+      await this.recordFailure({
+        venue,
+        operation,
+        amountLabel,
+        requestedBy,
+        sourceAccount,
+        metadata,
+        apiError,
+      });
+      throw apiError;
+    }
+
+    const { txHash, shares } = sent;
+    const record = await TreasuryRepository.recordTransaction({
+      venue: venue.id,
+      operation,
+      status: 'submitted',
+      vaultContractId: venue.vaultContractId,
+      sourceAccount,
+      assetCode: venue.assetCode,
+      amount: amountLabel,
+      shares: shares === null ? null : fromSmallestUnit(shares, venue.assetDecimals),
+      txHash,
+      requestedBy,
+      metadata,
+    });
+
+    await this.audit.logAction({
+      actor: requestedBy,
+      action: `treasury.${operation}`,
+      entityType: 'treasury_transaction',
+      entityId: record.id,
+      afterValue: { venue: venue.id, amount: amountLabel, assetCode: venue.assetCode, txHash },
+    });
+
+    return {
+      id: record.id,
+      venue: venue.id,
+      operation,
+      status: 'submitted',
+      amount: amountLabel,
+      assetCode: venue.assetCode,
+      txHash,
+      explorerUrl: `${getStellarExpertBaseUrl()}/tx/${txHash}`,
+    };
+  }
+
+  private async recordFailure(params: {
+    venue: TreasuryVenue;
+    operation: 'deposit' | 'withdraw';
+    amountLabel: string;
+    requestedBy: string;
+    sourceAccount: string;
+    metadata: Record<string, unknown>;
+    apiError: ApiError;
+  }): Promise<void> {
+    const details = params.apiError.details as
+      { venueError?: string; contractErrorCode?: number | null } | undefined;
+
+    await TreasuryRepository.recordTransaction({
+      venue: params.venue.id,
+      operation: params.operation,
+      status: 'failed',
+      vaultContractId: params.venue.vaultContractId,
+      sourceAccount: params.sourceAccount,
+      assetCode: params.venue.assetCode,
+      amount: params.amountLabel,
+      errorName: details?.venueError ?? params.apiError.code,
+      errorCode: details?.contractErrorCode != null ? String(details.contractErrorCode) : null,
+      requestedBy: params.requestedBy,
+      metadata: { ...params.metadata, message: params.apiError.message },
+    }).catch((error: unknown) => {
+      logger.error('Failed to record treasury movement failure', {
+        venue: params.venue.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  /** Recorded movements, newest first. */
+  async getHistory(params: { venue?: TreasuryVenueId; limit: number; offset: number }) {
+    const [transactions, snapshots] = await Promise.all([
+      TreasuryRepository.listTransactions(params),
+      TreasuryRepository.listSnapshots(params),
+    ]);
+
+    return {
+      transactions: transactions.map((row) => ({
+        id: row.id,
+        venue: row.venue,
+        operation: row.operation,
+        status: row.status,
+        assetCode: row.assetCode,
+        amount: row.amount,
+        shares: row.shares,
+        txHash: row.txHash,
+        explorerUrl: row.txHash ? `${getStellarExpertBaseUrl()}/tx/${row.txHash}` : null,
+        errorName: row.errorName,
+        errorCode: row.errorCode,
+        requestedBy: row.requestedBy,
+        createdAt: row.createdAt,
+      })),
+      snapshots: snapshots.map((row) => ({
+        venue: row.venue,
+        assetCode: row.assetCode,
+        shares: row.shares,
+        positionValue: row.positionValue,
+        vaultTotalManaged: row.vaultTotalManaged,
+        capturedAt: row.capturedAt,
+      })),
+    };
+  }
+
+  /** Underlying-asset value of a share balance, read from the vault. */
+  private async valueOfShares(client: VaultClient, shares: bigint): Promise<bigint> {
+    const amounts = await client.getAssetAmountsPerShares(shares);
+    return amounts[0] ?? 0n;
+  }
+
+  /**
+   * Shares to burn to receive `amount` of the underlying asset.
+   *
+   * Rounded up, because rounding down would leave the withdrawal short of the
+   * requested amount and trip the caller's own slippage floor.
+   */
+  private async sharesForAmount(
+    client: VaultClient,
+    venue: TreasuryVenue,
+    amount: bigint,
+  ): Promise<bigint> {
+    const [totalSupply, managedFunds] = await Promise.all([
+      client.totalSupply(),
+      client.fetchTotalManagedFunds(),
+    ]);
+
+    const allocation = this.selectAllocation(managedFunds, venue);
+
+    if (totalSupply <= 0n || allocation.total_amount <= 0n) {
+      throw new ApiError(
+        409,
+        'TREASURY_INSUFFICIENT_VENUE_LIQUIDITY',
+        'The venue holds no funds, so there is nothing to withdraw',
+      );
+    }
+
+    if (amount > allocation.total_amount) {
+      throw new ApiError(
+        409,
+        'TREASURY_INSUFFICIENT_VENUE_LIQUIDITY',
+        'The venue does not currently hold enough liquidity to service this movement',
+      );
+    }
+
+    const numerator = totalSupply * amount;
+    const shares = numerator / allocation.total_amount;
+    return numerator % allocation.total_amount === 0n ? shares : shares + 1n;
+  }
+
+  /**
+   * Pick the allocation entry for the venue's configured asset.
+   *
+   * These vaults are single-asset today, but selecting by address rather than
+   * by index means a vault that later gains a second asset reports the right
+   * one instead of silently reporting the wrong balance.
+   */
+  private selectAllocation(
+    managedFunds: CurrentAssetInvestmentAllocation[],
+    venue: TreasuryVenue,
+  ): CurrentAssetInvestmentAllocation {
+    const match = managedFunds.find((allocation) => allocation.asset === venue.assetContractId);
+
+    if (!match) {
+      throw new ApiError(
+        502,
+        'TREASURY_VENUE_ASSET_MISMATCH',
+        `Vault ${venue.vaultContractId} does not manage the configured asset ${venue.assetContractId}`,
+        { managedAssets: managedFunds.map((allocation) => allocation.asset) },
+      );
+    }
+
+    return match;
+  }
+
+  /**
+   * Submit an assembled movement and read back what the contract returned.
+   *
+   * The share delta is best-effort: it enriches the recorded history, so a
+   * result shape this service does not recognise is left as `null` rather than
+   * failing a movement that has already landed on chain.
+   */
+  private async signAndSend(
+    transaction: {
+      signAndSend: () => Promise<SentMovement>;
+    },
+    operation: 'deposit' | 'withdraw',
+  ): Promise<{ txHash: string; shares: bigint | null }> {
+    const sent = await transaction.signAndSend();
+    const txHash = sent.sendTransactionResponse?.hash ?? sent.getTransactionResponse?.txHash;
+
+    if (!txHash) {
+      throw new ApiError(
+        502,
+        'TREASURY_TX_HASH_MISSING',
+        'The treasury movement was submitted but no transaction hash was returned',
+      );
+    }
+
+    return { txHash, shares: readSharesFromResult(sent, operation) };
+  }
+
+  /**
+   * Store a position snapshot, at most once per {@link SNAPSHOT_MIN_INTERVAL_MS}
+   * per venue. Read-triggered capture is what builds the history chart, but an
+   * unauthenticated endpoint must not turn page loads into unbounded writes.
+   */
+  private async persistSnapshot(position: TreasuryPosition): Promise<void> {
+    const now = Date.now();
+    const last = this.lastSnapshotAt.get(position.venue) ?? 0;
+    if (now - last < SNAPSHOT_MIN_INTERVAL_MS) {
+      return;
+    }
+    this.lastSnapshotAt.set(position.venue, now);
+
+    await TreasuryRepository.recordSnapshot({
+      venue: position.venue,
+      vaultContractId: position.vaultContractId,
+      assetCode: position.assetCode,
+      shares: position.shares,
+      positionValue: position.positionValue,
+      vaultTotalManaged: position.vaultTotalManaged,
+    });
+  }
+
+  private requireVenue(venueId: TreasuryVenueId): TreasuryVenue {
+    const venue = getTreasuryVenue(venueId);
+    if (!venue) {
+      throw new ApiError(
+        503,
+        'TREASURY_VENUE_NOT_CONFIGURED',
+        `Treasury venue '${venueId}' has no contract addresses configured for this network`,
+      );
+    }
+    return venue;
+  }
+
+  private requireSourceAccount() {
+    const source = getTreasurySourceAccount();
+    if (!source) {
+      throw new ApiError(
+        503,
+        'TREASURY_SOURCE_NOT_CONFIGURED',
+        'No treasury signing key is configured; treasury movements are unavailable',
+      );
+    }
+    return source;
+  }
+
+  private explorerContractUrl(contractId: string): string {
+    return `${getStellarExpertBaseUrl()}/contract/${contractId}`;
+  }
+
+  private explorerAccountUrl(address: string): string {
+    return `${getStellarExpertBaseUrl()}/account/${address}`;
+  }
+
+  private toApiError(error: unknown): ApiError {
+    if (error instanceof ApiError) {
+      return error;
+    }
+
+    const vaultError = error instanceof DefindexVaultError ? error : toDefindexVaultError(error);
+
+    return mapVaultErrorToApiError(vaultError);
+  }
+}
+
+export const treasuryService = new TreasuryService();

--- a/apps/api/src/tests/treasury.integration.test.ts
+++ b/apps/api/src/tests/treasury.integration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Integration tests for the Phase 1a treasury track, run against the real
+ * DeFindex vaults deployed on Stellar testnet. Nothing here is mocked: every
+ * assertion is about what the deployed contracts actually return.
+ *
+ * Two venues are covered:
+ *   - `defindex-blend`       — DeFindex USDC vault, strategy `USDC Blend Strategy`
+ *   - `etherfuse-stablebond` — DeFindex CETES vault, strategy `CETES Blend Strategy`
+ *     (CETES is Etherfuse's tokenized Mexican sovereign-debt Stablebond)
+ *
+ * Reads are simulations and move no funds. The deposit test also runs against
+ * the real vault: it assembles and simulates a genuine `deposit` from a
+ * freshly funded account, which the deployed contract rejects at the token
+ * transfer. That failure is the point — it proves the argument encoding is
+ * accepted by the live WASM and that a real on-chain error decodes into the
+ * typed error the API maps to an HTTP response.
+ *
+ * These are opt-in because they need outbound network access to Stellar
+ * testnet and friendbot:
+ *
+ *   RUN_TREASURY_INTEGRATION_TESTS=1 bun test src/tests/treasury.integration.test.ts
+ */
+import { describe, expect, test } from 'bun:test';
+import { Keypair } from '@stellar/stellar-sdk';
+import { DefindexVaultContractClient, DefindexVaultError } from '@akkuea/shared';
+import { getTreasuryVenue, type TreasuryVenueId } from '../config/treasury';
+import { mapVaultErrorToApiError } from '../services/TreasuryService';
+
+const RUN = process.env.RUN_TREASURY_INTEGRATION_TESTS === '1';
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const FRIENDBOT_URL = 'https://friendbot.stellar.org';
+const NETWORK_TIMEOUT_MS = 60_000;
+
+const describeIntegration = RUN ? describe : describe.skip;
+
+function venueOrThrow(id: TreasuryVenueId) {
+  // The venue registry is network-scoped; these tests target testnet.
+  process.env.STELLAR_NETWORK = 'testnet';
+  const venue = getTreasuryVenue(id);
+  if (!venue) {
+    throw new Error(`Treasury venue '${id}' is not configured for testnet`);
+  }
+  return venue;
+}
+
+function clientFor(id: TreasuryVenueId, publicKey?: string) {
+  return DefindexVaultContractClient.fromConfig({
+    contractId: venueOrThrow(id).vaultContractId,
+    networkPassphrase: NETWORK_PASSPHRASE,
+    rpcUrl: RPC_URL,
+    publicKey,
+  });
+}
+
+async function fundedTestnetAccount(): Promise<string> {
+  const keypair = Keypair.random();
+  const response = await fetch(`${FRIENDBOT_URL}?addr=${keypair.publicKey()}`);
+
+  if (!response.ok) {
+    throw new Error(`Friendbot funding failed with status ${response.status}`);
+  }
+
+  return keypair.publicKey();
+}
+
+const VENUE_EXPECTATIONS: Array<{
+  id: TreasuryVenueId;
+  strategyName: string;
+  assetCode: string;
+}> = [
+  { id: 'defindex-blend', strategyName: 'USDC Blend Strategy', assetCode: 'USDC' },
+  { id: 'etherfuse-stablebond', strategyName: 'CETES Blend Strategy', assetCode: 'CETES' },
+];
+
+describeIntegration('treasury venues against deployed DeFindex vaults (testnet)', () => {
+  for (const expectation of VENUE_EXPECTATIONS) {
+    describe(expectation.id, () => {
+      test(
+        'the configured vault manages the configured asset through the expected strategy',
+        async () => {
+          const venue = venueOrThrow(expectation.id);
+          const assets = await clientFor(expectation.id).getAssets();
+
+          const managed = assets.find((entry) => entry.address === venue.assetContractId);
+          expect(managed).toBeDefined();
+
+          const strategyNames = managed!.strategies.map((strategy) => strategy.name);
+          expect(strategyNames).toContain(expectation.strategyName);
+          expect(venue.assetCode).toBe(expectation.assetCode);
+        },
+        NETWORK_TIMEOUT_MS,
+      );
+
+      test(
+        'configured decimals match what the deployed vault reports',
+        async () => {
+          const venue = venueOrThrow(expectation.id);
+          const onChainDecimals = await clientFor(expectation.id).decimals();
+
+          expect(onChainDecimals).toBe(venue.assetDecimals);
+        },
+        NETWORK_TIMEOUT_MS,
+      );
+
+      test(
+        'total managed funds are internally consistent and non-negative',
+        async () => {
+          const venue = venueOrThrow(expectation.id);
+          const managedFunds = await clientFor(expectation.id).fetchTotalManagedFunds();
+
+          const allocation = managedFunds.find((entry) => entry.asset === venue.assetContractId);
+          expect(allocation).toBeDefined();
+          expect(allocation!.total_amount).toBeGreaterThanOrEqual(0n);
+          expect(allocation!.idle_amount + allocation!.invested_amount).toBe(
+            allocation!.total_amount,
+          );
+
+          const strategyTotal = allocation!.strategy_allocations.reduce(
+            (sum, entry) => sum + entry.amount,
+            0n,
+          );
+          expect(strategyTotal).toBe(allocation!.invested_amount);
+        },
+        NETWORK_TIMEOUT_MS,
+      );
+
+      test(
+        'share price is readable and a share is worth at least its face value',
+        async () => {
+          const client = clientFor(expectation.id);
+          const [totalSupply, oneShareWorth] = await Promise.all([
+            client.totalSupply(),
+            // 1.0 share at 7 decimals.
+            client.getAssetAmountsPerShares(10_000_000n),
+          ]);
+
+          expect(totalSupply).toBeGreaterThan(0n);
+          // Vaults only accrue value, so a share never redeems for less than 1:1.
+          expect(oneShareWorth[0]).toBeGreaterThanOrEqual(10_000_000n);
+        },
+        NETWORK_TIMEOUT_MS,
+      );
+
+      test(
+        'a real deposit call is accepted by the deployed vault and fails only on funding',
+        async () => {
+          const source = await fundedTestnetAccount();
+          const client = clientFor(expectation.id, source);
+
+          // A freshly funded account holds no USDC/CETES and has no trustline,
+          // so the deployed contract must reject this at the token transfer.
+          const attempt = client.deposit({
+            amountsDesired: [10_000_000n],
+            amountsMin: [9_950_000n],
+            from: source,
+            invest: true,
+          });
+
+          const error = await attempt.then(
+            () => null,
+            (caught: unknown) => caught as DefindexVaultError,
+          );
+
+          expect(error).toBeInstanceOf(DefindexVaultError);
+          if (!error) {
+            throw new Error('Expected the deployed vault to reject an unfunded deposit');
+          }
+
+          // #13 TrustlineMissingError, or #10 BalanceError if a trustline exists
+          // but is empty. Either proves the call reached the token transfer,
+          // which means the vault accepted the arguments.
+          expect(['TrustlineMissingError', 'BalanceError']).toContain(error.errorName);
+          expect(error.source).toBe('token');
+
+          const apiError = mapVaultErrorToApiError(error);
+          expect(apiError.statusCode).toBe(409);
+          expect(['TREASURY_TRUSTLINE_MISSING', 'TREASURY_INSUFFICIENT_BALANCE']).toContain(
+            apiError.code,
+          );
+        },
+        NETWORK_TIMEOUT_MS,
+      );
+    });
+  }
+
+  test(
+    'the two venues are distinct vaults holding distinct assets',
+    async () => {
+      const blend = venueOrThrow('defindex-blend');
+      const etherfuse = venueOrThrow('etherfuse-stablebond');
+
+      expect(blend.vaultContractId).not.toBe(etherfuse.vaultContractId);
+      expect(blend.assetContractId).not.toBe(etherfuse.assetContractId);
+    },
+    NETWORK_TIMEOUT_MS,
+  );
+});
+
+if (!RUN) {
+  describe('treasury integration tests', () => {
+    test('are skipped without RUN_TREASURY_INTEGRATION_TESTS=1', () => {
+      expect(RUN).toBe(false);
+    });
+  });
+}

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -47,7 +47,7 @@
     "typescript-eslint": "^8.57.0"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^13.3.0",
+    "@stellar/stellar-sdk": "^14.2.0",
     "zod": "^3.25.76"
   },
   "resolutions": {

--- a/apps/shared/src/contracts/defindexVault.ts
+++ b/apps/shared/src/contracts/defindexVault.ts
@@ -1,0 +1,329 @@
+import type { AssembledTransaction } from "@stellar/stellar-sdk/contract";
+import {
+  Client as GeneratedDefindexVaultClient,
+  ContractError as VAULT_CONTRACT_ERRORS,
+  StrategyError as VAULT_STRATEGY_ERRORS,
+  type AssetStrategySet,
+  type CurrentAssetInvestmentAllocation,
+} from "./generated/defindexVault";
+import {
+  buildContractClientOptions,
+  type SorobanClientConfig,
+} from "./clientConfig";
+
+export type {
+  AssetStrategySet,
+  CurrentAssetInvestmentAllocation,
+  StrategyAllocation,
+} from "./generated/defindexVault";
+
+/**
+ * Per-call transaction knobs accepted by the generated bindings. Declared here
+ * rather than reusing the SDK's `MethodOptions` because the bindings type `fee`
+ * as a number, while `MethodOptions` types it as a string.
+ */
+export interface VaultMethodOptions {
+  /** Max fee to pay, in stroops. */
+  fee?: number;
+  /** How long the transaction stays valid for, in seconds. */
+  timeoutInSeconds?: number;
+  /** Set `false` to assemble without simulating. */
+  simulate?: boolean;
+}
+
+export interface VaultDepositArgs {
+  /** Desired amount of each underlying asset, in the asset's smallest unit. */
+  amountsDesired: bigint[];
+  /** Slippage floor per asset; the vault reverts if it can't transfer this much. */
+  amountsMin: bigint[];
+  /** Address the assets are pulled from, and that receives the dfTokens. */
+  from: string;
+  /**
+   * `true` routes the deposit straight into the vault's strategies.
+   * `false` leaves it as idle funds inside the vault.
+   */
+  invest: boolean;
+}
+
+export interface VaultWithdrawArgs {
+  /** Number of dfToken shares to burn. */
+  withdrawShares: bigint;
+  /** Minimum amount of each underlying asset the caller will accept. */
+  minAmountsOut: bigint[];
+  /** Address burning the shares and receiving the underlying assets. */
+  from: string;
+}
+
+/**
+ * A vault call that failed inside the contract, with the on-chain error code
+ * resolved to its declared name where possible.
+ *
+ * Soroban surfaces two shapes of failure through the JS SDK:
+ *   - a declared `Result::Err`, which the bindings hand back as an `Err` value;
+ *   - a host trap (`Error(Contract, #N)`), thrown from `simulate`/`signAndSend`,
+ *     which is what a nested call — a strategy, or the underlying token — does
+ *     when it fails.
+ *
+ * Both end up here so callers only have to handle one thing.
+ */
+export class DefindexVaultError extends Error {
+  constructor(
+    /** Declared error name (`StrategyPaused`, `InsufficientBalance`, …) or `Unknown`. */
+    public readonly errorName: string,
+    /** Raw contract error code, when one could be parsed out. */
+    public readonly errorCode: number | undefined,
+    /** Which contract the code belongs to. */
+    public readonly source: "vault" | "strategy" | "token" | "unknown",
+    message: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "DefindexVaultError";
+    Object.setPrototypeOf(this, DefindexVaultError.prototype);
+  }
+}
+
+/**
+ * Stellar Asset Contract error codes. Deposits and withdrawals bottom out in a
+ * SAC `transfer`, so these are the codes a treasury deposit actually trips on
+ * before it ever reaches vault logic.
+ *
+ * Source: soroban-env-host `ContractError` for the built-in token contract.
+ */
+const TOKEN_CONTRACT_ERRORS: Record<number, string> = {
+  8: "InternalError",
+  9: "OperationNotSupported",
+  10: "BalanceError",
+  11: "BalanceDeauthorizedError",
+  12: "OverflowError",
+  13: "TrustlineMissingError",
+};
+
+/** Vault error codes start at 100; strategy codes at 401; SAC codes below 100. */
+function classifyErrorCode(code: number): {
+  errorName: string;
+  source: DefindexVaultError["source"];
+} {
+  const vaultName = (
+    VAULT_CONTRACT_ERRORS as Record<number, { message: string }>
+  )[code]?.message;
+  if (vaultName) {
+    return { errorName: vaultName, source: "vault" };
+  }
+
+  const strategyName = (
+    VAULT_STRATEGY_ERRORS as Record<number, { message: string }>
+  )[code]?.message;
+  if (strategyName) {
+    return { errorName: strategyName, source: "strategy" };
+  }
+
+  const tokenName = TOKEN_CONTRACT_ERRORS[code];
+  if (tokenName) {
+    return { errorName: tokenName, source: "token" };
+  }
+
+  return { errorName: "Unknown", source: "unknown" };
+}
+
+/**
+ * Turn anything thrown by a vault call into a {@link DefindexVaultError}.
+ *
+ * Host traps arrive as an `Error` whose message embeds `Error(Contract, #N)`;
+ * that code is the only machine-readable part, so it is what we key on.
+ */
+export function toDefindexVaultError(error: unknown): DefindexVaultError {
+  if (error instanceof DefindexVaultError) {
+    return error;
+  }
+
+  const message =
+    error instanceof Error ? error.message : String(error ?? "unknown error");
+  const codeMatch = /Error\(Contract,\s*#(\d+)\)/.exec(message);
+
+  if (!codeMatch) {
+    return new DefindexVaultError(
+      "Unknown",
+      undefined,
+      "unknown",
+      message,
+      error,
+    );
+  }
+
+  const code = Number(codeMatch[1]);
+  const { errorName, source } = classifyErrorCode(code);
+
+  return new DefindexVaultError(
+    errorName,
+    code,
+    source,
+    `DeFindex vault call failed with ${source} error #${code} (${errorName})`,
+    error,
+  );
+}
+
+/**
+ * Typed client for a DeFindex Vault (the `dfToken` contract).
+ *
+ * Wraps the generated bindings the way {@link DefiLendingContractClient} wraps
+ * the platform's own lending contract: camelCase args, `bigint` amounts, and
+ * read helpers that simulate and hand back plain values instead of an
+ * `AssembledTransaction`.
+ */
+export class DefindexVaultContractClient {
+  constructor(private readonly client: GeneratedDefindexVaultClient) {}
+
+  static fromConfig(config: SorobanClientConfig): DefindexVaultContractClient {
+    return new DefindexVaultContractClient(
+      new GeneratedDefindexVaultClient(buildContractClientOptions(config)),
+    );
+  }
+
+  /**
+   * Build a `deposit` transaction, already simulated.
+   *
+   * A vault that would reject the deposit fails here rather than at submit
+   * time, so the caller never signs a transaction that cannot land.
+   */
+  async deposit(
+    args: VaultDepositArgs,
+    options?: VaultMethodOptions,
+  ): Promise<AssembledTransaction<unknown>> {
+    return this.assemble(() =>
+      this.client.deposit(
+        {
+          amounts_desired: args.amountsDesired,
+          amounts_min: args.amountsMin,
+          from: args.from,
+          invest: args.invest,
+        },
+        options,
+      ),
+    );
+  }
+
+  /** Build a simulated `withdraw` transaction that burns `withdrawShares` dfTokens. */
+  async withdraw(
+    args: VaultWithdrawArgs,
+    options?: VaultMethodOptions,
+  ): Promise<AssembledTransaction<unknown>> {
+    return this.assemble(() =>
+      this.client.withdraw(
+        {
+          withdraw_shares: args.withdrawShares,
+          min_amounts_out: args.minAmountsOut,
+          from: args.from,
+        },
+        options,
+      ),
+    );
+  }
+
+  /**
+   * Assemble a write call and surface a failed simulation immediately.
+   *
+   * The SDK builds the transaction without throwing when simulation fails; the
+   * error only appears when `simulationData` is read, which for an unwary
+   * caller is at `signAndSend`. Reading it here moves a contract rejection —
+   * a paused strategy, an unfunded treasury account — to the point where the
+   * call is made, where it can still be handled.
+   */
+  private async assemble(
+    call: () => Promise<AssembledTransaction<unknown>>,
+  ): Promise<AssembledTransaction<unknown>> {
+    try {
+      const transaction = await call();
+      void transaction.simulationData;
+      return transaction;
+    } catch (error) {
+      throw toDefindexVaultError(error);
+    }
+  }
+
+  /** dfToken (share) balance held by `address`. */
+  async balance(address: string): Promise<bigint> {
+    return this.read(() => this.client.balance({ id: address }));
+  }
+
+  /** Total dfToken supply across every holder. */
+  async totalSupply(): Promise<bigint> {
+    return this.read(() => this.client.total_supply());
+  }
+
+  /** Decimal precision of the dfToken and, for these vaults, of the assets. */
+  async decimals(): Promise<number> {
+    return this.read(() => this.client.decimals());
+  }
+
+  /** dfToken symbol, e.g. `DFXV`. */
+  async symbol(): Promise<string> {
+    return this.read(() => this.client.symbol());
+  }
+
+  /**
+   * Every underlying asset the vault manages, with idle vs. invested split and
+   * the per-strategy allocation — including each strategy's `paused` flag.
+   */
+  async fetchTotalManagedFunds(): Promise<CurrentAssetInvestmentAllocation[]> {
+    return this.readResult(() => this.client.fetch_total_managed_funds());
+  }
+
+  /** Underlying-asset amounts backing `vaultShares` dfTokens right now. */
+  async getAssetAmountsPerShares(vaultShares: bigint): Promise<bigint[]> {
+    return this.readResult(() =>
+      this.client.get_asset_amounts_per_shares({ vault_shares: vaultShares }),
+    );
+  }
+
+  /** Assets and the strategies configured for each. */
+  async getAssets(): Promise<AssetStrategySet[]> {
+    return this.readResult(() => this.client.get_assets());
+  }
+
+  /** `[vaultFeeBps, defindexProtocolFeeBps]`. */
+  async getFees(): Promise<[number, number]> {
+    const fees = await this.read(() => this.client.get_fees());
+    return [fees[0], fees[1]];
+  }
+
+  /** Simulate a plain-valued read and return the value. */
+  private async read<T>(
+    call: () => Promise<AssembledTransaction<T>>,
+  ): Promise<T> {
+    try {
+      const tx = await call();
+      return tx.result;
+    } catch (error) {
+      throw toDefindexVaultError(error);
+    }
+  }
+
+  /** Simulate a `Result`-valued read and unwrap it. */
+  private async readResult<T>(
+    call: () => Promise<
+      AssembledTransaction<{
+        unwrap(): T;
+        isErr(): boolean;
+        unwrapErr(): { message: string };
+      }>
+    >,
+  ): Promise<T> {
+    try {
+      const tx = await call();
+      const result = tx.result;
+      if (result.isErr()) {
+        const { message } = result.unwrapErr();
+        throw new DefindexVaultError(
+          message,
+          undefined,
+          "vault",
+          `DeFindex vault call failed: ${message}`,
+        );
+      }
+      return result.unwrap();
+    } catch (error) {
+      throw toDefindexVaultError(error);
+    }
+  }
+}

--- a/apps/shared/src/contracts/generated/defindexVault.ts
+++ b/apps/shared/src/contracts/generated/defindexVault.ts
@@ -1,0 +1,1907 @@
+/**
+ * TypeScript bindings for the DeFindex Vault contract.
+ *
+ * GENERATED FILE — do not edit by hand. Produced with:
+ *
+ *   stellar contract bindings typescript \
+ *     --network testnet \
+ *     --contract-id CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN \
+ *     --output-dir <tmp>
+ *
+ * The spec below is downloaded from the WASM of the DeFindex USDC/Blend vault
+ * deployed on Stellar testnet, so the interface here is the interface the
+ * deployed contract actually exposes — not a transcription of documentation.
+ * The same vault WASM backs the CETES (Etherfuse Stablebond) vault, so one set
+ * of bindings covers both treasury venues.
+ *
+ * Upstream source: https://github.com/paltalabs/defindex
+ * Deployment registry: https://github.com/defindex-io/stellar-contracts/blob/main/public/testnet.contracts.json
+ *
+ * Only the header imports were adjusted from the CLI output, to drop the
+ * wildcard `@stellar/stellar-sdk` re-exports that would otherwise leak into
+ * this package's public API.
+ */
+import { Buffer } from "buffer";
+import { Address } from "@stellar/stellar-sdk";
+import {
+  AssembledTransaction,
+  Client as ContractClient,
+  Spec as ContractSpec,
+} from "@stellar/stellar-sdk/contract";
+import type {
+  ClientOptions as ContractClientOptions,
+  MethodOptions,
+  Result,
+} from "@stellar/stellar-sdk/contract";
+import type {
+  u32,
+  i32,
+  u64,
+  i64,
+  u128,
+  i128,
+  u256,
+  i256,
+  Option,
+  Typepoint,
+  Duration,
+} from "@stellar/stellar-sdk/contract";
+
+const browserWindow = globalThis as typeof globalThis & {
+  window?: { Buffer?: typeof Buffer };
+};
+
+if (browserWindow.window) {
+  browserWindow.window.Buffer = browserWindow.window.Buffer || Buffer;
+}
+
+export const networks = {
+  testnet: {
+    networkPassphrase: "Test SDF Network ; September 2015",
+    contractId: "CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN",
+  },
+} as const;
+
+export const ContractError = {
+  100: { message: "NotInitialized" },
+  101: { message: "InvalidRatio" },
+  102: { message: "StrategyDoesNotSupportAsset" },
+  103: { message: "NoAssetAllocation" },
+  104: { message: "RolesIncomplete" },
+  105: { message: "MetadataIncomplete" },
+  106: { message: "MaximumFeeExceeded" },
+  107: { message: "DuplicatedAsset" },
+  108: { message: "DuplicatedStrategy" },
+  110: { message: "AmountNotAllowed" },
+  111: { message: "InsufficientBalance" },
+  112: { message: "WrongAmountsLength" },
+  113: { message: "WrongLockedFees" },
+  114: { message: "InsufficientManagedFunds" },
+  115: { message: "MissingInstructionData" },
+  116: { message: "UnsupportedAsset" },
+  117: { message: "InsufficientAmount" },
+  118: { message: "NoOptimalAmounts" },
+  119: { message: "WrongInvestmentLength" },
+  122: { message: "WrongAssetAddress" },
+  123: { message: "WrongStrategiesLength" },
+  124: { message: "AmountOverTotalSupply" },
+  125: { message: "NoInstructions" },
+  126: { message: "NotUpgradable" },
+  128: { message: "UnwindMoreThanAvailable" },
+  129: { message: "InsufficientFeesToRelease" },
+  120: { message: "ArithmeticError" },
+  121: { message: "Overflow" },
+  127: { message: "Underflow" },
+  130: { message: "Unauthorized" },
+  131: { message: "RoleNotFound" },
+  132: { message: "ManagerNotInQueue" },
+  133: { message: "SetManagerBeforeTime" },
+  134: { message: "QueueEmpty" },
+  140: { message: "StrategyNotFound" },
+  141: { message: "StrategyPausedOrNotFound" },
+  142: { message: "StrategyWithdrawError" },
+  143: { message: "StrategyInvestError" },
+  144: { message: "StrategyPaused" },
+  150: { message: "AssetNotFound" },
+  151: { message: "NoAssetsProvided" },
+  160: { message: "InsufficientOutputAmount" },
+  161: { message: "ExcessiveInputAmount" },
+  162: { message: "InvalidFeeBps" },
+  190: { message: "LibrarySortIdenticalTokens" },
+  200: { message: "SoroswapRouterError" },
+  201: { message: "SwapExactInError" },
+  202: { message: "SwapExactOutError" },
+};
+
+export type DataKey =
+  | { tag: "Allowance"; values: readonly [AllowanceDataKey] }
+  | { tag: "Balance"; values: readonly [string] }
+  | { tag: "TotalSupply"; values: void };
+
+export interface AllowanceValue {
+  amount: i128;
+  expiration_ledger: u32;
+}
+
+export interface AllowanceDataKey {
+  from: string;
+  spender: string;
+}
+
+export type RolesDataKey =
+  | { tag: "EmergencyManager"; values: void }
+  | { tag: "VaultFeeReceiver"; values: void }
+  | { tag: "Manager"; values: void }
+  | { tag: "RebalanceManager"; values: void };
+
+export interface InvestEvent {
+  asset_investments: Array<AssetInvestmentAllocation>;
+  rebalance_method: string;
+  report: Report;
+}
+
+export interface UnwindEvent {
+  call_params: Array<readonly [string, i128, string]>;
+  rebalance_method: string;
+  report: Report;
+}
+
+export interface SwapExactInEvent {
+  rebalance_method: string;
+  swap_args: Array<any>;
+}
+
+export interface SwapExactOutEvent {
+  rebalance_method: string;
+  swap_args: Array<any>;
+}
+
+export interface VaultDepositEvent {
+  amounts: Array<i128>;
+  depositor: string;
+  df_tokens_minted: i128;
+  total_managed_funds_before: Array<CurrentAssetInvestmentAllocation>;
+  total_supply_before: i128;
+}
+
+export interface VaultWithdrawEvent {
+  amounts_withdrawn: Array<i128>;
+  df_tokens_burned: i128;
+  total_managed_funds_before: Array<CurrentAssetInvestmentAllocation>;
+  total_supply_before: i128;
+  withdrawer: string;
+}
+
+export interface ManagerChangedEvent {
+  new_manager: string;
+}
+
+export interface StrategyPausedEvent {
+  caller: string;
+  strategy_address: string;
+}
+
+export interface FeesDistributedEvent {
+  distributed_fees: Array<readonly [string, i128]>;
+}
+
+export interface StrategyUnpausedEvent {
+  caller: string;
+  strategy_address: string;
+}
+
+export interface EmergencyWithdrawEvent {
+  amount_withdrawn: i128;
+  caller: string;
+  strategy_address: string;
+}
+
+export interface FeeReceiverChangedEvent {
+  caller: string;
+  new_fee_receiver: string;
+}
+
+export interface EmergencyManagerChangedEvent {
+  new_emergency_manager: string;
+}
+
+export interface RebalanceManagerChangedEvent {
+  new_rebalance_manager: string;
+}
+
+export type Instruction =
+  | { tag: "Unwind"; values: readonly [string, i128] }
+  | { tag: "Invest"; values: readonly [string, i128] }
+  | { tag: "SwapExactIn"; values: readonly [string, string, i128, i128, u64] }
+  | { tag: "SwapExactOut"; values: readonly [string, string, i128, i128, u64] };
+
+export interface StrategyAllocation {
+  amount: i128;
+  paused: boolean;
+  strategy_address: string;
+}
+
+export interface AssetInvestmentAllocation {
+  asset: string;
+  strategy_allocations: Array<Option<StrategyAllocation>>;
+}
+
+export interface CurrentAssetInvestmentAllocation {
+  asset: string;
+  idle_amount: i128;
+  invested_amount: i128;
+  strategy_allocations: Array<StrategyAllocation>;
+  total_amount: i128;
+}
+
+export interface Report {
+  gains_or_losses: i128;
+  locked_fee: i128;
+  prev_balance: i128;
+}
+
+export interface Strategy {
+  address: string;
+  name: string;
+  paused: boolean;
+}
+
+export interface AssetStrategySet {
+  address: string;
+  strategies: Array<Strategy>;
+}
+
+export const StrategyError = {
+  401: { message: "NotInitialized" },
+  410: { message: "NegativeNotAllowed" },
+  411: { message: "InvalidArgument" },
+  412: { message: "InsufficientBalance" },
+  413: { message: "UnderflowOverflow" },
+  414: { message: "ArithmeticError" },
+  415: { message: "DivisionByZero" },
+  416: { message: "InvalidSharesMinted" },
+  417: { message: "OnlyPositiveAmountAllowed" },
+  418: { message: "NotAuthorized" },
+  420: { message: "ProtocolAddressNotFound" },
+  421: { message: "DeadlineExpired" },
+  422: { message: "ExternalError" },
+  423: { message: "SoroswapPairError" },
+  451: { message: "AmountBelowMinDust" },
+  452: { message: "UnderlyingAmountBelowMin" },
+  453: { message: "BTokensAmountBelowMin" },
+  454: { message: "InternalSwapError" },
+  455: { message: "SupplyNotFound" },
+};
+
+export interface DepositEvent {
+  amount: i128;
+  from: string;
+}
+
+export interface HarvestEvent {
+  amount: i128;
+  from: string;
+  price_per_share: i128;
+}
+
+export interface WithdrawEvent {
+  amount: i128;
+  from: string;
+}
+
+export interface TokenMetadata {
+  decimal: u32;
+  name: string;
+  symbol: string;
+}
+
+export const SoroswapLibraryError = {
+  /**
+   * SoroswapLibrary: insufficient amount
+   */
+  301: { message: "InsufficientAmount" },
+  /**
+   * SoroswapLibrary: insufficient liquidity
+   */
+  302: { message: "InsufficientLiquidity" },
+  /**
+   * SoroswapLibrary: insufficient input amount
+   */
+  303: { message: "InsufficientInputAmount" },
+  /**
+   * SoroswapLibrary: insufficient output amount
+   */
+  304: { message: "InsufficientOutputAmount" },
+  /**
+   * SoroswapLibrary: invalid path
+   */
+  305: { message: "InvalidPath" },
+  /**
+   * SoroswapLibrary: token_a and token_b have identical addresses
+   */
+  306: { message: "SortIdenticalTokens" },
+};
+
+export interface Client {
+  /**
+   * Construct and simulate a report transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Generates reports for all strategies in the vault, tracking their performance and fee accrual.
+   *
+   * This function iterates through all assets and their associated strategies to generate
+   * performance reports. It updates each strategy's report with current balances and
+   * calculates gains or losses since the last report.
+   *
+   * # Arguments
+   * * `e` - The environment reference.
+   *
+   * # Function Flow
+   * 1. **Instance Extension**:
+   * - Extends contract TTL
+   *
+   * 2. **Asset & Strategy Retrieval**:
+   * - Gets all assets and their strategies
+   * - Initializes reports vector
+   *
+   * 3. **Report Generation**:
+   * - For each asset:
+   * - For each strategy:
+   * - Gets current strategy balance
+   * - Updates report with new balance
+   * - Stores updated report
+   *
+   * # Returns
+   * * `Result<Vec<Report>, ContractError>` - On success, returns a vector of reports
+   * where each report contains performance metrics for a strategy. Returns
+   * ContractError if report generation fails.
+   *
+   * # Note
+   * Reports track:
+   * - Current strategy balance
+   * - Gains or losses since last report
+   * - Locked fees
+   * - Fee distribution status
+   */
+  report: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<Array<Report>>>>;
+
+  /**
+   * Construct and simulate a rescue transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Executes rescue (formerly emergency withdrawal) from a specific strategy.
+   *
+   * This function allows the emergency manager or manager to withdraw all assets from a particular strategy
+   * and store them as idle funds within the vault. It also pauses the strategy to prevent further use until
+   * unpaused.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `strategy_address` - The address of the strategy to withdraw from.
+   * * `caller` - The address initiating the emergency withdrawal (must be the manager or emergency manager).
+   *
+   * # Returns
+   * * `Result<(), ContractError>` - Success (()) or ContractError if the rescue operation fails
+   */
+  rescue: (
+    { strategy_address, caller }: { strategy_address: string; caller: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<void>>>;
+
+  /**
+   * Construct and simulate a deposit transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Handles user deposits into the DeFindex Vault and optionally allocates investments automatically.
+   *
+   * This function processes a deposit by transferring each specified asset amount from the user's address to
+   * the vault and mints vault shares that represent the user's proportional share in the vault. Additionally,
+   * if the `invest` parameter is set to `true`, the function will immediately generate and execute investment
+   * allocations based on the vault's strategy configuration.
+   *
+   * # Parameters
+   * * `e` - The current environment reference (`Env`), for access to the contract state and utilities.
+   * * `amounts_desired` - A vector specifying the user's intended deposit amounts for each asset.
+   * * `amounts_min` - A vector of minimum deposit amounts required for the transaction to proceed.
+   * * `from` - The address of the user making the deposit.
+   * * `invest` - A boolean flag indicating whether to immediately invest the deposited funds into the vault's strategies:
+   * - `true`: Generate and execute investments after the deposit.
+   * - `false`: Lea
+   */
+  deposit: (
+    {
+      amounts_desired,
+      amounts_min,
+      from,
+      invest,
+    }: {
+      amounts_desired: Array<i128>;
+      amounts_min: Array<i128>;
+      from: string;
+      invest: boolean;
+    },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<
+    AssembledTransaction<
+      Result<
+        readonly [
+          Array<i128>,
+          i128,
+          Option<Array<Option<AssetInvestmentAllocation>>>,
+        ]
+      >
+    >
+  >;
+
+  /**
+   * Construct and simulate a upgrade transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Upgrades the contract with new WebAssembly (WASM) code.
+   *
+   * This function updates the contract with new WASM code provided by the `new_wasm_hash`.
+   *
+   * # Arguments
+   *
+   * * `e` - The runtime environment.
+   * * `new_wasm_hash` - The hash of the new WASM code to upgrade the contract to.
+   *
+   * # Returns
+   * * `Result<(), ContractError>` - Returns Ok(()) on success, ContractError if upgrade fails
+   *
+   */
+  upgrade: (
+    { new_wasm_hash }: { new_wasm_hash: Buffer },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<void>>>;
+
+  /**
+   * Construct and simulate a get_fees transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Retrieves the current fee rates for the vault and the DeFindex protocol.
+   *
+   * This function returns the fee rates for both the vault and the DeFindex protocol.
+   *
+   * # Arguments
+   * * `e` - The environment.
+   *
+   * # Returns
+   * * `(u32, u32)` - A tuple containing:
+   * - The vault fee rate as a percentage in basis points.
+   * - The DeFindex protocol fee rate as a percentage in basis points.
+   *
+   */
+  get_fees: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<readonly [u32, u32]>>;
+
+  /**
+   * Construct and simulate a withdraw transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Handles user withdrawals from the DeFindex Vault by burning shares and returning assets.
+   *
+   * This function processes a withdrawal request by burning the specified amount of vault shares
+   * and returning a proportional amount of the vault's assets to the user. It can unwind positions
+   * from strategies if necessary to fulfill the withdrawal.
+   *
+   * ## Parameters:
+   * - `e`: The contract environment (`Env`).
+   * - `withdraw_shares`: The number of vault shares to withdraw.
+   * - `min_amounts_out`: A vector of minimum amounts required for each asset to be withdrawn.
+   * - `from`: The address initiating the withdrawal.
+   *
+   * ## Returns
+   * * `Result<Vec<i128>, ContractError>` - On success, returns a vector of withdrawn amounts
+   * where each index corresponds to the asset index in the vault's asset list.
+   * Returns ContractError if the withdrawal fails.
+   *
+   * ## Errors:
+   * - `ContractError::AmountOverTotalSupply`: If the specified shares exceed the total supply.
+   * - `ContractError::ArithmeticError`: If any arithmetic operation fails during calculations.
+   * - `ContractError
+   */
+  withdraw: (
+    {
+      withdraw_shares,
+      min_amounts_out,
+      from,
+    }: { withdraw_shares: i128; min_amounts_out: Array<i128>; from: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Array<i128>>>>;
+
+  /**
+   * Construct and simulate a lock_fees transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Locks fees for all assets and their strategies.
+   *
+   * Iterates through each asset and its strategies, locking fees based on `new_fee_bps` or the default vault fee.
+   *
+   * # Arguments
+   * * `e` - The environment reference.
+   * * `new_fee_bps` - Optional fee basis points to override the default.
+   *
+   * # Returns
+   * * `Result<Vec<(Address, i128)>, ContractError>` - A vector of tuples with strategy addresses and locked fee amounts in their underlying_asset.
+   */
+  lock_fees: (
+    { new_fee_bps }: { new_fee_bps: Option<u32> },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Array<Report>>>>;
+
+  /**
+   * Construct and simulate a rebalance transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Rebalances the vault by executing a series of instructions.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `instructions` - A vector of `Instruction` structs representing actions (withdraw, invest, swap, zapper) to be taken.
+   *
+   * # Returns:
+   * * `Result<(), ContractError>` - Ok if successful, otherwise returns a ContractError.
+   */
+  rebalance: (
+    {
+      caller,
+      instructions,
+    }: { caller: string; instructions: Array<Instruction> },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<void>>>;
+
+  /**
+   * Construct and simulate a get_assets transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Retrieves the list of assets managed by the DeFindex Vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   *
+   * # Returns:
+   * * `Vec<AssetStrategySet>` - A vector of `AssetStrategySet` structs representing the assets managed by the vault.
+   */
+  get_assets: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<Array<AssetStrategySet>>>>;
+
+  /**
+   * Construct and simulate a get_manager transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Retrieves the current manager address for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   *
+   * # Returns:
+   * * `Result<Address, ContractError>` - The manager address if successful, otherwise returns a ContractError.
+   */
+  get_manager: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<string>>>;
+
+  /**
+   * Construct and simulate a set_manager transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Sets the manager for the vault.
+   *
+   * This function allows the current manager to set a new manager for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `new_manager` - The new manager address.
+   *
+   * # Returns
+   * * `Result<(), ContractError>` - Success (()) or ContractError if the manager change fails
+   */
+  set_manager: (
+    { new_manager }: { new_manager: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<void>>>;
+
+  /**
+   * Construct and simulate a release_fees transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Releases locked fees for a specific strategy.
+   *
+   * # Arguments
+   * * `e` - The environment reference.
+   * * `strategy` - The address of the strategy for which to release fees.
+   * * `amount` - The amount of fees to release.
+   *
+   * # Returns
+   * * `Result<Report, ContractError>` - A report of the released fees or a `ContractError` if the operation fails.
+   */
+  release_fees: (
+    { strategy, amount }: { strategy: string; amount: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Report>>>;
+
+  /**
+   * Construct and simulate a pause_strategy transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Pauses a strategy to prevent it from being used in the vault.
+   *
+   * This function pauses a strategy by setting its `paused` field to `true`. Only the manager or emergency
+   * manager can pause a strategy.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `strategy_address` - The address of the strategy to pause.
+   * * `caller` - The address initiating the pause (must be the manager or emergency manager).
+   *
+   * # Returns
+   * * `Result<(), ContractError>` - Success (()) or ContractError if the pause operation fails
+   */
+  pause_strategy: (
+    { strategy_address, caller }: { strategy_address: string; caller: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<void>>>;
+
+  /**
+   * Construct and simulate a distribute_fees transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Distributes the locked fees for all assets and their strategies.
+   *
+   * This function iterates through each asset and its strategies, calculating the fees to be distributed
+   * to the vault fee receiver and the DeFindex protocol fee receiver based on their respective fee rates.
+   * It ensures proper authorization and validation checks before proceeding with the distribution.
+   *
+   * # Arguments
+   * * `e` - The environment reference.
+   * * `caller` - The address initiating the fee distribution.
+   *
+   * # Returns
+   * * `Result<Vec<(Address, i128)>, ContractError>` - A vector of tuples with asset addresses and the total distributed fee amounts.
+   */
+  distribute_fees: (
+    { caller }: { caller: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Array<readonly [string, i128]>>>>;
+
+  /**
+   * Construct and simulate a get_fee_receiver transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Retrieves the current fee receiver address for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   *
+   * # Returns:
+   * * `Result<Address, ContractError>` - The fee receiver address if successful, otherwise returns a ContractError.
+   */
+  get_fee_receiver: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<string>>>;
+
+  /**
+   * Construct and simulate a set_fee_receiver transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Sets the fee receiver for the vault.
+   *
+   * This function allows the manager or the vault fee receiver to set a new fee receiver address for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `caller` - The address initiating the change (must be the manager or the vault fee receiver).
+   * * `vault_fee_receiver` - The new fee receiver address.
+   *
+   * # Returns:
+   * * `()` - No return value.
+   */
+  set_fee_receiver: (
+    { caller, new_fee_receiver }: { caller: string; new_fee_receiver: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a unpause_strategy transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Unpauses a previously paused strategy.
+   *
+   * This function unpauses a strategy by setting its `paused` field to `false`, allowing it to be used
+   * again in the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `strategy_address` - The address of the strategy to unpause.
+   * * `caller` - The address initiating the unpause (must be the manager or emergency manager).
+   *
+   * # Returns:
+   * * `Result<(), ContractError>` - Ok if successful, otherwise returns a ContractError.
+   */
+  unpause_strategy: (
+    { strategy_address, caller }: { strategy_address: string; caller: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<void>>>;
+
+  /**
+   * Construct and simulate a get_emergency_manager transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Retrieves the current emergency manager address for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   *
+   * # Returns:
+   * * `Result<Address, ContractError>` - The emergency manager address if successful, otherwise returns a ContractError.
+   */
+  get_emergency_manager: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<string>>>;
+
+  /**
+   * Construct and simulate a get_rebalance_manager transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Retrieves the current rebalance manager address for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   *
+   * # Returns:
+   * * `Result<Address, ContractError>` - The rebalance manager address if successful, otherwise returns a ContractError.
+   */
+  get_rebalance_manager: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<Result<string>>>;
+
+  /**
+   * Construct and simulate a set_emergency_manager transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Sets the emergency manager for the vault.
+   *
+   * This function allows the current manager to set a new emergency manager for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `emergency_manager` - The new emergency manager address.
+   *
+   * # Returns:
+   * * `()` - No return value.
+   */
+  set_emergency_manager: (
+    { emergency_manager }: { emergency_manager: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a set_rebalance_manager transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Sets the rebalance manager for the vault.
+   *
+   * This function allows the current manager to set a new rebalance manager for the vault.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   * * `new_rebalance_manager` - The new rebalance manager address.
+   *
+   * # Returns:
+   * * `()` - No return value.
+   */
+  set_rebalance_manager: (
+    { new_rebalance_manager }: { new_rebalance_manager: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a fetch_total_managed_funds transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Returns the total managed funds of the vault, including both invested and idle funds.
+   *
+   * This function provides a vector of `CurrentAssetInvestmentAllocation` structs containing information
+   * about each asset's current allocation, including both invested amounts in strategies and idle amounts.
+   *
+   * # Arguments:
+   * * `e` - The environment.
+   *
+   * # Returns:
+   * * `Result<Vec<CurrentAssetInvestmentAllocation>, ContractError>` - A vector of asset allocations or error
+   */
+  fetch_total_managed_funds: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<
+    AssembledTransaction<Result<Array<CurrentAssetInvestmentAllocation>>>
+  >;
+
+  /**
+   * Construct and simulate a get_asset_amounts_per_shares transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * This function extends the contract's time-to-live and calculates how much of each asset corresponds
+   * per the provided number of vault shares (`vault_shares`). It provides proportional allocations for each asset
+   * in the vault relative to the specified shares.
+   *
+   * # Arguments
+   * * `e` - The current environment reference.
+   * * `vault_shares` - The number of vault shares for which the corresponding asset amounts are calculated.
+   *
+   * # Returns
+   * * `Result<Vec<i128>, ContractError>` - A vector of asset amounts corresponding to the vault shares, where each index
+   * matches the asset index in the vault's asset list. Returns ContractError if calculation fails.
+   */
+  get_asset_amounts_per_shares: (
+    { vault_shares }: { vault_shares: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Array<i128>>>>;
+
+  /**
+   * Construct and simulate a burn transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  burn: (
+    { from, amount }: { from: string; amount: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a name transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  name: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<string>>;
+
+  /**
+   * Construct and simulate a symbol transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  symbol: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<string>>;
+
+  /**
+   * Construct and simulate a approve transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  approve: (
+    {
+      from,
+      spender,
+      amount,
+      expiration_ledger,
+    }: { from: string; spender: string; amount: i128; expiration_ledger: u32 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a balance transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  balance: (
+    { id }: { id: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<i128>>;
+
+  /**
+   * Construct and simulate a decimals transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  decimals: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<u32>>;
+
+  /**
+   * Construct and simulate a transfer transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  transfer: (
+    { from, to, amount }: { from: string; to: string; amount: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a allowance transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  allowance: (
+    { from, spender }: { from: string; spender: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<i128>>;
+
+  /**
+   * Construct and simulate a burn_from transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  burn_from: (
+    { spender, from, amount }: { spender: string; from: string; amount: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a total_supply transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  total_supply: (options?: {
+    /**
+     * The fee to pay for the transaction. Default: BASE_FEE
+     */
+    fee?: number;
+
+    /**
+     * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+     */
+    timeoutInSeconds?: number;
+
+    /**
+     * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+     */
+    simulate?: boolean;
+  }) => Promise<AssembledTransaction<i128>>;
+
+  /**
+   * Construct and simulate a transfer_from transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  transfer_from: (
+    {
+      spender,
+      from,
+      to,
+      amount,
+    }: { spender: string; from: string; to: string; amount: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<null>>;
+
+  /**
+   * Construct and simulate a quote transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Given some amount of an asset and pair reserves, returns an equivalent amount of the other asset.
+   *
+   * # Arguments
+   *
+   * * `amount_a` - The amount of the first asset.
+   * * `reserve_a` - Reserves of the first asset in the pair.
+   * * `reserve_b` - Reserves of the second asset in the pair.
+   *
+   * # Returns
+   *
+   * Returns `Result<i128, SoroswapLibraryError>` where `Ok` contains the calculated equivalent amount, and `Err` indicates an error such as insufficient amount or liquidity
+   */
+  quote: (
+    {
+      amount_a,
+      reserve_a,
+      reserve_b,
+    }: { amount_a: i128; reserve_a: i128; reserve_b: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<i128>>>;
+
+  /**
+   * Construct and simulate a pair_for transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Calculates the deterministic address for a pair without making any external calls.
+   * check <https://github.com/paltalabs/deterministic-address-soroban>
+   *
+   * # Arguments
+   *
+   * * `e` - The environment.
+   * * `factory` - The factory address.
+   * * `token_a` - The address of the first token.
+   * * `token_b` - The address of the second token.
+   *
+   * # Returns
+   *
+   * Returns `Result<Address, SoroswapLibraryError>` where `Ok` contains the deterministic address for the pair, and `Err` indicates an error such as identical tokens or an issue with sorting.
+   */
+  pair_for: (
+    {
+      factory,
+      token_a,
+      token_b,
+    }: { factory: string; token_a: string; token_b: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<string>>>;
+
+  /**
+   * Construct and simulate a sort_tokens transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Sorts two token addresses in a consistent order.
+   *
+   * # Arguments
+   *
+   * * `token_a` - The address of the first token.
+   * * `token_b` - The address of the second token.
+   *
+   * # Returns
+   *
+   * Returns `Result<(Address, Address), SoroswapLibraryError>` where `Ok` contains a tuple with the sorted token addresses, and `Err` indicates an error such as identical tokens.
+   */
+  sort_tokens: (
+    { token_a, token_b }: { token_a: string; token_b: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<readonly [string, string]>>>;
+
+  /**
+   * Construct and simulate a get_amount_in transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Given an output amount of an asset and pair reserves, returns a required input amount of the other asset.
+   *
+   * # Arguments
+   *
+   * * `amount_out` - The output amount of the asset.
+   * * `reserve_in` - Reserves of the input asset in the pair.
+   * * `reserve_out` - Reserves of the output asset in the pair.
+   *
+   * # Returns
+   *
+   * Returns `Result<i128, SoroswapLibraryError>` where `Ok` contains the required input amount, and `Err` indicates an error such as insufficient output amount or liquidity.
+   */
+  get_amount_in: (
+    {
+      amount_out,
+      reserve_in,
+      reserve_out,
+    }: { amount_out: i128; reserve_in: i128; reserve_out: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<i128>>>;
+
+  /**
+   * Construct and simulate a get_amounts_in transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Performs chained get_amount_in calculations on any number of pairs.
+   *
+   * # Arguments
+   *
+   * * `e` - The environment.
+   * * `factory` - The factory address.
+   * * `amount_out` - The output amount.
+   * * `path` - Vector of token addresses representing the path.
+   *
+   * # Returns
+   *
+   * Returns `Result<Vec<i128>, SoroswapLibraryError>` where `Ok` contains a vector of calculated amounts, and `Err` indicates an error such as an invalid path.
+   */
+  get_amounts_in: (
+    {
+      factory,
+      amount_out,
+      path,
+    }: { factory: string; amount_out: i128; path: Array<string> },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Array<i128>>>>;
+
+  /**
+   * Construct and simulate a get_amount_out transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset.
+   *
+   * # Arguments
+   *
+   * * `amount_in` - The input amount of the asset.
+   * * `reserve_in` - Reserves of the input asset in the pair.
+   * * `reserve_out` - Reserves of the output asset in the pair.
+   *
+   * # Returns
+   *
+   * Returns `Result<i128, SoroswapLibraryError>` where `Ok` contains the calculated maximum output amount, and `Err` indicates an error such as insufficient input amount or liquidity.
+   */
+  get_amount_out: (
+    {
+      amount_in,
+      reserve_in,
+      reserve_out,
+    }: { amount_in: i128; reserve_in: i128; reserve_out: i128 },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<i128>>>;
+
+  /**
+   * Construct and simulate a get_amounts_out transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Performs chained get_amount_out calculations on any number of pairs.
+   *
+   * # Arguments
+   *
+   * * `e` - The environment.
+   * * `factory` - The factory address.
+   * * `amount_in` - The input amount.
+   * * `path` - Vector of token addresses representing the path.
+   *
+   * # Returns
+   *
+   * Returns `Result<Vec<i128>, SoroswapLibraryError>` where `Ok` contains a vector of calculated amounts, and `Err` indicates an error such as an invalid path.
+   */
+  get_amounts_out: (
+    {
+      factory,
+      amount_in,
+      path,
+    }: { factory: string; amount_in: i128; path: Array<string> },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<Array<i128>>>>;
+
+  /**
+   * Construct and simulate a get_reserves_with_pair transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Fetches and sorts the reserves for a pair of tokens using the pair address.
+   *
+   * # Arguments
+   *
+   * * `e` - The environment.
+   * * `pair` - The pair address.
+   * * `token_a` - The address of the first token.
+   * * `token_b` - The address of the second token.
+   *
+   * # Returns
+   *
+   * Returns `Result<(i128, i128), SoroswapLibraryError>` where `Ok` contains a tuple of sorted reserves, and `Err` indicates an error such as identical tokens or an issue with sorting.
+   */
+  get_reserves_with_pair: (
+    {
+      pair,
+      token_a,
+      token_b,
+    }: { pair: string; token_a: string; token_b: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<readonly [i128, i128]>>>;
+
+  /**
+   * Construct and simulate a get_reserves_with_factory transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   * Fetches and sorts the reserves for a pair of tokens using the factory address.
+   *
+   * # Arguments
+   *
+   * * `e` - The environment.
+   * * `factory` - The factory address.
+   * * `token_a` - The address of the first token.
+   * * `token_b` - The address of the second token.
+   *
+   * # Returns
+   *
+   * Returns `Result<(i128, i128), SoroswapLibraryError>` where `Ok` contains a tuple of sorted reserves, and `Err` indicates an error such as identical tokens or an issue with sorting.
+   */
+  get_reserves_with_factory: (
+    {
+      factory,
+      token_a,
+      token_b,
+    }: { factory: string; token_a: string; token_b: string },
+    options?: {
+      /**
+       * The fee to pay for the transaction. Default: BASE_FEE
+       */
+      fee?: number;
+
+      /**
+       * The maximum amount of time to wait for the transaction to complete. Default: DEFAULT_TIMEOUT
+       */
+      timeoutInSeconds?: number;
+
+      /**
+       * Whether to automatically simulate the transaction when constructing the AssembledTransaction. Default: true
+       */
+      simulate?: boolean;
+    },
+  ) => Promise<AssembledTransaction<Result<readonly [i128, i128]>>>;
+}
+export class Client extends ContractClient {
+  static override async deploy<T = Client>(
+    /** Constructor/Initialization Args for the contract's `__constructor` method */
+    {
+      assets,
+      roles,
+      vault_fee,
+      defindex_protocol_receiver,
+      defindex_protocol_rate,
+      soroswap_router,
+      name_symbol,
+      upgradable,
+    }: {
+      assets: Array<AssetStrategySet>;
+      roles: Map<u32, string>;
+      vault_fee: u32;
+      defindex_protocol_receiver: string;
+      defindex_protocol_rate: u32;
+      soroswap_router: string;
+      name_symbol: Map<string, string>;
+      upgradable: boolean;
+    },
+    /** Options for initializing a Client as well as for calling a method, with extras specific to deploying. */
+    options: MethodOptions &
+      Omit<ContractClientOptions, "contractId"> & {
+        /** The hash of the Wasm blob, which must already be installed on-chain. */
+        wasmHash: Buffer | string;
+        /** Salt used to generate the contract's ID. Passed through to {@link Operation.createCustomContract}. Default: random. */
+        salt?: Buffer | Uint8Array;
+        /** The format used to decode `wasmHash`, if it's provided as a string. */
+        format?: "hex" | "base64";
+      },
+  ): Promise<AssembledTransaction<T>> {
+    return ContractClient.deploy(
+      {
+        assets,
+        roles,
+        vault_fee,
+        defindex_protocol_receiver,
+        defindex_protocol_rate,
+        soroswap_router,
+        name_symbol,
+        upgradable,
+      },
+      options,
+    );
+  }
+  constructor(public override readonly options: ContractClientOptions) {
+    super(
+      new ContractSpec([
+        "AAAAAAAAA/pHZW5lcmF0ZXMgcmVwb3J0cyBmb3IgYWxsIHN0cmF0ZWdpZXMgaW4gdGhlIHZhdWx0LCB0cmFja2luZyB0aGVpciBwZXJmb3JtYW5jZSBhbmQgZmVlIGFjY3J1YWwuCgpUaGlzIGZ1bmN0aW9uIGl0ZXJhdGVzIHRocm91Z2ggYWxsIGFzc2V0cyBhbmQgdGhlaXIgYXNzb2NpYXRlZCBzdHJhdGVnaWVzIHRvIGdlbmVyYXRlCnBlcmZvcm1hbmNlIHJlcG9ydHMuIEl0IHVwZGF0ZXMgZWFjaCBzdHJhdGVneSdzIHJlcG9ydCB3aXRoIGN1cnJlbnQgYmFsYW5jZXMgYW5kCmNhbGN1bGF0ZXMgZ2FpbnMgb3IgbG9zc2VzIHNpbmNlIHRoZSBsYXN0IHJlcG9ydC4KCiMgQXJndW1lbnRzCiogYGVgIC0gVGhlIGVudmlyb25tZW50IHJlZmVyZW5jZS4KCiMgRnVuY3Rpb24gRmxvdwoxLiAqKkluc3RhbmNlIEV4dGVuc2lvbioqOgotIEV4dGVuZHMgY29udHJhY3QgVFRMCgoyLiAqKkFzc2V0ICYgU3RyYXRlZ3kgUmV0cmlldmFsKio6Ci0gR2V0cyBhbGwgYXNzZXRzIGFuZCB0aGVpciBzdHJhdGVnaWVzCi0gSW5pdGlhbGl6ZXMgcmVwb3J0cyB2ZWN0b3IKCjMuICoqUmVwb3J0IEdlbmVyYXRpb24qKjoKLSBGb3IgZWFjaCBhc3NldDoKLSBGb3IgZWFjaCBzdHJhdGVneToKLSBHZXRzIGN1cnJlbnQgc3RyYXRlZ3kgYmFsYW5jZQotIFVwZGF0ZXMgcmVwb3J0IHdpdGggbmV3IGJhbGFuY2UKLSBTdG9yZXMgdXBkYXRlZCByZXBvcnQKCiMgUmV0dXJucwoqIGBSZXN1bHQ8VmVjPFJlcG9ydD4sIENvbnRyYWN0RXJyb3I+YCAtIE9uIHN1Y2Nlc3MsIHJldHVybnMgYSB2ZWN0b3Igb2YgcmVwb3J0cwp3aGVyZSBlYWNoIHJlcG9ydCBjb250YWlucyBwZXJmb3JtYW5jZSBtZXRyaWNzIGZvciBhIHN0cmF0ZWd5LiBSZXR1cm5zCkNvbnRyYWN0RXJyb3IgaWYgcmVwb3J0IGdlbmVyYXRpb24gZmFpbHMuCgojIE5vdGUKUmVwb3J0cyB0cmFjazoKLSBDdXJyZW50IHN0cmF0ZWd5IGJhbGFuY2UKLSBHYWlucyBvciBsb3NzZXMgc2luY2UgbGFzdCByZXBvcnQKLSBMb2NrZWQgZmVlcwotIEZlZSBkaXN0cmlidXRpb24gc3RhdHVzAAAAAAAGcmVwb3J0AAAAAAAAAAAAAQAAA+kAAAPqAAAH0AAAAAZSZXBvcnQAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
+        "AAAAAAAAAmBFeGVjdXRlcyByZXNjdWUgKGZvcm1lcmx5IGVtZXJnZW5jeSB3aXRoZHJhd2FsKSBmcm9tIGEgc3BlY2lmaWMgc3RyYXRlZ3kuCgpUaGlzIGZ1bmN0aW9uIGFsbG93cyB0aGUgZW1lcmdlbmN5IG1hbmFnZXIgb3IgbWFuYWdlciB0byB3aXRoZHJhdyBhbGwgYXNzZXRzIGZyb20gYSBwYXJ0aWN1bGFyIHN0cmF0ZWd5CmFuZCBzdG9yZSB0aGVtIGFzIGlkbGUgZnVuZHMgd2l0aGluIHRoZSB2YXVsdC4gSXQgYWxzbyBwYXVzZXMgdGhlIHN0cmF0ZWd5IHRvIHByZXZlbnQgZnVydGhlciB1c2UgdW50aWwKdW5wYXVzZWQuCgojIEFyZ3VtZW50czoKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQuCiogYHN0cmF0ZWd5X2FkZHJlc3NgIC0gVGhlIGFkZHJlc3Mgb2YgdGhlIHN0cmF0ZWd5IHRvIHdpdGhkcmF3IGZyb20uCiogYGNhbGxlcmAgLSBUaGUgYWRkcmVzcyBpbml0aWF0aW5nIHRoZSBlbWVyZ2VuY3kgd2l0aGRyYXdhbCAobXVzdCBiZSB0aGUgbWFuYWdlciBvciBlbWVyZ2VuY3kgbWFuYWdlcikuCgojIFJldHVybnMKKiBgUmVzdWx0PCgpLCBDb250cmFjdEVycm9yPmAgLSBTdWNjZXNzICgoKSkgb3IgQ29udHJhY3RFcnJvciBpZiB0aGUgcmVzY3VlIG9wZXJhdGlvbiBmYWlscwAAAAZyZXNjdWUAAAAAAAIAAAAAAAAAEHN0cmF0ZWd5X2FkZHJlc3MAAAATAAAAAAAAAAZjYWxsZXIAAAAAABMAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAABABIYW5kbGVzIHVzZXIgZGVwb3NpdHMgaW50byB0aGUgRGVGaW5kZXggVmF1bHQgYW5kIG9wdGlvbmFsbHkgYWxsb2NhdGVzIGludmVzdG1lbnRzIGF1dG9tYXRpY2FsbHkuCgpUaGlzIGZ1bmN0aW9uIHByb2Nlc3NlcyBhIGRlcG9zaXQgYnkgdHJhbnNmZXJyaW5nIGVhY2ggc3BlY2lmaWVkIGFzc2V0IGFtb3VudCBmcm9tIHRoZSB1c2VyJ3MgYWRkcmVzcyB0bwp0aGUgdmF1bHQgYW5kIG1pbnRzIHZhdWx0IHNoYXJlcyB0aGF0IHJlcHJlc2VudCB0aGUgdXNlcidzIHByb3BvcnRpb25hbCBzaGFyZSBpbiB0aGUgdmF1bHQuIEFkZGl0aW9uYWxseSwKaWYgdGhlIGBpbnZlc3RgIHBhcmFtZXRlciBpcyBzZXQgdG8gYHRydWVgLCB0aGUgZnVuY3Rpb24gd2lsbCBpbW1lZGlhdGVseSBnZW5lcmF0ZSBhbmQgZXhlY3V0ZSBpbnZlc3RtZW50CmFsbG9jYXRpb25zIGJhc2VkIG9uIHRoZSB2YXVsdCdzIHN0cmF0ZWd5IGNvbmZpZ3VyYXRpb24uCgojIFBhcmFtZXRlcnMKKiBgZWAgLSBUaGUgY3VycmVudCBlbnZpcm9ubWVudCByZWZlcmVuY2UgKGBFbnZgKSwgZm9yIGFjY2VzcyB0byB0aGUgY29udHJhY3Qgc3RhdGUgYW5kIHV0aWxpdGllcy4KKiBgYW1vdW50c19kZXNpcmVkYCAtIEEgdmVjdG9yIHNwZWNpZnlpbmcgdGhlIHVzZXIncyBpbnRlbmRlZCBkZXBvc2l0IGFtb3VudHMgZm9yIGVhY2ggYXNzZXQuCiogYGFtb3VudHNfbWluYCAtIEEgdmVjdG9yIG9mIG1pbmltdW0gZGVwb3NpdCBhbW91bnRzIHJlcXVpcmVkIGZvciB0aGUgdHJhbnNhY3Rpb24gdG8gcHJvY2VlZC4KKiBgZnJvbWAgLSBUaGUgYWRkcmVzcyBvZiB0aGUgdXNlciBtYWtpbmcgdGhlIGRlcG9zaXQuCiogYGludmVzdGAgLSBBIGJvb2xlYW4gZmxhZyBpbmRpY2F0aW5nIHdoZXRoZXIgdG8gaW1tZWRpYXRlbHkgaW52ZXN0IHRoZSBkZXBvc2l0ZWQgZnVuZHMgaW50byB0aGUgdmF1bHQncyBzdHJhdGVnaWVzOgotIGB0cnVlYDogR2VuZXJhdGUgYW5kIGV4ZWN1dGUgaW52ZXN0bWVudHMgYWZ0ZXIgdGhlIGRlcG9zaXQuCi0gYGZhbHNlYDogTGVhAAAAB2RlcG9zaXQAAAAABAAAAAAAAAAPYW1vdW50c19kZXNpcmVkAAAAA+oAAAALAAAAAAAAAAthbW91bnRzX21pbgAAAAPqAAAACwAAAAAAAAAEZnJvbQAAABMAAAAAAAAABmludmVzdAAAAAAAAQAAAAEAAAPpAAAD7QAAAAMAAAPqAAAACwAAAAsAAAPoAAAD6gAAA+gAAAfQAAAAGUFzc2V0SW52ZXN0bWVudEFsbG9jYXRpb24AAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAAXJVcGdyYWRlcyB0aGUgY29udHJhY3Qgd2l0aCBuZXcgV2ViQXNzZW1ibHkgKFdBU00pIGNvZGUuCgpUaGlzIGZ1bmN0aW9uIHVwZGF0ZXMgdGhlIGNvbnRyYWN0IHdpdGggbmV3IFdBU00gY29kZSBwcm92aWRlZCBieSB0aGUgYG5ld193YXNtX2hhc2hgLgoKIyBBcmd1bWVudHMKCiogYGVgIC0gVGhlIHJ1bnRpbWUgZW52aXJvbm1lbnQuCiogYG5ld193YXNtX2hhc2hgIC0gVGhlIGhhc2ggb2YgdGhlIG5ldyBXQVNNIGNvZGUgdG8gdXBncmFkZSB0aGUgY29udHJhY3QgdG8uCgojIFJldHVybnMKKiBgUmVzdWx0PCgpLCBDb250cmFjdEVycm9yPmAgLSBSZXR1cm5zIE9rKCgpKSBvbiBzdWNjZXNzLCBDb250cmFjdEVycm9yIGlmIHVwZ3JhZGUgZmFpbHMKAAAAAAAHdXBncmFkZQAAAAABAAAAAAAAAA1uZXdfd2FzbV9oYXNoAAAAAAAD7gAAACAAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAAWpSZXRyaWV2ZXMgdGhlIGN1cnJlbnQgZmVlIHJhdGVzIGZvciB0aGUgdmF1bHQgYW5kIHRoZSBEZUZpbmRleCBwcm90b2NvbC4KClRoaXMgZnVuY3Rpb24gcmV0dXJucyB0aGUgZmVlIHJhdGVzIGZvciBib3RoIHRoZSB2YXVsdCBhbmQgdGhlIERlRmluZGV4IHByb3RvY29sLgoKIyBBcmd1bWVudHMKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQuCgojIFJldHVybnMKKiBgKHUzMiwgdTMyKWAgLSBBIHR1cGxlIGNvbnRhaW5pbmc6Ci0gVGhlIHZhdWx0IGZlZSByYXRlIGFzIGEgcGVyY2VudGFnZSBpbiBiYXNpcyBwb2ludHMuCi0gVGhlIERlRmluZGV4IHByb3RvY29sIGZlZSByYXRlIGFzIGEgcGVyY2VudGFnZSBpbiBiYXNpcyBwb2ludHMuCgAAAAAACGdldF9mZWVzAAAAAAAAAAEAAAPtAAAAAgAAAAQAAAAE",
+        "AAAAAAAABABIYW5kbGVzIHVzZXIgd2l0aGRyYXdhbHMgZnJvbSB0aGUgRGVGaW5kZXggVmF1bHQgYnkgYnVybmluZyBzaGFyZXMgYW5kIHJldHVybmluZyBhc3NldHMuCgpUaGlzIGZ1bmN0aW9uIHByb2Nlc3NlcyBhIHdpdGhkcmF3YWwgcmVxdWVzdCBieSBidXJuaW5nIHRoZSBzcGVjaWZpZWQgYW1vdW50IG9mIHZhdWx0IHNoYXJlcwphbmQgcmV0dXJuaW5nIGEgcHJvcG9ydGlvbmFsIGFtb3VudCBvZiB0aGUgdmF1bHQncyBhc3NldHMgdG8gdGhlIHVzZXIuIEl0IGNhbiB1bndpbmQgcG9zaXRpb25zCmZyb20gc3RyYXRlZ2llcyBpZiBuZWNlc3NhcnkgdG8gZnVsZmlsbCB0aGUgd2l0aGRyYXdhbC4KCiMjIFBhcmFtZXRlcnM6Ci0gYGVgOiBUaGUgY29udHJhY3QgZW52aXJvbm1lbnQgKGBFbnZgKS4KLSBgd2l0aGRyYXdfc2hhcmVzYDogVGhlIG51bWJlciBvZiB2YXVsdCBzaGFyZXMgdG8gd2l0aGRyYXcuCi0gYG1pbl9hbW91bnRzX291dGA6IEEgdmVjdG9yIG9mIG1pbmltdW0gYW1vdW50cyByZXF1aXJlZCBmb3IgZWFjaCBhc3NldCB0byBiZSB3aXRoZHJhd24uCi0gYGZyb21gOiBUaGUgYWRkcmVzcyBpbml0aWF0aW5nIHRoZSB3aXRoZHJhd2FsLgoKIyMgUmV0dXJucwoqIGBSZXN1bHQ8VmVjPGkxMjg+LCBDb250cmFjdEVycm9yPmAgLSBPbiBzdWNjZXNzLCByZXR1cm5zIGEgdmVjdG9yIG9mIHdpdGhkcmF3biBhbW91bnRzCndoZXJlIGVhY2ggaW5kZXggY29ycmVzcG9uZHMgdG8gdGhlIGFzc2V0IGluZGV4IGluIHRoZSB2YXVsdCdzIGFzc2V0IGxpc3QuClJldHVybnMgQ29udHJhY3RFcnJvciBpZiB0aGUgd2l0aGRyYXdhbCBmYWlscy4KCiMjIEVycm9yczoKLSBgQ29udHJhY3RFcnJvcjo6QW1vdW50T3ZlclRvdGFsU3VwcGx5YDogSWYgdGhlIHNwZWNpZmllZCBzaGFyZXMgZXhjZWVkIHRoZSB0b3RhbCBzdXBwbHkuCi0gYENvbnRyYWN0RXJyb3I6OkFyaXRobWV0aWNFcnJvcmA6IElmIGFueSBhcml0aG1ldGljIG9wZXJhdGlvbiBmYWlscyBkdXJpbmcgY2FsY3VsYXRpb25zLgotIGBDb250cmFjdEVycm9yAAAACHdpdGhkcmF3AAAAAwAAAAAAAAAPd2l0aGRyYXdfc2hhcmVzAAAAAAsAAAAAAAAAD21pbl9hbW91bnRzX291dAAAAAPqAAAACwAAAAAAAAAEZnJvbQAAABMAAAABAAAD6QAAA+oAAAALAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAAa1Mb2NrcyBmZWVzIGZvciBhbGwgYXNzZXRzIGFuZCB0aGVpciBzdHJhdGVnaWVzLgoKSXRlcmF0ZXMgdGhyb3VnaCBlYWNoIGFzc2V0IGFuZCBpdHMgc3RyYXRlZ2llcywgbG9ja2luZyBmZWVzIGJhc2VkIG9uIGBuZXdfZmVlX2Jwc2Agb3IgdGhlIGRlZmF1bHQgdmF1bHQgZmVlLgoKIyBBcmd1bWVudHMKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQgcmVmZXJlbmNlLgoqIGBuZXdfZmVlX2Jwc2AgLSBPcHRpb25hbCBmZWUgYmFzaXMgcG9pbnRzIHRvIG92ZXJyaWRlIHRoZSBkZWZhdWx0LgoKIyBSZXR1cm5zCiogYFJlc3VsdDxWZWM8KEFkZHJlc3MsIGkxMjgpPiwgQ29udHJhY3RFcnJvcj5gIC0gQSB2ZWN0b3Igb2YgdHVwbGVzIHdpdGggc3RyYXRlZ3kgYWRkcmVzc2VzIGFuZCBsb2NrZWQgZmVlIGFtb3VudHMgaW4gdGhlaXIgdW5kZXJseWluZ19hc3NldC4AAAAAAAAJbG9ja19mZWVzAAAAAAAAAQAAAAAAAAALbmV3X2ZlZV9icHMAAAAD6AAAAAQAAAABAAAD6QAAA+oAAAfQAAAABlJlcG9ydAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAATtSZWJhbGFuY2VzIHRoZSB2YXVsdCBieSBleGVjdXRpbmcgYSBzZXJpZXMgb2YgaW5zdHJ1Y3Rpb25zLgoKIyBBcmd1bWVudHM6CiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoqIGBpbnN0cnVjdGlvbnNgIC0gQSB2ZWN0b3Igb2YgYEluc3RydWN0aW9uYCBzdHJ1Y3RzIHJlcHJlc2VudGluZyBhY3Rpb25zICh3aXRoZHJhdywgaW52ZXN0LCBzd2FwLCB6YXBwZXIpIHRvIGJlIHRha2VuLgoKIyBSZXR1cm5zOgoqIGBSZXN1bHQ8KCksIENvbnRyYWN0RXJyb3I+YCAtIE9rIGlmIHN1Y2Nlc3NmdWwsIG90aGVyd2lzZSByZXR1cm5zIGEgQ29udHJhY3RFcnJvci4AAAAACXJlYmFsYW5jZQAAAAAAAAIAAAAAAAAABmNhbGxlcgAAAAAAEwAAAAAAAAAMaW5zdHJ1Y3Rpb25zAAAD6gAAB9AAAAALSW5zdHJ1Y3Rpb24AAAAAAQAAA+kAAAPtAAAAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
+        "AAAAAAAAAN9SZXRyaWV2ZXMgdGhlIGxpc3Qgb2YgYXNzZXRzIG1hbmFnZWQgYnkgdGhlIERlRmluZGV4IFZhdWx0LgoKIyBBcmd1bWVudHM6CiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoKIyBSZXR1cm5zOgoqIGBWZWM8QXNzZXRTdHJhdGVneVNldD5gIC0gQSB2ZWN0b3Igb2YgYEFzc2V0U3RyYXRlZ3lTZXRgIHN0cnVjdHMgcmVwcmVzZW50aW5nIHRoZSBhc3NldHMgbWFuYWdlZCBieSB0aGUgdmF1bHQuAAAAAApnZXRfYXNzZXRzAAAAAAAAAAAAAQAAA+kAAAPqAAAH0AAAABBBc3NldFN0cmF0ZWd5U2V0AAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAANJSZXRyaWV2ZXMgdGhlIGN1cnJlbnQgbWFuYWdlciBhZGRyZXNzIGZvciB0aGUgdmF1bHQuCgojIEFyZ3VtZW50czoKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQuCgojIFJldHVybnM6CiogYFJlc3VsdDxBZGRyZXNzLCBDb250cmFjdEVycm9yPmAgLSBUaGUgbWFuYWdlciBhZGRyZXNzIGlmIHN1Y2Nlc3NmdWwsIG90aGVyd2lzZSByZXR1cm5zIGEgQ29udHJhY3RFcnJvci4AAAAAAAtnZXRfbWFuYWdlcgAAAAAAAAAAAQAAA+kAAAATAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAASRTZXRzIHRoZSBtYW5hZ2VyIGZvciB0aGUgdmF1bHQuCgpUaGlzIGZ1bmN0aW9uIGFsbG93cyB0aGUgY3VycmVudCBtYW5hZ2VyIHRvIHNldCBhIG5ldyBtYW5hZ2VyIGZvciB0aGUgdmF1bHQuCgojIEFyZ3VtZW50czoKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQuCiogYG5ld19tYW5hZ2VyYCAtIFRoZSBuZXcgbWFuYWdlciBhZGRyZXNzLgoKIyBSZXR1cm5zCiogYFJlc3VsdDwoKSwgQ29udHJhY3RFcnJvcj5gIC0gU3VjY2VzcyAoKCkpIG9yIENvbnRyYWN0RXJyb3IgaWYgdGhlIG1hbmFnZXIgY2hhbmdlIGZhaWxzAAAAC3NldF9tYW5hZ2VyAAAAAAEAAAAAAAAAC25ld19tYW5hZ2VyAAAAABMAAAABAAAD6QAAA+0AAAAAAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAAUlSZWxlYXNlcyBsb2NrZWQgZmVlcyBmb3IgYSBzcGVjaWZpYyBzdHJhdGVneS4KCiMgQXJndW1lbnRzCiogYGVgIC0gVGhlIGVudmlyb25tZW50IHJlZmVyZW5jZS4KKiBgc3RyYXRlZ3lgIC0gVGhlIGFkZHJlc3Mgb2YgdGhlIHN0cmF0ZWd5IGZvciB3aGljaCB0byByZWxlYXNlIGZlZXMuCiogYGFtb3VudGAgLSBUaGUgYW1vdW50IG9mIGZlZXMgdG8gcmVsZWFzZS4KCiMgUmV0dXJucwoqIGBSZXN1bHQ8UmVwb3J0LCBDb250cmFjdEVycm9yPmAgLSBBIHJlcG9ydCBvZiB0aGUgcmVsZWFzZWQgZmVlcyBvciBhIGBDb250cmFjdEVycm9yYCBpZiB0aGUgb3BlcmF0aW9uIGZhaWxzLgAAAAAAAAxyZWxlYXNlX2ZlZXMAAAACAAAAAAAAAAhzdHJhdGVneQAAABMAAAAAAAAABmFtb3VudAAAAAAACwAAAAEAAAPpAAAH0AAAAAZSZXBvcnQAAAAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
+        "AAAAAAAABABJbml0aWFsaXplcyB0aGUgRGVGaW5kZXggVmF1bHQgY29udHJhY3Qgd2l0aCB0aGUgcmVxdWlyZWQgcGFyYW1ldGVycy4KCiMgQXJndW1lbnRzCiogYGVgIC0gVGhlIGVudmlyb25tZW50IHJlZmVyZW5jZS4KKiBgYXNzZXRzYCAtIExpc3Qgb2YgYXNzZXQgYWxsb2NhdGlvbnMgZm9yIHRoZSB2YXVsdCwgaW5jbHVkaW5nIHN0cmF0ZWdpZXMgZm9yIGVhY2ggYXNzZXQuCiogYHJvbGVzYCAtIE1hcCBvZiByb2xlIElEcyB0byBhZGRyZXNzZXMgY29udGFpbmluZzoKLSBFbWVyZ2VuY3kgTWFuYWdlcjogRm9yIGVtZXJnZW5jeSBjb250cm9sCi0gVmF1bHQgRmVlIFJlY2VpdmVyOiBGb3IgcmVjZWl2aW5nIHZhdWx0IGZlZXMKLSBNYW5hZ2VyOiBGb3IgcHJpbWFyeSB2YXVsdCBjb250cm9sCi0gUmViYWxhbmNlIE1hbmFnZXI6IEZvciByZWJhbGFuY2luZyBvcGVyYXRpb25zCiogYHZhdWx0X2ZlZWAgLSBWYXVsdC1zcGVjaWZpYyBmZWUgaW4gYmFzaXMgcG9pbnRzICgwXzIwMDAgZm9yIDAuMjAlKQoqIGBkZWZpbmRleF9wcm90b2NvbF9yZWNlaXZlcmAgLSBBZGRyZXNzIHJlY2VpdmluZyBwcm90b2NvbCBmZWVzCiogYGRlZmluZGV4X3Byb3RvY29sX3JhdGVgIC0gUHJvdG9jb2wgZmVlIHJhdGUgaW4gYmFzaXMgcG9pbnRzICgwLTkwMDAgZm9yIDAtOTAlKQoqIGBzb3Jvc3dhcF9yb3V0ZXJgIC0gU29yb3N3YXAgcm91dGVyIGFkZHJlc3MKKiBgbmFtZV9zeW1ib2xgIC0gTWFwIGNvbnRhaW5pbmc6Ci0gIm5hbWUiOiBWYXVsdCB0b2tlbiBuYW1lCi0gInN5bWJvbCI6IFZhdWx0IHRva2VuIHN5bWJvbAoqIGB1cGdyYWRhYmxlYCAtIEJvb2xlYW4gZmxhZyBmb3IgY29udHJhY3QgdXBncmFkZWFiaWxpdHkKCiMgRnVuY3Rpb24gRmxvdwoxLiAqKlJvbGUgQXNzaWdubWVudCoqOgotIFNldHMgRW1lcmdlbmN5IE1hbmFnZXIKLSBTZXRzIFZhdWx0IEZlZSBSZWNlaXZlcgotIFNldHMgTWFuYWdlcgotIFNldHMgUmViYWxhbmNlIE1hbmFnZXIKCjIuICoqRmVlIENvbmZpZ3VyYXRpb24qKjoKLSBTZXRzIHZhdWx0IGZlAAAADV9fY29uc3RydWN0b3IAAAAAAAAIAAAAAAAAAAZhc3NldHMAAAAAA+oAAAfQAAAAEEFzc2V0U3RyYXRlZ3lTZXQAAAAAAAAABXJvbGVzAAAAAAAD7AAAAAQAAAATAAAAAAAAAAl2YXVsdF9mZWUAAAAAAAAEAAAAAAAAABpkZWZpbmRleF9wcm90b2NvbF9yZWNlaXZlcgAAAAAAEwAAAAAAAAAWZGVmaW5kZXhfcHJvdG9jb2xfcmF0ZQAAAAAABAAAAAAAAAAPc29yb3N3YXBfcm91dGVyAAAAABMAAAAAAAAAC25hbWVfc3ltYm9sAAAAA+wAAAAQAAAAEAAAAAAAAAAKdXBncmFkYWJsZQAAAAAAAQAAAAA=",
+        "AAAAAAAAAedQYXVzZXMgYSBzdHJhdGVneSB0byBwcmV2ZW50IGl0IGZyb20gYmVpbmcgdXNlZCBpbiB0aGUgdmF1bHQuCgpUaGlzIGZ1bmN0aW9uIHBhdXNlcyBhIHN0cmF0ZWd5IGJ5IHNldHRpbmcgaXRzIGBwYXVzZWRgIGZpZWxkIHRvIGB0cnVlYC4gT25seSB0aGUgbWFuYWdlciBvciBlbWVyZ2VuY3kKbWFuYWdlciBjYW4gcGF1c2UgYSBzdHJhdGVneS4KCiMgQXJndW1lbnRzOgoqIGBlYCAtIFRoZSBlbnZpcm9ubWVudC4KKiBgc3RyYXRlZ3lfYWRkcmVzc2AgLSBUaGUgYWRkcmVzcyBvZiB0aGUgc3RyYXRlZ3kgdG8gcGF1c2UuCiogYGNhbGxlcmAgLSBUaGUgYWRkcmVzcyBpbml0aWF0aW5nIHRoZSBwYXVzZSAobXVzdCBiZSB0aGUgbWFuYWdlciBvciBlbWVyZ2VuY3kgbWFuYWdlcikuCgojIFJldHVybnMKKiBgUmVzdWx0PCgpLCBDb250cmFjdEVycm9yPmAgLSBTdWNjZXNzICgoKSkgb3IgQ29udHJhY3RFcnJvciBpZiB0aGUgcGF1c2Ugb3BlcmF0aW9uIGZhaWxzAAAAAA5wYXVzZV9zdHJhdGVneQAAAAAAAgAAAAAAAAAQc3RyYXRlZ3lfYWRkcmVzcwAAABMAAAAAAAAABmNhbGxlcgAAAAAAEwAAAAEAAAPpAAAD7QAAAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAAmFEaXN0cmlidXRlcyB0aGUgbG9ja2VkIGZlZXMgZm9yIGFsbCBhc3NldHMgYW5kIHRoZWlyIHN0cmF0ZWdpZXMuCgpUaGlzIGZ1bmN0aW9uIGl0ZXJhdGVzIHRocm91Z2ggZWFjaCBhc3NldCBhbmQgaXRzIHN0cmF0ZWdpZXMsIGNhbGN1bGF0aW5nIHRoZSBmZWVzIHRvIGJlIGRpc3RyaWJ1dGVkCnRvIHRoZSB2YXVsdCBmZWUgcmVjZWl2ZXIgYW5kIHRoZSBEZUZpbmRleCBwcm90b2NvbCBmZWUgcmVjZWl2ZXIgYmFzZWQgb24gdGhlaXIgcmVzcGVjdGl2ZSBmZWUgcmF0ZXMuCkl0IGVuc3VyZXMgcHJvcGVyIGF1dGhvcml6YXRpb24gYW5kIHZhbGlkYXRpb24gY2hlY2tzIGJlZm9yZSBwcm9jZWVkaW5nIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCiMgQXJndW1lbnRzCiogYGVgIC0gVGhlIGVudmlyb25tZW50IHJlZmVyZW5jZS4KKiBgY2FsbGVyYCAtIFRoZSBhZGRyZXNzIGluaXRpYXRpbmcgdGhlIGZlZSBkaXN0cmlidXRpb24uCgojIFJldHVybnMKKiBgUmVzdWx0PFZlYzwoQWRkcmVzcywgaTEyOCk+LCBDb250cmFjdEVycm9yPmAgLSBBIHZlY3RvciBvZiB0dXBsZXMgd2l0aCBhc3NldCBhZGRyZXNzZXMgYW5kIHRoZSB0b3RhbCBkaXN0cmlidXRlZCBmZWUgYW1vdW50cy4AAAAAAAAPZGlzdHJpYnV0ZV9mZWVzAAAAAAEAAAAAAAAABmNhbGxlcgAAAAAAEwAAAAEAAAPpAAAD6gAAA+0AAAACAAAAEwAAAAsAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAANxSZXRyaWV2ZXMgdGhlIGN1cnJlbnQgZmVlIHJlY2VpdmVyIGFkZHJlc3MgZm9yIHRoZSB2YXVsdC4KCiMgQXJndW1lbnRzOgoqIGBlYCAtIFRoZSBlbnZpcm9ubWVudC4KCiMgUmV0dXJuczoKKiBgUmVzdWx0PEFkZHJlc3MsIENvbnRyYWN0RXJyb3I+YCAtIFRoZSBmZWUgcmVjZWl2ZXIgYWRkcmVzcyBpZiBzdWNjZXNzZnVsLCBvdGhlcndpc2UgcmV0dXJucyBhIENvbnRyYWN0RXJyb3IuAAAAEGdldF9mZWVfcmVjZWl2ZXIAAAAAAAAAAQAAA+kAAAATAAAH0AAAAA1Db250cmFjdEVycm9yAAAA",
+        "AAAAAAAAAXVTZXRzIHRoZSBmZWUgcmVjZWl2ZXIgZm9yIHRoZSB2YXVsdC4KClRoaXMgZnVuY3Rpb24gYWxsb3dzIHRoZSBtYW5hZ2VyIG9yIHRoZSB2YXVsdCBmZWUgcmVjZWl2ZXIgdG8gc2V0IGEgbmV3IGZlZSByZWNlaXZlciBhZGRyZXNzIGZvciB0aGUgdmF1bHQuCgojIEFyZ3VtZW50czoKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQuCiogYGNhbGxlcmAgLSBUaGUgYWRkcmVzcyBpbml0aWF0aW5nIHRoZSBjaGFuZ2UgKG11c3QgYmUgdGhlIG1hbmFnZXIgb3IgdGhlIHZhdWx0IGZlZSByZWNlaXZlcikuCiogYHZhdWx0X2ZlZV9yZWNlaXZlcmAgLSBUaGUgbmV3IGZlZSByZWNlaXZlciBhZGRyZXNzLgoKIyBSZXR1cm5zOgoqIGAoKWAgLSBObyByZXR1cm4gdmFsdWUuAAAAAAAAEHNldF9mZWVfcmVjZWl2ZXIAAAACAAAAAAAAAAZjYWxsZXIAAAAAABMAAAAAAAAAEG5ld19mZWVfcmVjZWl2ZXIAAAATAAAAAA==",
+        "AAAAAAAAAcFVbnBhdXNlcyBhIHByZXZpb3VzbHkgcGF1c2VkIHN0cmF0ZWd5LgoKVGhpcyBmdW5jdGlvbiB1bnBhdXNlcyBhIHN0cmF0ZWd5IGJ5IHNldHRpbmcgaXRzIGBwYXVzZWRgIGZpZWxkIHRvIGBmYWxzZWAsIGFsbG93aW5nIGl0IHRvIGJlIHVzZWQKYWdhaW4gaW4gdGhlIHZhdWx0LgoKIyBBcmd1bWVudHM6CiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoqIGBzdHJhdGVneV9hZGRyZXNzYCAtIFRoZSBhZGRyZXNzIG9mIHRoZSBzdHJhdGVneSB0byB1bnBhdXNlLgoqIGBjYWxsZXJgIC0gVGhlIGFkZHJlc3MgaW5pdGlhdGluZyB0aGUgdW5wYXVzZSAobXVzdCBiZSB0aGUgbWFuYWdlciBvciBlbWVyZ2VuY3kgbWFuYWdlcikuCgojIFJldHVybnM6CiogYFJlc3VsdDwoKSwgQ29udHJhY3RFcnJvcj5gIC0gT2sgaWYgc3VjY2Vzc2Z1bCwgb3RoZXJ3aXNlIHJldHVybnMgYSBDb250cmFjdEVycm9yLgAAAAAAABB1bnBhdXNlX3N0cmF0ZWd5AAAAAgAAAAAAAAAQc3RyYXRlZ3lfYWRkcmVzcwAAABMAAAAAAAAABmNhbGxlcgAAAAAAEwAAAAEAAAPpAAAD7QAAAAAAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAAOZSZXRyaWV2ZXMgdGhlIGN1cnJlbnQgZW1lcmdlbmN5IG1hbmFnZXIgYWRkcmVzcyBmb3IgdGhlIHZhdWx0LgoKIyBBcmd1bWVudHM6CiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoKIyBSZXR1cm5zOgoqIGBSZXN1bHQ8QWRkcmVzcywgQ29udHJhY3RFcnJvcj5gIC0gVGhlIGVtZXJnZW5jeSBtYW5hZ2VyIGFkZHJlc3MgaWYgc3VjY2Vzc2Z1bCwgb3RoZXJ3aXNlIHJldHVybnMgYSBDb250cmFjdEVycm9yLgAAAAAAFWdldF9lbWVyZ2VuY3lfbWFuYWdlcgAAAAAAAAAAAAABAAAD6QAAABMAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAAOZSZXRyaWV2ZXMgdGhlIGN1cnJlbnQgcmViYWxhbmNlIG1hbmFnZXIgYWRkcmVzcyBmb3IgdGhlIHZhdWx0LgoKIyBBcmd1bWVudHM6CiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoKIyBSZXR1cm5zOgoqIGBSZXN1bHQ8QWRkcmVzcywgQ29udHJhY3RFcnJvcj5gIC0gVGhlIHJlYmFsYW5jZSBtYW5hZ2VyIGFkZHJlc3MgaWYgc3VjY2Vzc2Z1bCwgb3RoZXJ3aXNlIHJldHVybnMgYSBDb250cmFjdEVycm9yLgAAAAAAFWdldF9yZWJhbGFuY2VfbWFuYWdlcgAAAAAAAAAAAAABAAAD6QAAABMAAAfQAAAADUNvbnRyYWN0RXJyb3IAAAA=",
+        "AAAAAAAAAQlTZXRzIHRoZSBlbWVyZ2VuY3kgbWFuYWdlciBmb3IgdGhlIHZhdWx0LgoKVGhpcyBmdW5jdGlvbiBhbGxvd3MgdGhlIGN1cnJlbnQgbWFuYWdlciB0byBzZXQgYSBuZXcgZW1lcmdlbmN5IG1hbmFnZXIgZm9yIHRoZSB2YXVsdC4KCiMgQXJndW1lbnRzOgoqIGBlYCAtIFRoZSBlbnZpcm9ubWVudC4KKiBgZW1lcmdlbmN5X21hbmFnZXJgIC0gVGhlIG5ldyBlbWVyZ2VuY3kgbWFuYWdlciBhZGRyZXNzLgoKIyBSZXR1cm5zOgoqIGAoKWAgLSBObyByZXR1cm4gdmFsdWUuAAAAAAAAFXNldF9lbWVyZ2VuY3lfbWFuYWdlcgAAAAAAAAEAAAAAAAAAEWVtZXJnZW5jeV9tYW5hZ2VyAAAAAAAAEwAAAAA=",
+        "AAAAAAAAAQ1TZXRzIHRoZSByZWJhbGFuY2UgbWFuYWdlciBmb3IgdGhlIHZhdWx0LgoKVGhpcyBmdW5jdGlvbiBhbGxvd3MgdGhlIGN1cnJlbnQgbWFuYWdlciB0byBzZXQgYSBuZXcgcmViYWxhbmNlIG1hbmFnZXIgZm9yIHRoZSB2YXVsdC4KCiMgQXJndW1lbnRzOgoqIGBlYCAtIFRoZSBlbnZpcm9ubWVudC4KKiBgbmV3X3JlYmFsYW5jZV9tYW5hZ2VyYCAtIFRoZSBuZXcgcmViYWxhbmNlIG1hbmFnZXIgYWRkcmVzcy4KCiMgUmV0dXJuczoKKiBgKClgIC0gTm8gcmV0dXJuIHZhbHVlLgAAAAAAABVzZXRfcmViYWxhbmNlX21hbmFnZXIAAAAAAAABAAAAAAAAABVuZXdfcmViYWxhbmNlX21hbmFnZXIAAAAAAAATAAAAAA==",
+        "AAAAAAAAAb9SZXR1cm5zIHRoZSB0b3RhbCBtYW5hZ2VkIGZ1bmRzIG9mIHRoZSB2YXVsdCwgaW5jbHVkaW5nIGJvdGggaW52ZXN0ZWQgYW5kIGlkbGUgZnVuZHMuCgpUaGlzIGZ1bmN0aW9uIHByb3ZpZGVzIGEgdmVjdG9yIG9mIGBDdXJyZW50QXNzZXRJbnZlc3RtZW50QWxsb2NhdGlvbmAgc3RydWN0cyBjb250YWluaW5nIGluZm9ybWF0aW9uCmFib3V0IGVhY2ggYXNzZXQncyBjdXJyZW50IGFsbG9jYXRpb24sIGluY2x1ZGluZyBib3RoIGludmVzdGVkIGFtb3VudHMgaW4gc3RyYXRlZ2llcyBhbmQgaWRsZSBhbW91bnRzLgoKIyBBcmd1bWVudHM6CiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoKIyBSZXR1cm5zOgoqIGBSZXN1bHQ8VmVjPEN1cnJlbnRBc3NldEludmVzdG1lbnRBbGxvY2F0aW9uPiwgQ29udHJhY3RFcnJvcj5gIC0gQSB2ZWN0b3Igb2YgYXNzZXQgYWxsb2NhdGlvbnMgb3IgZXJyb3IAAAAAGWZldGNoX3RvdGFsX21hbmFnZWRfZnVuZHMAAAAAAAAAAAAAAQAAA+kAAAPqAAAH0AAAACBDdXJyZW50QXNzZXRJbnZlc3RtZW50QWxsb2NhdGlvbgAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
+        "AAAAAAAAAn9UaGlzIGZ1bmN0aW9uIGV4dGVuZHMgdGhlIGNvbnRyYWN0J3MgdGltZS10by1saXZlIGFuZCBjYWxjdWxhdGVzIGhvdyBtdWNoIG9mIGVhY2ggYXNzZXQgY29ycmVzcG9uZHMKcGVyIHRoZSBwcm92aWRlZCBudW1iZXIgb2YgdmF1bHQgc2hhcmVzIChgdmF1bHRfc2hhcmVzYCkuIEl0IHByb3ZpZGVzIHByb3BvcnRpb25hbCBhbGxvY2F0aW9ucyBmb3IgZWFjaCBhc3NldAppbiB0aGUgdmF1bHQgcmVsYXRpdmUgdG8gdGhlIHNwZWNpZmllZCBzaGFyZXMuCgojIEFyZ3VtZW50cwoqIGBlYCAtIFRoZSBjdXJyZW50IGVudmlyb25tZW50IHJlZmVyZW5jZS4KKiBgdmF1bHRfc2hhcmVzYCAtIFRoZSBudW1iZXIgb2YgdmF1bHQgc2hhcmVzIGZvciB3aGljaCB0aGUgY29ycmVzcG9uZGluZyBhc3NldCBhbW91bnRzIGFyZSBjYWxjdWxhdGVkLgoKIyBSZXR1cm5zCiogYFJlc3VsdDxWZWM8aTEyOD4sIENvbnRyYWN0RXJyb3I+YCAtIEEgdmVjdG9yIG9mIGFzc2V0IGFtb3VudHMgY29ycmVzcG9uZGluZyB0byB0aGUgdmF1bHQgc2hhcmVzLCB3aGVyZSBlYWNoIGluZGV4Cm1hdGNoZXMgdGhlIGFzc2V0IGluZGV4IGluIHRoZSB2YXVsdCdzIGFzc2V0IGxpc3QuIFJldHVybnMgQ29udHJhY3RFcnJvciBpZiBjYWxjdWxhdGlvbiBmYWlscy4AAAAAHGdldF9hc3NldF9hbW91bnRzX3Blcl9zaGFyZXMAAAABAAAAAAAAAAx2YXVsdF9zaGFyZXMAAAALAAAAAQAAA+kAAAPqAAAACwAAB9AAAAANQ29udHJhY3RFcnJvcgAAAA==",
+        "AAAABAAAAAAAAAAAAAAADUNvbnRyYWN0RXJyb3IAAAAAAAAwAAAAAAAAAA5Ob3RJbml0aWFsaXplZAAAAAAAZAAAAAAAAAAMSW52YWxpZFJhdGlvAAAAZQAAAAAAAAAbU3RyYXRlZ3lEb2VzTm90U3VwcG9ydEFzc2V0AAAAAGYAAAAAAAAAEU5vQXNzZXRBbGxvY2F0aW9uAAAAAAAAZwAAAAAAAAAPUm9sZXNJbmNvbXBsZXRlAAAAAGgAAAAAAAAAEk1ldGFkYXRhSW5jb21wbGV0ZQAAAAAAaQAAAAAAAAASTWF4aW11bUZlZUV4Y2VlZGVkAAAAAABqAAAAAAAAAA9EdXBsaWNhdGVkQXNzZXQAAAAAawAAAAAAAAASRHVwbGljYXRlZFN0cmF0ZWd5AAAAAABsAAAAAAAAABBBbW91bnROb3RBbGxvd2VkAAAAbgAAAAAAAAATSW5zdWZmaWNpZW50QmFsYW5jZQAAAABvAAAAAAAAABJXcm9uZ0Ftb3VudHNMZW5ndGgAAAAAAHAAAAAAAAAAD1dyb25nTG9ja2VkRmVlcwAAAABxAAAAAAAAABhJbnN1ZmZpY2llbnRNYW5hZ2VkRnVuZHMAAAByAAAAAAAAABZNaXNzaW5nSW5zdHJ1Y3Rpb25EYXRhAAAAAABzAAAAAAAAABBVbnN1cHBvcnRlZEFzc2V0AAAAdAAAAAAAAAASSW5zdWZmaWNpZW50QW1vdW50AAAAAAB1AAAAAAAAABBOb09wdGltYWxBbW91bnRzAAAAdgAAAAAAAAAVV3JvbmdJbnZlc3RtZW50TGVuZ3RoAAAAAAAAdwAAAAAAAAARV3JvbmdBc3NldEFkZHJlc3MAAAAAAAB6AAAAAAAAABVXcm9uZ1N0cmF0ZWdpZXNMZW5ndGgAAAAAAAB7AAAAAAAAABVBbW91bnRPdmVyVG90YWxTdXBwbHkAAAAAAAB8AAAAAAAAAA5Ob0luc3RydWN0aW9ucwAAAAAAfQAAAAAAAAANTm90VXBncmFkYWJsZQAAAAAAAH4AAAAAAAAAF1Vud2luZE1vcmVUaGFuQXZhaWxhYmxlAAAAAIAAAAAAAAAAGUluc3VmZmljaWVudEZlZXNUb1JlbGVhc2UAAAAAAACBAAAAAAAAAA9Bcml0aG1ldGljRXJyb3IAAAAAeAAAAAAAAAAIT3ZlcmZsb3cAAAB5AAAAAAAAAAlVbmRlcmZsb3cAAAAAAAB/AAAAAAAAAAxVbmF1dGhvcml6ZWQAAACCAAAAAAAAAAxSb2xlTm90Rm91bmQAAACDAAAAAAAAABFNYW5hZ2VyTm90SW5RdWV1ZQAAAAAAAIQAAAAAAAAAFFNldE1hbmFnZXJCZWZvcmVUaW1lAAAAhQAAAAAAAAAKUXVldWVFbXB0eQAAAAAAhgAAAAAAAAAQU3RyYXRlZ3lOb3RGb3VuZAAAAIwAAAAAAAAAGFN0cmF0ZWd5UGF1c2VkT3JOb3RGb3VuZAAAAI0AAAAAAAAAFVN0cmF0ZWd5V2l0aGRyYXdFcnJvcgAAAAAAAI4AAAAAAAAAE1N0cmF0ZWd5SW52ZXN0RXJyb3IAAAAAjwAAAAAAAAAOU3RyYXRlZ3lQYXVzZWQAAAAAAJAAAAAAAAAADUFzc2V0Tm90Rm91bmQAAAAAAACWAAAAAAAAABBOb0Fzc2V0c1Byb3ZpZGVkAAAAlwAAAAAAAAAYSW5zdWZmaWNpZW50T3V0cHV0QW1vdW50AAAAoAAAAAAAAAAURXhjZXNzaXZlSW5wdXRBbW91bnQAAAChAAAAAAAAAA1JbnZhbGlkRmVlQnBzAAAAAAAAogAAAAAAAAAaTGlicmFyeVNvcnRJZGVudGljYWxUb2tlbnMAAAAAAL4AAAAAAAAAE1Nvcm9zd2FwUm91dGVyRXJyb3IAAAAAyAAAAAAAAAAQU3dhcEV4YWN0SW5FcnJvcgAAAMkAAAAAAAAAEVN3YXBFeGFjdE91dEVycm9yAAAAAAAAyg==",
+        "AAAAAgAAAAAAAAAAAAAAB0RhdGFLZXkAAAAAAwAAAAEAAAAAAAAACUFsbG93YW5jZQAAAAAAAAEAAAfQAAAAEEFsbG93YW5jZURhdGFLZXkAAAABAAAAAAAAAAdCYWxhbmNlAAAAAAEAAAATAAAAAAAAAAAAAAALVG90YWxTdXBwbHkA",
+        "AAAAAQAAAAAAAAAAAAAADkFsbG93YW5jZVZhbHVlAAAAAAACAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAAAAAAEWV4cGlyYXRpb25fbGVkZ2VyAAAAAAAABA==",
+        "AAAAAQAAAAAAAAAAAAAAEEFsbG93YW5jZURhdGFLZXkAAAACAAAAAAAAAARmcm9tAAAAEwAAAAAAAAAHc3BlbmRlcgAAAAAT",
+        "AAAAAAAAAAAAAAAEYnVybgAAAAIAAAAAAAAABGZyb20AAAATAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAA",
+        "AAAAAAAAAAAAAAAEbmFtZQAAAAAAAAABAAAAEA==",
+        "AAAAAAAAAAAAAAAGc3ltYm9sAAAAAAAAAAAAAQAAABA=",
+        "AAAAAAAAAAAAAAAHYXBwcm92ZQAAAAAEAAAAAAAAAARmcm9tAAAAEwAAAAAAAAAHc3BlbmRlcgAAAAATAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAAAAAAEWV4cGlyYXRpb25fbGVkZ2VyAAAAAAAABAAAAAA=",
+        "AAAAAAAAAAAAAAAHYmFsYW5jZQAAAAABAAAAAAAAAAJpZAAAAAAAEwAAAAEAAAAL",
+        "AAAAAAAAAAAAAAAIZGVjaW1hbHMAAAAAAAAAAQAAAAQ=",
+        "AAAAAAAAAAAAAAAIdHJhbnNmZXIAAAADAAAAAAAAAARmcm9tAAAAEwAAAAAAAAACdG8AAAAAABMAAAAAAAAABmFtb3VudAAAAAAACwAAAAA=",
+        "AAAAAAAAAAAAAAAJYWxsb3dhbmNlAAAAAAAAAgAAAAAAAAAEZnJvbQAAABMAAAAAAAAAB3NwZW5kZXIAAAAAEwAAAAEAAAAL",
+        "AAAAAAAAAAAAAAAJYnVybl9mcm9tAAAAAAAAAwAAAAAAAAAHc3BlbmRlcgAAAAATAAAAAAAAAARmcm9tAAAAEwAAAAAAAAAGYW1vdW50AAAAAAALAAAAAA==",
+        "AAAAAAAAAAAAAAAMdG90YWxfc3VwcGx5AAAAAAAAAAEAAAAL",
+        "AAAAAAAAAAAAAAANdHJhbnNmZXJfZnJvbQAAAAAAAAQAAAAAAAAAB3NwZW5kZXIAAAAAEwAAAAAAAAAEZnJvbQAAABMAAAAAAAAAAnRvAAAAAAATAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAA",
+        "AAAAAgAAAAAAAAAAAAAADFJvbGVzRGF0YUtleQAAAAQAAAAAAAAAAAAAABBFbWVyZ2VuY3lNYW5hZ2VyAAAAAAAAAAAAAAAQVmF1bHRGZWVSZWNlaXZlcgAAAAAAAAAAAAAAB01hbmFnZXIAAAAAAAAAAAAAAAAQUmViYWxhbmNlTWFuYWdlcg==",
+        "AAAAAQAAAAAAAAAAAAAAC0ludmVzdEV2ZW50AAAAAAMAAAAAAAAAEWFzc2V0X2ludmVzdG1lbnRzAAAAAAAD6gAAB9AAAAAZQXNzZXRJbnZlc3RtZW50QWxsb2NhdGlvbgAAAAAAAAAAAAAQcmViYWxhbmNlX21ldGhvZAAAABEAAAAAAAAABnJlcG9ydAAAAAAH0AAAAAZSZXBvcnQAAA==",
+        "AAAAAQAAAAAAAAAAAAAAC1Vud2luZEV2ZW50AAAAAAMAAAAAAAAAC2NhbGxfcGFyYW1zAAAAA+oAAAPtAAAAAwAAABMAAAALAAAAEwAAAAAAAAAQcmViYWxhbmNlX21ldGhvZAAAABEAAAAAAAAABnJlcG9ydAAAAAAH0AAAAAZSZXBvcnQAAA==",
+        "AAAAAQAAAAAAAAAAAAAAEFN3YXBFeGFjdEluRXZlbnQAAAACAAAAAAAAABByZWJhbGFuY2VfbWV0aG9kAAAAEQAAAAAAAAAJc3dhcF9hcmdzAAAAAAAD6gAAAAA=",
+        "AAAAAQAAAAAAAAAAAAAAEVN3YXBFeGFjdE91dEV2ZW50AAAAAAAAAgAAAAAAAAAQcmViYWxhbmNlX21ldGhvZAAAABEAAAAAAAAACXN3YXBfYXJncwAAAAAAA+oAAAAA",
+        "AAAAAQAAAAAAAAAAAAAAEVZhdWx0RGVwb3NpdEV2ZW50AAAAAAAABQAAAAAAAAAHYW1vdW50cwAAAAPqAAAACwAAAAAAAAAJZGVwb3NpdG9yAAAAAAAAEwAAAAAAAAAQZGZfdG9rZW5zX21pbnRlZAAAAAsAAAAAAAAAGnRvdGFsX21hbmFnZWRfZnVuZHNfYmVmb3JlAAAAAAPqAAAH0AAAACBDdXJyZW50QXNzZXRJbnZlc3RtZW50QWxsb2NhdGlvbgAAAAAAAAATdG90YWxfc3VwcGx5X2JlZm9yZQAAAAAL",
+        "AAAAAQAAAAAAAAAAAAAAElZhdWx0V2l0aGRyYXdFdmVudAAAAAAABQAAAAAAAAARYW1vdW50c193aXRoZHJhd24AAAAAAAPqAAAACwAAAAAAAAAQZGZfdG9rZW5zX2J1cm5lZAAAAAsAAAAAAAAAGnRvdGFsX21hbmFnZWRfZnVuZHNfYmVmb3JlAAAAAAPqAAAH0AAAACBDdXJyZW50QXNzZXRJbnZlc3RtZW50QWxsb2NhdGlvbgAAAAAAAAATdG90YWxfc3VwcGx5X2JlZm9yZQAAAAALAAAAAAAAAAp3aXRoZHJhd2VyAAAAAAAT",
+        "AAAAAQAAAAAAAAAAAAAAE01hbmFnZXJDaGFuZ2VkRXZlbnQAAAAAAQAAAAAAAAALbmV3X21hbmFnZXIAAAAAEw==",
+        "AAAAAQAAAAAAAAAAAAAAE1N0cmF0ZWd5UGF1c2VkRXZlbnQAAAAAAgAAAAAAAAAGY2FsbGVyAAAAAAATAAAAAAAAABBzdHJhdGVneV9hZGRyZXNzAAAAEw==",
+        "AAAAAQAAAAAAAAAAAAAAFEZlZXNEaXN0cmlidXRlZEV2ZW50AAAAAQAAAAAAAAAQZGlzdHJpYnV0ZWRfZmVlcwAAA+oAAAPtAAAAAgAAABMAAAAL",
+        "AAAAAQAAAAAAAAAAAAAAFVN0cmF0ZWd5VW5wYXVzZWRFdmVudAAAAAAAAAIAAAAAAAAABmNhbGxlcgAAAAAAEwAAAAAAAAAQc3RyYXRlZ3lfYWRkcmVzcwAAABM=",
+        "AAAAAQAAAAAAAAAAAAAAFkVtZXJnZW5jeVdpdGhkcmF3RXZlbnQAAAAAAAMAAAAAAAAAEGFtb3VudF93aXRoZHJhd24AAAALAAAAAAAAAAZjYWxsZXIAAAAAABMAAAAAAAAAEHN0cmF0ZWd5X2FkZHJlc3MAAAAT",
+        "AAAAAQAAAAAAAAAAAAAAF0ZlZVJlY2VpdmVyQ2hhbmdlZEV2ZW50AAAAAAIAAAAAAAAABmNhbGxlcgAAAAAAEwAAAAAAAAAQbmV3X2ZlZV9yZWNlaXZlcgAAABM=",
+        "AAAAAQAAAAAAAAAAAAAAHEVtZXJnZW5jeU1hbmFnZXJDaGFuZ2VkRXZlbnQAAAABAAAAAAAAABVuZXdfZW1lcmdlbmN5X21hbmFnZXIAAAAAAAAT",
+        "AAAAAQAAAAAAAAAAAAAAHFJlYmFsYW5jZU1hbmFnZXJDaGFuZ2VkRXZlbnQAAAABAAAAAAAAABVuZXdfcmViYWxhbmNlX21hbmFnZXIAAAAAAAAT",
+        "AAAAAgAAAAAAAAAAAAAAC0luc3RydWN0aW9uAAAAAAQAAAABAAAAH1dpdGhkcmF3IGZ1bmRzIGZyb20gYSBzdHJhdGVneS4AAAAABlVud2luZAAAAAAAAgAAABMAAAALAAAAAQAAAB1JbnZlc3QgZnVuZHMgaW50byBhIHN0cmF0ZWd5LgAAAAAAAAZJbnZlc3QAAAAAAAIAAAATAAAACwAAAAEAAAAqUGVyZm9ybSBhIHN3YXAgd2l0aCBhbiBleGFjdCBpbnB1dCBhbW91bnQuAAAAAAALU3dhcEV4YWN0SW4AAAAABQAAABMAAAATAAAACwAAAAsAAAAGAAAAAQAAACtQZXJmb3JtIGEgc3dhcCB3aXRoIGFuIGV4YWN0IG91dHB1dCBhbW91bnQuAAAAAAxTd2FwRXhhY3RPdXQAAAAFAAAAEwAAABMAAAALAAAACwAAAAY=",
+        "AAAAAQAAAAAAAAAAAAAAElN0cmF0ZWd5QWxsb2NhdGlvbgAAAAAAAwAAAAAAAAAGYW1vdW50AAAAAAALAAAAAAAAAAZwYXVzZWQAAAAAAAEAAAAAAAAAEHN0cmF0ZWd5X2FkZHJlc3MAAAAT",
+        "AAAAAQAAAAAAAAAAAAAAGUFzc2V0SW52ZXN0bWVudEFsbG9jYXRpb24AAAAAAAACAAAAAAAAAAVhc3NldAAAAAAAABMAAAAAAAAAFHN0cmF0ZWd5X2FsbG9jYXRpb25zAAAD6gAAA+gAAAfQAAAAElN0cmF0ZWd5QWxsb2NhdGlvbgAA",
+        "AAAAAQAAAAAAAAAAAAAAIEN1cnJlbnRBc3NldEludmVzdG1lbnRBbGxvY2F0aW9uAAAABQAAAAAAAAAFYXNzZXQAAAAAAAATAAAAAAAAAAtpZGxlX2Ftb3VudAAAAAALAAAAAAAAAA9pbnZlc3RlZF9hbW91bnQAAAAACwAAAAAAAAAUc3RyYXRlZ3lfYWxsb2NhdGlvbnMAAAPqAAAH0AAAABJTdHJhdGVneUFsbG9jYXRpb24AAAAAAAAAAAAMdG90YWxfYW1vdW50AAAACw==",
+        "AAAAAQAAAAAAAAAAAAAABlJlcG9ydAAAAAAAAwAAAAAAAAAPZ2FpbnNfb3JfbG9zc2VzAAAAAAsAAAAAAAAACmxvY2tlZF9mZWUAAAAAAAsAAAAAAAAADHByZXZfYmFsYW5jZQAAAAs=",
+        "AAAAAQAAAAAAAAAAAAAACFN0cmF0ZWd5AAAAAwAAAAAAAAAHYWRkcmVzcwAAAAATAAAAAAAAAARuYW1lAAAAEAAAAAAAAAAGcGF1c2VkAAAAAAAB",
+        "AAAAAQAAAAAAAAAAAAAAEEFzc2V0U3RyYXRlZ3lTZXQAAAACAAAAAAAAAAdhZGRyZXNzAAAAABMAAAAAAAAACnN0cmF0ZWdpZXMAAAAAA+oAAAfQAAAACFN0cmF0ZWd5",
+        "AAAABAAAAAAAAAAAAAAADVN0cmF0ZWd5RXJyb3IAAAAAAAATAAAAAAAAAA5Ob3RJbml0aWFsaXplZAAAAAABkQAAAAAAAAASTmVnYXRpdmVOb3RBbGxvd2VkAAAAAAGaAAAAAAAAAA9JbnZhbGlkQXJndW1lbnQAAAABmwAAAAAAAAATSW5zdWZmaWNpZW50QmFsYW5jZQAAAAGcAAAAAAAAABFVbmRlcmZsb3dPdmVyZmxvdwAAAAAAAZ0AAAAAAAAAD0FyaXRobWV0aWNFcnJvcgAAAAGeAAAAAAAAAA5EaXZpc2lvbkJ5WmVybwAAAAABnwAAAAAAAAATSW52YWxpZFNoYXJlc01pbnRlZAAAAAGgAAAAAAAAABlPbmx5UG9zaXRpdmVBbW91bnRBbGxvd2VkAAAAAAABoQAAAAAAAAANTm90QXV0aG9yaXplZAAAAAAAAaIAAAAAAAAAF1Byb3RvY29sQWRkcmVzc05vdEZvdW5kAAAAAaQAAAAAAAAAD0RlYWRsaW5lRXhwaXJlZAAAAAGlAAAAAAAAAA1FeHRlcm5hbEVycm9yAAAAAAABpgAAAAAAAAARU29yb3N3YXBQYWlyRXJyb3IAAAAAAAGnAAAAAAAAABJBbW91bnRCZWxvd01pbkR1c3QAAAAAAcMAAAAAAAAAGFVuZGVybHlpbmdBbW91bnRCZWxvd01pbgAAAcQAAAAAAAAAFUJUb2tlbnNBbW91bnRCZWxvd01pbgAAAAAAAcUAAAAAAAAAEUludGVybmFsU3dhcEVycm9yAAAAAAABxgAAAAAAAAAOU3VwcGx5Tm90Rm91bmQAAAAAAcc=",
+        "AAAAAQAAAAAAAAAAAAAADERlcG9zaXRFdmVudAAAAAIAAAAAAAAABmFtb3VudAAAAAAACwAAAAAAAAAEZnJvbQAAABM=",
+        "AAAAAQAAAAAAAAAAAAAADEhhcnZlc3RFdmVudAAAAAMAAAAAAAAABmFtb3VudAAAAAAACwAAAAAAAAAEZnJvbQAAABMAAAAAAAAAD3ByaWNlX3Blcl9zaGFyZQAAAAAL",
+        "AAAAAQAAAAAAAAAAAAAADVdpdGhkcmF3RXZlbnQAAAAAAAACAAAAAAAAAAZhbW91bnQAAAAAAAsAAAAAAAAABGZyb20AAAAT",
+        "AAAAAQAAAAAAAAAAAAAADVRva2VuTWV0YWRhdGEAAAAAAAADAAAAAAAAAAdkZWNpbWFsAAAAAAQAAAAAAAAABG5hbWUAAAAQAAAAAAAAAAZzeW1ib2wAAAAAABA=",
+        "AAAAAAAAAcVHaXZlbiBzb21lIGFtb3VudCBvZiBhbiBhc3NldCBhbmQgcGFpciByZXNlcnZlcywgcmV0dXJucyBhbiBlcXVpdmFsZW50IGFtb3VudCBvZiB0aGUgb3RoZXIgYXNzZXQuCgojIEFyZ3VtZW50cwoKKiBgYW1vdW50X2FgIC0gVGhlIGFtb3VudCBvZiB0aGUgZmlyc3QgYXNzZXQuCiogYHJlc2VydmVfYWAgLSBSZXNlcnZlcyBvZiB0aGUgZmlyc3QgYXNzZXQgaW4gdGhlIHBhaXIuCiogYHJlc2VydmVfYmAgLSBSZXNlcnZlcyBvZiB0aGUgc2Vjb25kIGFzc2V0IGluIHRoZSBwYWlyLgoKIyBSZXR1cm5zCgpSZXR1cm5zIGBSZXN1bHQ8aTEyOCwgU29yb3N3YXBMaWJyYXJ5RXJyb3I+YCB3aGVyZSBgT2tgIGNvbnRhaW5zIHRoZSBjYWxjdWxhdGVkIGVxdWl2YWxlbnQgYW1vdW50LCBhbmQgYEVycmAgaW5kaWNhdGVzIGFuIGVycm9yIHN1Y2ggYXMgaW5zdWZmaWNpZW50IGFtb3VudCBvciBsaXF1aWRpdHkAAAAAAAAFcXVvdGUAAAAAAAADAAAAAAAAAAhhbW91bnRfYQAAAAsAAAAAAAAACXJlc2VydmVfYQAAAAAAAAsAAAAAAAAACXJlc2VydmVfYgAAAAAAAAsAAAABAAAD6QAAAAsAAAfQAAAAFFNvcm9zd2FwTGlicmFyeUVycm9y",
+        "AAAAAAAAAgRDYWxjdWxhdGVzIHRoZSBkZXRlcm1pbmlzdGljIGFkZHJlc3MgZm9yIGEgcGFpciB3aXRob3V0IG1ha2luZyBhbnkgZXh0ZXJuYWwgY2FsbHMuCmNoZWNrIDxodHRwczovL2dpdGh1Yi5jb20vcGFsdGFsYWJzL2RldGVybWluaXN0aWMtYWRkcmVzcy1zb3JvYmFuPgoKIyBBcmd1bWVudHMKCiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoqIGBmYWN0b3J5YCAtIFRoZSBmYWN0b3J5IGFkZHJlc3MuCiogYHRva2VuX2FgIC0gVGhlIGFkZHJlc3Mgb2YgdGhlIGZpcnN0IHRva2VuLgoqIGB0b2tlbl9iYCAtIFRoZSBhZGRyZXNzIG9mIHRoZSBzZWNvbmQgdG9rZW4uCgojIFJldHVybnMKClJldHVybnMgYFJlc3VsdDxBZGRyZXNzLCBTb3Jvc3dhcExpYnJhcnlFcnJvcj5gIHdoZXJlIGBPa2AgY29udGFpbnMgdGhlIGRldGVybWluaXN0aWMgYWRkcmVzcyBmb3IgdGhlIHBhaXIsIGFuZCBgRXJyYCBpbmRpY2F0ZXMgYW4gZXJyb3Igc3VjaCBhcyBpZGVudGljYWwgdG9rZW5zIG9yIGFuIGlzc3VlIHdpdGggc29ydGluZy4AAAAIcGFpcl9mb3IAAAADAAAAAAAAAAdmYWN0b3J5AAAAABMAAAAAAAAAB3Rva2VuX2EAAAAAEwAAAAAAAAAHdG9rZW5fYgAAAAATAAAAAQAAA+kAAAATAAAH0AAAABRTb3Jvc3dhcExpYnJhcnlFcnJvcg==",
+        "AAAAAAAAAVZTb3J0cyB0d28gdG9rZW4gYWRkcmVzc2VzIGluIGEgY29uc2lzdGVudCBvcmRlci4KCiMgQXJndW1lbnRzCgoqIGB0b2tlbl9hYCAtIFRoZSBhZGRyZXNzIG9mIHRoZSBmaXJzdCB0b2tlbi4KKiBgdG9rZW5fYmAgLSBUaGUgYWRkcmVzcyBvZiB0aGUgc2Vjb25kIHRva2VuLgoKIyBSZXR1cm5zCgpSZXR1cm5zIGBSZXN1bHQ8KEFkZHJlc3MsIEFkZHJlc3MpLCBTb3Jvc3dhcExpYnJhcnlFcnJvcj5gIHdoZXJlIGBPa2AgY29udGFpbnMgYSB0dXBsZSB3aXRoIHRoZSBzb3J0ZWQgdG9rZW4gYWRkcmVzc2VzLCBhbmQgYEVycmAgaW5kaWNhdGVzIGFuIGVycm9yIHN1Y2ggYXMgaWRlbnRpY2FsIHRva2Vucy4AAAAAAAtzb3J0X3Rva2VucwAAAAACAAAAAAAAAAd0b2tlbl9hAAAAABMAAAAAAAAAB3Rva2VuX2IAAAAAEwAAAAEAAAPpAAAD7QAAAAIAAAATAAAAEwAAB9AAAAAUU29yb3N3YXBMaWJyYXJ5RXJyb3I=",
+        "AAAAAAAAAdRHaXZlbiBhbiBvdXRwdXQgYW1vdW50IG9mIGFuIGFzc2V0IGFuZCBwYWlyIHJlc2VydmVzLCByZXR1cm5zIGEgcmVxdWlyZWQgaW5wdXQgYW1vdW50IG9mIHRoZSBvdGhlciBhc3NldC4KCiMgQXJndW1lbnRzCgoqIGBhbW91bnRfb3V0YCAtIFRoZSBvdXRwdXQgYW1vdW50IG9mIHRoZSBhc3NldC4KKiBgcmVzZXJ2ZV9pbmAgLSBSZXNlcnZlcyBvZiB0aGUgaW5wdXQgYXNzZXQgaW4gdGhlIHBhaXIuCiogYHJlc2VydmVfb3V0YCAtIFJlc2VydmVzIG9mIHRoZSBvdXRwdXQgYXNzZXQgaW4gdGhlIHBhaXIuCgojIFJldHVybnMKClJldHVybnMgYFJlc3VsdDxpMTI4LCBTb3Jvc3dhcExpYnJhcnlFcnJvcj5gIHdoZXJlIGBPa2AgY29udGFpbnMgdGhlIHJlcXVpcmVkIGlucHV0IGFtb3VudCwgYW5kIGBFcnJgIGluZGljYXRlcyBhbiBlcnJvciBzdWNoIGFzIGluc3VmZmljaWVudCBvdXRwdXQgYW1vdW50IG9yIGxpcXVpZGl0eS4AAAANZ2V0X2Ftb3VudF9pbgAAAAAAAAMAAAAAAAAACmFtb3VudF9vdXQAAAAAAAsAAAAAAAAACnJlc2VydmVfaW4AAAAAAAsAAAAAAAAAC3Jlc2VydmVfb3V0AAAAAAsAAAABAAAD6QAAAAsAAAfQAAAAFFNvcm9zd2FwTGlicmFyeUVycm9y",
+        "AAAAAAAAAZVQZXJmb3JtcyBjaGFpbmVkIGdldF9hbW91bnRfaW4gY2FsY3VsYXRpb25zIG9uIGFueSBudW1iZXIgb2YgcGFpcnMuCgojIEFyZ3VtZW50cwoKKiBgZWAgLSBUaGUgZW52aXJvbm1lbnQuCiogYGZhY3RvcnlgIC0gVGhlIGZhY3RvcnkgYWRkcmVzcy4KKiBgYW1vdW50X291dGAgLSBUaGUgb3V0cHV0IGFtb3VudC4KKiBgcGF0aGAgLSBWZWN0b3Igb2YgdG9rZW4gYWRkcmVzc2VzIHJlcHJlc2VudGluZyB0aGUgcGF0aC4KCiMgUmV0dXJucwoKUmV0dXJucyBgUmVzdWx0PFZlYzxpMTI4PiwgU29yb3N3YXBMaWJyYXJ5RXJyb3I+YCB3aGVyZSBgT2tgIGNvbnRhaW5zIGEgdmVjdG9yIG9mIGNhbGN1bGF0ZWQgYW1vdW50cywgYW5kIGBFcnJgIGluZGljYXRlcyBhbiBlcnJvciBzdWNoIGFzIGFuIGludmFsaWQgcGF0aC4AAAAAAAAOZ2V0X2Ftb3VudHNfaW4AAAAAAAMAAAAAAAAAB2ZhY3RvcnkAAAAAEwAAAAAAAAAKYW1vdW50X291dAAAAAAACwAAAAAAAAAEcGF0aAAAA+oAAAATAAAAAQAAA+kAAAPqAAAACwAAB9AAAAAUU29yb3N3YXBMaWJyYXJ5RXJyb3I=",
+        "AAAAAAAAAd1HaXZlbiBhbiBpbnB1dCBhbW91bnQgb2YgYW4gYXNzZXQgYW5kIHBhaXIgcmVzZXJ2ZXMsIHJldHVybnMgdGhlIG1heGltdW0gb3V0cHV0IGFtb3VudCBvZiB0aGUgb3RoZXIgYXNzZXQuCgojIEFyZ3VtZW50cwoKKiBgYW1vdW50X2luYCAtIFRoZSBpbnB1dCBhbW91bnQgb2YgdGhlIGFzc2V0LgoqIGByZXNlcnZlX2luYCAtIFJlc2VydmVzIG9mIHRoZSBpbnB1dCBhc3NldCBpbiB0aGUgcGFpci4KKiBgcmVzZXJ2ZV9vdXRgIC0gUmVzZXJ2ZXMgb2YgdGhlIG91dHB1dCBhc3NldCBpbiB0aGUgcGFpci4KCiMgUmV0dXJucwoKUmV0dXJucyBgUmVzdWx0PGkxMjgsIFNvcm9zd2FwTGlicmFyeUVycm9yPmAgd2hlcmUgYE9rYCBjb250YWlucyB0aGUgY2FsY3VsYXRlZCBtYXhpbXVtIG91dHB1dCBhbW91bnQsIGFuZCBgRXJyYCBpbmRpY2F0ZXMgYW4gZXJyb3Igc3VjaCBhcyBpbnN1ZmZpY2llbnQgaW5wdXQgYW1vdW50IG9yIGxpcXVpZGl0eS4AAAAAAAAOZ2V0X2Ftb3VudF9vdXQAAAAAAAMAAAAAAAAACWFtb3VudF9pbgAAAAAAAAsAAAAAAAAACnJlc2VydmVfaW4AAAAAAAsAAAAAAAAAC3Jlc2VydmVfb3V0AAAAAAsAAAABAAAD6QAAAAsAAAfQAAAAFFNvcm9zd2FwTGlicmFyeUVycm9y",
+        "AAAAAAAAAZRQZXJmb3JtcyBjaGFpbmVkIGdldF9hbW91bnRfb3V0IGNhbGN1bGF0aW9ucyBvbiBhbnkgbnVtYmVyIG9mIHBhaXJzLgoKIyBBcmd1bWVudHMKCiogYGVgIC0gVGhlIGVudmlyb25tZW50LgoqIGBmYWN0b3J5YCAtIFRoZSBmYWN0b3J5IGFkZHJlc3MuCiogYGFtb3VudF9pbmAgLSBUaGUgaW5wdXQgYW1vdW50LgoqIGBwYXRoYCAtIFZlY3RvciBvZiB0b2tlbiBhZGRyZXNzZXMgcmVwcmVzZW50aW5nIHRoZSBwYXRoLgoKIyBSZXR1cm5zCgpSZXR1cm5zIGBSZXN1bHQ8VmVjPGkxMjg+LCBTb3Jvc3dhcExpYnJhcnlFcnJvcj5gIHdoZXJlIGBPa2AgY29udGFpbnMgYSB2ZWN0b3Igb2YgY2FsY3VsYXRlZCBhbW91bnRzLCBhbmQgYEVycmAgaW5kaWNhdGVzIGFuIGVycm9yIHN1Y2ggYXMgYW4gaW52YWxpZCBwYXRoLgAAAA9nZXRfYW1vdW50c19vdXQAAAAAAwAAAAAAAAAHZmFjdG9yeQAAAAATAAAAAAAAAAlhbW91bnRfaW4AAAAAAAALAAAAAAAAAARwYXRoAAAD6gAAABMAAAABAAAD6QAAA+oAAAALAAAH0AAAABRTb3Jvc3dhcExpYnJhcnlFcnJvcg==",
+        "AAAAAAAAAa1GZXRjaGVzIGFuZCBzb3J0cyB0aGUgcmVzZXJ2ZXMgZm9yIGEgcGFpciBvZiB0b2tlbnMgdXNpbmcgdGhlIHBhaXIgYWRkcmVzcy4KCiMgQXJndW1lbnRzCgoqIGBlYCAtIFRoZSBlbnZpcm9ubWVudC4KKiBgcGFpcmAgLSBUaGUgcGFpciBhZGRyZXNzLgoqIGB0b2tlbl9hYCAtIFRoZSBhZGRyZXNzIG9mIHRoZSBmaXJzdCB0b2tlbi4KKiBgdG9rZW5fYmAgLSBUaGUgYWRkcmVzcyBvZiB0aGUgc2Vjb25kIHRva2VuLgoKIyBSZXR1cm5zCgpSZXR1cm5zIGBSZXN1bHQ8KGkxMjgsIGkxMjgpLCBTb3Jvc3dhcExpYnJhcnlFcnJvcj5gIHdoZXJlIGBPa2AgY29udGFpbnMgYSB0dXBsZSBvZiBzb3J0ZWQgcmVzZXJ2ZXMsIGFuZCBgRXJyYCBpbmRpY2F0ZXMgYW4gZXJyb3Igc3VjaCBhcyBpZGVudGljYWwgdG9rZW5zIG9yIGFuIGlzc3VlIHdpdGggc29ydGluZy4AAAAAAAAWZ2V0X3Jlc2VydmVzX3dpdGhfcGFpcgAAAAAAAwAAAAAAAAAEcGFpcgAAABMAAAAAAAAAB3Rva2VuX2EAAAAAEwAAAAAAAAAHdG9rZW5fYgAAAAATAAAAAQAAA+kAAAPtAAAAAgAAAAsAAAALAAAH0AAAABRTb3Jvc3dhcExpYnJhcnlFcnJvcg==",
+        "AAAAAAAAAbZGZXRjaGVzIGFuZCBzb3J0cyB0aGUgcmVzZXJ2ZXMgZm9yIGEgcGFpciBvZiB0b2tlbnMgdXNpbmcgdGhlIGZhY3RvcnkgYWRkcmVzcy4KCiMgQXJndW1lbnRzCgoqIGBlYCAtIFRoZSBlbnZpcm9ubWVudC4KKiBgZmFjdG9yeWAgLSBUaGUgZmFjdG9yeSBhZGRyZXNzLgoqIGB0b2tlbl9hYCAtIFRoZSBhZGRyZXNzIG9mIHRoZSBmaXJzdCB0b2tlbi4KKiBgdG9rZW5fYmAgLSBUaGUgYWRkcmVzcyBvZiB0aGUgc2Vjb25kIHRva2VuLgoKIyBSZXR1cm5zCgpSZXR1cm5zIGBSZXN1bHQ8KGkxMjgsIGkxMjgpLCBTb3Jvc3dhcExpYnJhcnlFcnJvcj5gIHdoZXJlIGBPa2AgY29udGFpbnMgYSB0dXBsZSBvZiBzb3J0ZWQgcmVzZXJ2ZXMsIGFuZCBgRXJyYCBpbmRpY2F0ZXMgYW4gZXJyb3Igc3VjaCBhcyBpZGVudGljYWwgdG9rZW5zIG9yIGFuIGlzc3VlIHdpdGggc29ydGluZy4AAAAAABlnZXRfcmVzZXJ2ZXNfd2l0aF9mYWN0b3J5AAAAAAAAAwAAAAAAAAAHZmFjdG9yeQAAAAATAAAAAAAAAAd0b2tlbl9hAAAAABMAAAAAAAAAB3Rva2VuX2IAAAAAEwAAAAEAAAPpAAAD7QAAAAIAAAALAAAACwAAB9AAAAAUU29yb3N3YXBMaWJyYXJ5RXJyb3I=",
+        "AAAABAAAAAAAAAAAAAAAFFNvcm9zd2FwTGlicmFyeUVycm9yAAAABgAAACRTb3Jvc3dhcExpYnJhcnk6IGluc3VmZmljaWVudCBhbW91bnQAAAASSW5zdWZmaWNpZW50QW1vdW50AAAAAAEtAAAAJ1Nvcm9zd2FwTGlicmFyeTogaW5zdWZmaWNpZW50IGxpcXVpZGl0eQAAAAAVSW5zdWZmaWNpZW50TGlxdWlkaXR5AAAAAAABLgAAACpTb3Jvc3dhcExpYnJhcnk6IGluc3VmZmljaWVudCBpbnB1dCBhbW91bnQAAAAAABdJbnN1ZmZpY2llbnRJbnB1dEFtb3VudAAAAAEvAAAAK1Nvcm9zd2FwTGlicmFyeTogaW5zdWZmaWNpZW50IG91dHB1dCBhbW91bnQAAAAAGEluc3VmZmljaWVudE91dHB1dEFtb3VudAAAATAAAAAdU29yb3N3YXBMaWJyYXJ5OiBpbnZhbGlkIHBhdGgAAAAAAAALSW52YWxpZFBhdGgAAAABMQAAAD1Tb3Jvc3dhcExpYnJhcnk6IHRva2VuX2EgYW5kIHRva2VuX2IgaGF2ZSBpZGVudGljYWwgYWRkcmVzc2VzAAAAAAAAE1NvcnRJZGVudGljYWxUb2tlbnMAAAABMg==",
+      ]),
+      options,
+    );
+  }
+  public readonly fromJSON = {
+    report: this.txFromJSON<Result<Array<Report>>>,
+    rescue: this.txFromJSON<Result<void>>,
+    deposit: this.txFromJSON<
+      Result<
+        readonly [
+          Array<i128>,
+          i128,
+          Option<Array<Option<AssetInvestmentAllocation>>>,
+        ]
+      >
+    >,
+    upgrade: this.txFromJSON<Result<void>>,
+    get_fees: this.txFromJSON<readonly [u32, u32]>,
+    withdraw: this.txFromJSON<Result<Array<i128>>>,
+    lock_fees: this.txFromJSON<Result<Array<Report>>>,
+    rebalance: this.txFromJSON<Result<void>>,
+    get_assets: this.txFromJSON<Result<Array<AssetStrategySet>>>,
+    get_manager: this.txFromJSON<Result<string>>,
+    set_manager: this.txFromJSON<Result<void>>,
+    release_fees: this.txFromJSON<Result<Report>>,
+    pause_strategy: this.txFromJSON<Result<void>>,
+    distribute_fees: this.txFromJSON<Result<Array<readonly [string, i128]>>>,
+    get_fee_receiver: this.txFromJSON<Result<string>>,
+    set_fee_receiver: this.txFromJSON<null>,
+    unpause_strategy: this.txFromJSON<Result<void>>,
+    get_emergency_manager: this.txFromJSON<Result<string>>,
+    get_rebalance_manager: this.txFromJSON<Result<string>>,
+    set_emergency_manager: this.txFromJSON<null>,
+    set_rebalance_manager: this.txFromJSON<null>,
+    fetch_total_managed_funds: this.txFromJSON<
+      Result<Array<CurrentAssetInvestmentAllocation>>
+    >,
+    get_asset_amounts_per_shares: this.txFromJSON<Result<Array<i128>>>,
+    burn: this.txFromJSON<null>,
+    name: this.txFromJSON<string>,
+    symbol: this.txFromJSON<string>,
+    approve: this.txFromJSON<null>,
+    balance: this.txFromJSON<i128>,
+    decimals: this.txFromJSON<u32>,
+    transfer: this.txFromJSON<null>,
+    allowance: this.txFromJSON<i128>,
+    burn_from: this.txFromJSON<null>,
+    total_supply: this.txFromJSON<i128>,
+    transfer_from: this.txFromJSON<null>,
+    quote: this.txFromJSON<Result<i128>>,
+    pair_for: this.txFromJSON<Result<string>>,
+    sort_tokens: this.txFromJSON<Result<readonly [string, string]>>,
+    get_amount_in: this.txFromJSON<Result<i128>>,
+    get_amounts_in: this.txFromJSON<Result<Array<i128>>>,
+    get_amount_out: this.txFromJSON<Result<i128>>,
+    get_amounts_out: this.txFromJSON<Result<Array<i128>>>,
+    get_reserves_with_pair: this.txFromJSON<Result<readonly [i128, i128]>>,
+    get_reserves_with_factory: this.txFromJSON<Result<readonly [i128, i128]>>,
+  };
+}

--- a/apps/shared/src/contracts/index.ts
+++ b/apps/shared/src/contracts/index.ts
@@ -8,4 +8,15 @@ export {
 } from "./clientConfig";
 export { RealEstateTokenContractClient } from "./realEstateToken";
 export { DefiLendingContractClient } from "./defiLending";
+export {
+  DefindexVaultContractClient,
+  DefindexVaultError,
+  toDefindexVaultError,
+  type AssetStrategySet,
+  type CurrentAssetInvestmentAllocation,
+  type StrategyAllocation,
+  type VaultDepositArgs,
+  type VaultMethodOptions,
+  type VaultWithdrawArgs,
+} from "./defindexVault";
 export * from "./game";

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -12,6 +12,17 @@ export {
 } from "./contracts/clientConfig";
 export { RealEstateTokenContractClient } from "./contracts/realEstateToken";
 export { DefiLendingContractClient } from "./contracts/defiLending";
+export {
+  DefindexVaultContractClient,
+  DefindexVaultError,
+  toDefindexVaultError,
+  type AssetStrategySet,
+  type CurrentAssetInvestmentAllocation,
+  type StrategyAllocation,
+  type VaultDepositArgs,
+  type VaultMethodOptions,
+  type VaultWithdrawArgs,
+} from "./contracts/defindexVault";
 export * from "./contracts/game";
 export * from "./utils/stellar";
 export * from "./utils/validation";

--- a/apps/webapp/messages/en.json
+++ b/apps/webapp/messages/en.json
@@ -162,5 +162,44 @@
     "lending": "Lending",
     "map": "Map",
     "connect": "Connect"
+  },
+  "Treasury": {
+    "title": "Treasury",
+    "whatThisIs": "Where the accumulated platform fee is held, and what it is doing.",
+    "whyItExists": "The platform fee builds up in a Stellar account. Rather than leave it sitting idle, it is deposited into two DeFi venues that are already deployed and already audited: DeFindex's Blend strategy, and Etherfuse's Stablebonds. This is treasury management — the balance earns a return instead of nothing. It is not an exercise in producing numbers to point at.",
+    "howToVerify": "Because it settles on chain, the record is checkable by anyone. Every figure on this page is read from the vault contracts when the page loads; none of it is estimated or projected. The links below go to the contracts and the treasury account on stellar.expert, so you can confirm each number against the ledger yourself.",
+    "positionValue": "Position value",
+    "sharesHeld": "{shares} vault shares",
+    "noDepositYet": "No funds deposited into this venue yet.",
+    "vaultTotal": "Vault total",
+    "vaultFee": "Vault fee",
+    "paused": "Paused",
+    "viewVault": "Vault on stellar.expert",
+    "viewAccount": "Treasury account",
+    "viewTx": "Transaction",
+    "contractId": "Contract {id}",
+    "noVenuesConfigured": "No treasury venue is configured for this network yet, so there is no position to show.",
+    "venuesUnavailable": "Some venues could not be read",
+    "historyTitle": "Movements",
+    "historyNote": "Every recorded deposit and withdrawal, including attempts that the venue rejected.",
+    "column": {
+      "date": "Date",
+      "action": "Action",
+      "amount": "Amount",
+      "result": "Result",
+      "record": "On chain"
+    },
+    "operation": {
+      "deposit": "Deposit",
+      "withdraw": "Withdraw"
+    },
+    "status": {
+      "submitted": "Submitted",
+      "failed": "Failed"
+    },
+    "readFailed": "Could not read the treasury position",
+    "retry": "Retry",
+    "readAtNote": "Read live from Stellar {network}. Treasury account: {account}.",
+    "noAccountConfigured": "not configured"
   }
 }

--- a/apps/webapp/messages/es.json
+++ b/apps/webapp/messages/es.json
@@ -162,5 +162,44 @@
     "lending": "Préstamos",
     "map": "Mapa",
     "connect": "Conectar"
+  },
+  "Treasury": {
+    "title": "Tesorería",
+    "whatThisIs": "Dónde se guarda la comisión acumulada de la plataforma y qué está haciendo.",
+    "whyItExists": "La comisión de la plataforma se acumula en una cuenta de Stellar. En lugar de dejarla inactiva, se deposita en dos plataformas DeFi ya desplegadas y ya auditadas: la estrategia Blend de DeFindex y los Stablebonds de Etherfuse. Esto es gestión de tesorería — el saldo genera un rendimiento en vez de nada. No es un ejercicio para producir cifras que exhibir.",
+    "howToVerify": "Como se liquida en cadena, el registro es verificable por cualquiera. Cada cifra de esta página se lee de los contratos de los vaults al cargarla; ninguna es estimada ni proyectada. Los enlaces de abajo llevan a los contratos y a la cuenta de tesorería en stellar.expert, para que puedas confirmar cada número contra el ledger.",
+    "positionValue": "Valor de la posición",
+    "sharesHeld": "{shares} participaciones del vault",
+    "noDepositYet": "Aún no se han depositado fondos en esta plataforma.",
+    "vaultTotal": "Total del vault",
+    "vaultFee": "Comisión del vault",
+    "paused": "En pausa",
+    "viewVault": "Vault en stellar.expert",
+    "viewAccount": "Cuenta de tesorería",
+    "viewTx": "Transacción",
+    "contractId": "Contrato {id}",
+    "noVenuesConfigured": "Aún no hay ninguna plataforma de tesorería configurada para esta red, así que no hay posición que mostrar.",
+    "venuesUnavailable": "No se pudieron leer algunas plataformas",
+    "historyTitle": "Movimientos",
+    "historyNote": "Todos los depósitos y retiros registrados, incluidos los intentos que la plataforma rechazó.",
+    "column": {
+      "date": "Fecha",
+      "action": "Acción",
+      "amount": "Importe",
+      "result": "Resultado",
+      "record": "En cadena"
+    },
+    "operation": {
+      "deposit": "Depósito",
+      "withdraw": "Retiro"
+    },
+    "status": {
+      "submitted": "Enviado",
+      "failed": "Fallido"
+    },
+    "readFailed": "No se pudo leer la posición de tesorería",
+    "retry": "Reintentar",
+    "readAtNote": "Leído en vivo de Stellar {network}. Cuenta de tesorería: {account}.",
+    "noAccountConfigured": "sin configurar"
   }
 }

--- a/apps/webapp/src/app/[locale]/treasury/page.tsx
+++ b/apps/webapp/src/app/[locale]/treasury/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Navbar, Footer } from "@/components/layout";
+import { ErrorBoundary, SectionErrorFallback } from "@/components/ui";
+import { TreasuryPanel } from "@/components/treasury";
+import { pageTransition } from "@/lib/animations";
+
+export default function TreasuryPage() {
+  return (
+    <div className="min-h-screen bg-black">
+      <Navbar />
+      <motion.main
+        variants={pageTransition}
+        initial="hidden"
+        animate="visible"
+        className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8"
+      >
+        <ErrorBoundary fallback={<SectionErrorFallback />}>
+          <TreasuryPanel />
+        </ErrorBoundary>
+      </motion.main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/webapp/src/components/treasury/TreasuryPanel.tsx
+++ b/apps/webapp/src/components/treasury/TreasuryPanel.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  AlertTriangle,
+  ExternalLink,
+  PauseCircle,
+  RefreshCw,
+} from "lucide-react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  SkeletonCard,
+} from "@/components/ui";
+import { useTreasury } from "@/hooks/useTreasury";
+import type {
+  TreasuryHistoryEntry,
+  TreasuryPosition,
+} from "@/services/api/treasury";
+import { cn, truncateAddress } from "@/lib/utils";
+
+/**
+ * Render an asset amount that arrived from the API as a decimal string.
+ *
+ * The string is kept as the source of truth and only trimmed for display —
+ * never parsed into a float and re-rendered — so what a reader sees always
+ * matches what the ledger holds.
+ */
+function formatAssetAmount(value: string, maxDecimals = 4): string {
+  const [whole, fraction = ""] = value.split(".");
+  const groupedWhole = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const trimmed = fraction.slice(0, maxDecimals).replace(/0+$/, "");
+
+  return trimmed ? `${groupedWhole}.${trimmed}` : groupedWhole;
+}
+
+function isZero(value: string): boolean {
+  return /^0(\.0*)?$/.test(value);
+}
+
+function VenueCard({
+  position,
+  t,
+}: {
+  position: TreasuryPosition;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const empty = isZero(position.positionValue);
+
+  return (
+    <Card variant="bordered" className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-base font-semibold text-zinc-100">
+            {position.label}
+          </h3>
+          <p className="mt-1 text-sm text-zinc-400">{position.strategy}</p>
+        </div>
+        {position.paused ? (
+          <Badge variant="warning">
+            <PauseCircle className="h-3 w-3" aria-hidden="true" />
+            {t("paused")}
+          </Badge>
+        ) : (
+          <Badge variant="outline">{position.provider}</Badge>
+        )}
+      </div>
+
+      <div>
+        <p className="text-xs uppercase tracking-wide text-zinc-500">
+          {t("positionValue")}
+        </p>
+        <p className="mt-1 text-2xl font-semibold tabular-nums text-zinc-50">
+          {formatAssetAmount(position.positionValue)}{" "}
+          <span className="text-base font-normal text-zinc-400">
+            {position.assetCode}
+          </span>
+        </p>
+        {empty ? (
+          <p className="mt-1 text-sm text-zinc-500">{t("noDepositYet")}</p>
+        ) : (
+          <p className="mt-1 text-sm text-zinc-500">
+            {t("sharesHeld", {
+              shares: formatAssetAmount(position.shares),
+            })}
+          </p>
+        )}
+      </div>
+
+      <dl className="grid grid-cols-2 gap-3 border-t border-zinc-800 pt-4 text-sm">
+        <div>
+          <dt className="text-zinc-500">{t("vaultTotal")}</dt>
+          <dd className="tabular-nums text-zinc-300">
+            {formatAssetAmount(position.vaultTotalManaged)} {position.assetCode}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-zinc-500">{t("vaultFee")}</dt>
+          <dd className="tabular-nums text-zinc-300">
+            {(position.fees.vaultBps / 100).toFixed(2)}%
+          </dd>
+        </div>
+      </dl>
+
+      <div className="flex flex-wrap gap-3 border-t border-zinc-800 pt-4 text-sm">
+        <a
+          href={position.explorer.vault}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-cyan-400 hover:text-cyan-300"
+        >
+          {t("viewVault")}
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        </a>
+        {position.explorer.account && (
+          <a
+            href={position.explorer.account}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-cyan-400 hover:text-cyan-300"
+          >
+            {t("viewAccount")}
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+        )}
+      </div>
+
+      <p className="text-xs text-zinc-600">
+        {t("contractId", { id: truncateAddress(position.vaultContractId, 6) })}
+      </p>
+    </Card>
+  );
+}
+
+function HistoryRow({
+  entry,
+  t,
+}: {
+  entry: TreasuryHistoryEntry;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const failed = entry.status === "failed";
+
+  return (
+    <tr className="border-b border-zinc-800/60 last:border-0">
+      <td className="py-2 pr-4 text-zinc-400">
+        {new Date(entry.createdAt).toLocaleDateString()}
+      </td>
+      <td className="py-2 pr-4 text-zinc-300">
+        {t(`operation.${entry.operation}`)}
+      </td>
+      <td className="py-2 pr-4 tabular-nums text-zinc-300">
+        {entry.amount ? formatAssetAmount(entry.amount) : "—"} {entry.assetCode}
+      </td>
+      <td className="py-2 pr-4">
+        <span
+          className={cn(
+            "text-xs",
+            failed ? "text-red-400" : "text-emerald-400",
+          )}
+        >
+          {failed
+            ? (entry.errorName ?? t("status.failed"))
+            : t("status.submitted")}
+        </span>
+      </td>
+      <td className="py-2">
+        {entry.explorerUrl ? (
+          <a
+            href={entry.explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-cyan-400 hover:text-cyan-300"
+          >
+            {t("viewTx")}
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        ) : (
+          <span className="text-zinc-600">—</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * Treasury panel for the Phase 1a treasury track.
+ *
+ * Every figure shown is read from the vault contracts by the API at request
+ * time and passed through as a decimal string. There are no placeholder
+ * numbers here: an empty position renders as an empty position, and a venue
+ * that could not be read says so rather than being quietly dropped.
+ */
+export function TreasuryPanel() {
+  const t = useTranslations("Treasury");
+  const { portfolio, history, isLoading, error, refetch } = useTreasury();
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2">
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    );
+  }
+
+  if (error || !portfolio) {
+    return (
+      <Card variant="bordered" className="flex flex-col items-start gap-3">
+        <div className="flex items-center gap-2 text-red-400">
+          <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+          <p className="text-sm">{t("readFailed")}</p>
+        </div>
+        <p className="text-sm text-zinc-500">{error}</p>
+        <Button variant="secondary" onClick={refetch}>
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          {t("retry")}
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card variant="gradient">
+        <CardHeader className="p-0">
+          <CardTitle>{t("title")}</CardTitle>
+          <CardDescription>{t("whatThisIs")}</CardDescription>
+        </CardHeader>
+        <p className="mt-4 text-sm leading-relaxed text-zinc-400">
+          {t("whyItExists")}
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-zinc-500">
+          {t("howToVerify")}
+        </p>
+      </Card>
+
+      {portfolio.positions.length > 0 ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {portfolio.positions.map((position) => (
+            <VenueCard key={position.venue} position={position} t={t} />
+          ))}
+        </div>
+      ) : (
+        <Card variant="bordered">
+          <p className="text-sm text-zinc-400">{t("noVenuesConfigured")}</p>
+        </Card>
+      )}
+
+      {portfolio.unavailable.length > 0 && (
+        <Card variant="bordered" className="space-y-2">
+          <div className="flex items-center gap-2 text-amber-400">
+            <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+            <p className="text-sm font-medium">{t("venuesUnavailable")}</p>
+          </div>
+          <ul className="space-y-1 text-sm text-zinc-500">
+            {portfolio.unavailable.map((entry) => (
+              <li key={entry.venue}>
+                <span className="text-zinc-400">{entry.venue}</span>:{" "}
+                {entry.reason}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {history && history.transactions.length > 0 && (
+        <Card variant="bordered">
+          <CardHeader className="p-0 pb-4">
+            <CardTitle className="text-base">{t("historyTitle")}</CardTitle>
+            <CardDescription>{t("historyNote")}</CardDescription>
+          </CardHeader>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[32rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-xs uppercase tracking-wide text-zinc-500">
+                  <th className="py-2 pr-4 font-medium">{t("column.date")}</th>
+                  <th className="py-2 pr-4 font-medium">
+                    {t("column.action")}
+                  </th>
+                  <th className="py-2 pr-4 font-medium">
+                    {t("column.amount")}
+                  </th>
+                  <th className="py-2 pr-4 font-medium">
+                    {t("column.result")}
+                  </th>
+                  <th className="py-2 font-medium">{t("column.record")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.transactions.map((entry) => (
+                  <HistoryRow key={entry.id} entry={entry} t={t} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      <p className="text-xs text-zinc-600">
+        {t("readAtNote", {
+          network: portfolio.network,
+          account: portfolio.sourceAccount
+            ? truncateAddress(portfolio.sourceAccount, 6)
+            : t("noAccountConfigured"),
+        })}
+      </p>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/treasury/index.ts
+++ b/apps/webapp/src/components/treasury/index.ts
@@ -1,0 +1,1 @@
+export { TreasuryPanel } from "./TreasuryPanel";

--- a/apps/webapp/src/hooks/useTreasury.ts
+++ b/apps/webapp/src/hooks/useTreasury.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  treasuryApi,
+  type TreasuryHistory,
+  type TreasuryPortfolio,
+} from "@/services/api/treasury";
+
+export interface UseTreasuryReturn {
+  portfolio: TreasuryPortfolio | null;
+  history: TreasuryHistory | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Loads the treasury position and its recorded history.
+ *
+ * The portfolio is the load-bearing call: if it fails there is nothing honest
+ * to display, so its failure is the hook's error. History is supplementary, so
+ * a history failure leaves `history` null rather than blanking the panel.
+ */
+export function useTreasury(): UseTreasuryReturn {
+  const [portfolio, setPortfolio] = useState<TreasuryPortfolio | null>(null);
+  const [history, setHistory] = useState<TreasuryHistory | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const refetch = useCallback(() => setFetchKey((key) => key + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const [nextPortfolio, nextHistory] = await Promise.all([
+          treasuryApi.getPortfolio(),
+          treasuryApi.getHistory().catch(() => null),
+        ]);
+
+        if (cancelled) return;
+        setPortfolio(nextPortfolio);
+        setHistory(nextHistory);
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Could not read the treasury position.",
+        );
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchKey]);
+
+  return { portfolio, history, isLoading, error, refetch };
+}

--- a/apps/webapp/src/services/api/__tests__/treasury.test.ts
+++ b/apps/webapp/src/services/api/__tests__/treasury.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { treasuryApi } from "../treasury";
+import type { TreasuryPortfolio } from "../treasury";
+import { setupMockFetch, wrapFetchMock } from "./helpers";
+
+const TESTNET_VAULT =
+  "CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN";
+const TESTNET_ASSET =
+  "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU";
+
+function portfolioFixture(): TreasuryPortfolio {
+  return {
+    positions: [
+      {
+        venue: "defindex-blend",
+        label: "DeFindex Blend strategy",
+        provider: "DeFindex",
+        strategy: "Lends the deposited USDC into Blend",
+        assetCode: "USDC",
+        vaultContractId: TESTNET_VAULT,
+        assetContractId: TESTNET_ASSET,
+        shares: "25.0000000",
+        positionValue: "25.1234567",
+        vaultTotalManaged: "932.1856304",
+        vaultIdleAmount: "932.1856304",
+        vaultInvestedAmount: "0.0000000",
+        strategies: [
+          {
+            address: "CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY",
+            amount: "0.0000000",
+            paused: false,
+          },
+        ],
+        paused: false,
+        fees: { vaultBps: 100, protocolBps: 2000 },
+        explorer: {
+          vault: `https://stellar.expert/explorer/testnet/contract/${TESTNET_VAULT}`,
+          asset: `https://stellar.expert/explorer/testnet/contract/${TESTNET_ASSET}`,
+          account: null,
+        },
+        readAt: "2026-08-18T00:00:00.000Z",
+      },
+    ],
+    unconfigured: [],
+    unavailable: [],
+    sourceAccount: null,
+    network: "testnet",
+  };
+}
+
+describe("Treasury API", () => {
+  beforeEach(() => {
+    global.fetch = wrapFetchMock(
+      mock(() => {
+        throw new Error("fetch not mocked");
+      }),
+    );
+  });
+
+  describe("getPortfolio", () => {
+    it("unwraps the API envelope and returns positions as decimal strings", async () => {
+      const { fetchMock, calls } = setupMockFetch({
+        body: { success: true, data: portfolioFixture() },
+      });
+      global.fetch = fetchMock;
+
+      const portfolio = await treasuryApi.getPortfolio();
+
+      expect(calls[0]!.url).toContain("/api/v1/treasury");
+      expect(portfolio.positions).toHaveLength(1);
+      // Amounts stay strings so no precision is lost on the way to the UI.
+      expect(portfolio.positions[0]!.positionValue).toBe("25.1234567");
+      expect(portfolio.positions[0]!.explorer.vault).toContain(
+        "stellar.expert",
+      );
+    });
+
+    it("preserves venues the API could not read", async () => {
+      const fixture = portfolioFixture();
+      fixture.unavailable = [
+        { venue: "etherfuse-stablebond", reason: "RPC unavailable" },
+      ];
+
+      const { fetchMock } = setupMockFetch({
+        body: { success: true, data: fixture },
+      });
+      global.fetch = fetchMock;
+
+      const portfolio = await treasuryApi.getPortfolio();
+
+      expect(portfolio.unavailable).toEqual([
+        { venue: "etherfuse-stablebond", reason: "RPC unavailable" },
+      ]);
+    });
+
+    it("retries a 503 and then propagates the error rather than showing an empty position", async () => {
+      const { fetchMock, calls } = setupMockFetch({
+        status: 503,
+        body: {
+          success: false,
+          code: "TREASURY_VENUE_NOT_CONFIGURED",
+          message: "no venue configured",
+        },
+      });
+      global.fetch = fetchMock;
+
+      await expect(treasuryApi.getPortfolio()).rejects.toThrow();
+      // The shared client treats 5xx as retryable: 1 attempt plus 3 retries.
+      expect(calls).toHaveLength(4);
+    }, 20_000);
+  });
+
+  describe("getHistory", () => {
+    it("requests the given limit and returns movements and snapshots", async () => {
+      const { fetchMock, calls } = setupMockFetch({
+        body: {
+          success: true,
+          data: {
+            transactions: [
+              {
+                id: "11111111-1111-4111-8111-111111111111",
+                venue: "defindex-blend",
+                operation: "deposit",
+                status: "submitted",
+                assetCode: "USDC",
+                amount: "10.0000000",
+                shares: null,
+                txHash: "abc",
+                explorerUrl: "https://stellar.expert/explorer/testnet/tx/abc",
+                errorName: null,
+                errorCode: null,
+                requestedBy: "internal-operations",
+                createdAt: "2026-08-18T00:00:00.000Z",
+              },
+            ],
+            snapshots: [],
+          },
+        },
+      });
+      global.fetch = fetchMock;
+
+      const history = await treasuryApi.getHistory(5);
+
+      expect(calls[0]!.url).toContain("/api/v1/treasury/history?limit=5");
+      expect(history.transactions).toHaveLength(1);
+      expect(history.transactions[0]!.explorerUrl).toContain("/tx/abc");
+    });
+  });
+});

--- a/apps/webapp/src/services/api/index.ts
+++ b/apps/webapp/src/services/api/index.ts
@@ -5,6 +5,7 @@ export { lendingApi } from "./lending";
 export { userApi } from "./users";
 export { transactionsApi } from "./transactions";
 export { adminOperationsApi } from "./adminOperations";
+export { treasuryApi } from "./treasury";
 export type {
   OperationalPropertyDetail,
   OperationalPropertyListItem,
@@ -12,3 +13,12 @@ export type {
   PropertyReviewStatus,
   ReviewAction,
 } from "./adminOperations";
+export type {
+  TreasuryHistory,
+  TreasuryHistoryEntry,
+  TreasuryPortfolio,
+  TreasuryPosition,
+  TreasurySnapshot,
+  TreasuryVenueId,
+  TreasuryVenueStatus,
+} from "./treasury";

--- a/apps/webapp/src/services/api/treasury.ts
+++ b/apps/webapp/src/services/api/treasury.ts
@@ -1,0 +1,105 @@
+import { apiClient } from "./client";
+
+export type TreasuryVenueId = "defindex-blend" | "etherfuse-stablebond";
+
+export interface TreasuryStrategy {
+  address: string;
+  amount: string;
+  paused: boolean;
+}
+
+export interface TreasuryPosition {
+  venue: TreasuryVenueId;
+  label: string;
+  provider: string;
+  strategy: string;
+  assetCode: string;
+  vaultContractId: string;
+  assetContractId: string;
+  /** dfToken shares the treasury holds, as a decimal string. */
+  shares: string;
+  /** What those shares are worth right now, in the underlying asset. */
+  positionValue: string;
+  vaultTotalManaged: string;
+  vaultIdleAmount: string;
+  vaultInvestedAmount: string;
+  strategies: TreasuryStrategy[];
+  paused: boolean;
+  fees: { vaultBps: number; protocolBps: number };
+  explorer: { vault: string; asset: string; account: string | null };
+  /** When the API read these numbers off chain. */
+  readAt: string;
+}
+
+export interface TreasuryVenueStatus {
+  venue: TreasuryVenueId;
+  configured: boolean;
+  label: string;
+  provider: string;
+  strategy: string;
+}
+
+export interface TreasuryPortfolio {
+  positions: TreasuryPosition[];
+  unconfigured: TreasuryVenueStatus[];
+  unavailable: Array<{ venue: TreasuryVenueId; reason: string }>;
+  sourceAccount: string | null;
+  network: string;
+}
+
+export interface TreasuryHistoryEntry {
+  id: string;
+  venue: TreasuryVenueId;
+  operation: "deposit" | "withdraw";
+  status: "submitted" | "confirmed" | "failed";
+  assetCode: string;
+  amount: string | null;
+  shares: string | null;
+  txHash: string | null;
+  explorerUrl: string | null;
+  errorName: string | null;
+  errorCode: string | null;
+  requestedBy: string;
+  createdAt: string;
+}
+
+export interface TreasurySnapshot {
+  venue: TreasuryVenueId;
+  assetCode: string;
+  shares: string;
+  positionValue: string;
+  vaultTotalManaged: string;
+  capturedAt: string;
+}
+
+export interface TreasuryHistory {
+  transactions: TreasuryHistoryEntry[];
+  snapshots: TreasurySnapshot[];
+}
+
+interface ApiEnvelope<T> {
+  success: boolean;
+  data: T;
+}
+
+/**
+ * Read-only treasury API.
+ *
+ * There are deliberately no deposit/withdraw calls here: those are
+ * admin-triggered through the internal API key, not something the web app can
+ * initiate.
+ */
+export const treasuryApi = {
+  async getPortfolio(): Promise<TreasuryPortfolio> {
+    const response =
+      await apiClient.get<ApiEnvelope<TreasuryPortfolio>>("/api/v1/treasury");
+    return response.data.data;
+  },
+
+  async getHistory(limit = 20): Promise<TreasuryHistory> {
+    const response = await apiClient.get<ApiEnvelope<TreasuryHistory>>(
+      `/api/v1/treasury/history?limit=${limit}`,
+    );
+    return response.data.data;
+  },
+};

--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/jwt": "^1.4.2",
         "@elysiajs/swagger": "^1.3.1",
-        "@stellar/stellar-sdk": "^13.3.0",
+        "@stellar/stellar-sdk": "^14.2.0",
         "bun": "^1.3.9",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.26",
@@ -101,7 +101,7 @@
       "name": "@akkuea/shared",
       "version": "1.0.0",
       "dependencies": {
-        "@stellar/stellar-sdk": "^13.3.0",
+        "@stellar/stellar-sdk": "^14.2.0",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -3574,9 +3574,13 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
+    "@akkuea/api/@stellar/stellar-sdk": ["@stellar/stellar-sdk@14.6.1", "", { "dependencies": { "@stellar/stellar-base": "^14.1.0", "axios": "^1.13.3", "bignumber.js": "^9.3.1", "commander": "^14.0.2", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.1" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg=="],
+
     "@akkuea/land/@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
 
     "@akkuea/land/@stellar/stellar-sdk": ["@stellar/stellar-sdk@14.6.1", "", { "dependencies": { "@stellar/stellar-base": "^14.1.0", "axios": "^1.13.3", "bignumber.js": "^9.3.1", "commander": "^14.0.2", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.1" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg=="],
+
+    "@akkuea/shared/@stellar/stellar-sdk": ["@stellar/stellar-sdk@14.6.1", "", { "dependencies": { "@stellar/stellar-base": "^14.1.0", "axios": "^1.13.3", "bignumber.js": "^9.3.1", "commander": "^14.0.2", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.1" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg=="],
 
     "@akkuea/webapp/@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
 
@@ -4218,9 +4222,17 @@
 
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
+    "@akkuea/api/@stellar/stellar-sdk/@stellar/stellar-base": ["@stellar/stellar-base@14.1.0", "", { "dependencies": { "@noble/curves": "^1.9.6", "@stellar/js-xdr": "^3.1.2", "base32.js": "^0.1.0", "bignumber.js": "^9.3.1", "buffer": "^6.0.3", "sha.js": "^2.4.12" } }, "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw=="],
+
+    "@akkuea/api/@stellar/stellar-sdk/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
     "@akkuea/land/@stellar/stellar-sdk/@stellar/stellar-base": ["@stellar/stellar-base@14.1.0", "", { "dependencies": { "@noble/curves": "^1.9.6", "@stellar/js-xdr": "^3.1.2", "base32.js": "^0.1.0", "bignumber.js": "^9.3.1", "buffer": "^6.0.3", "sha.js": "^2.4.12" } }, "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw=="],
 
     "@akkuea/land/@stellar/stellar-sdk/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "@akkuea/shared/@stellar/stellar-sdk/@stellar/stellar-base": ["@stellar/stellar-base@14.1.0", "", { "dependencies": { "@noble/curves": "^1.9.6", "@stellar/js-xdr": "^3.1.2", "base32.js": "^0.1.0", "bignumber.js": "^9.3.1", "buffer": "^6.0.3", "sha.js": "^2.4.12" } }, "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw=="],
+
+    "@akkuea/shared/@stellar/stellar-sdk/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "@akkuea/webapp/eslint-config-next/@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.7", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w=="],
 
@@ -4760,7 +4772,11 @@
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
+    "@akkuea/api/@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@3.1.2", "", {}, "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="],
+
     "@akkuea/land/@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@3.1.2", "", {}, "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="],
+
+    "@akkuea/shared/@stellar/stellar-sdk/@stellar/stellar-base/@stellar/js-xdr": ["@stellar/js-xdr@3.1.2", "", {}, "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="],
 
     "@coinbase/cdp-sdk/@solana/kit/@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 

--- a/docs/operations/runbook-treasury-track.md
+++ b/docs/operations/runbook-treasury-track.md
@@ -1,0 +1,255 @@
+# Runbook: Phase 1a Treasury Track (DeFindex + Etherfuse)
+
+**Severity:** Medium — treasury movements are blocked; platform operations are unaffected
+**Audience:** On-call operators with the internal operations API key
+**Related source:** `apps/api/src/services/TreasuryService.ts`, `apps/api/src/config/treasury.ts`, `apps/shared/src/contracts/defindexVault.ts`
+
+---
+
+## What this track is
+
+The accumulated platform fee sits in a Stellar account. Rather than leave it idle,
+it is deposited into two DeFi venues that are already deployed and already audited.
+The balance earns a return, and because it settles on chain the whole position is
+checkable by anyone against the ledger.
+
+This is treasury management. It is not an exercise in generating activity to point
+at, and the UI copy in `apps/webapp/messages/en.json` (`Treasury` namespace) is
+written to say exactly that. If that copy is ever edited into something more
+promotional, it has drifted from what the system actually does.
+
+---
+
+## Venues
+
+Both venues are DeFindex Vaults and share one contract interface. Etherfuse does not
+publish a direct Soroban mint/redeem interface for Stablebonds; the documented
+on-chain path is the DeFindex strategy, which is what this integration uses.
+
+| Venue ID | Vault | Underlying asset | Strategy |
+| --- | --- | --- | --- |
+| `defindex-blend` | `CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN` | USDC (`CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU`) | `USDC Blend Strategy` |
+| `etherfuse-stablebond` | `CBIS5TEMTNNOTBE3WXPQUAGUEDYZZVIWAKTXEQCOUJ34OJJ3FJ5NLF2P` | CETES (`CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC`) | `CETES Blend Strategy` |
+
+Both addresses are **testnet**, taken from the upstream deployment registry at
+<https://github.com/defindex-io/stellar-contracts/blob/main/public/testnet.contracts.json>.
+
+CETES is Etherfuse's tokenized Mexican sovereign-debt Stablebond. The mainnet
+Etherfuse strategies (CETES, USTRY, TESOURO) are listed in the same registry's
+`mainnet.contracts.json`, but mainnet **vaults** are deployed per partner through
+the DeFindex factory, so there are no committed mainnet defaults. Supply them with:
+
+```
+TREASURY_DEFINDEX_BLEND_VAULT_ID=C...
+TREASURY_DEFINDEX_BLEND_ASSET_ID=C...
+TREASURY_ETHERFUSE_VAULT_ID=C...
+TREASURY_ETHERFUSE_ASSET_ID=C...
+```
+
+### Verification transcript (2026-08-18, testnet)
+
+The committed addresses were confirmed against the deployed contracts, not against
+documentation:
+
+```
+$ stellar contract invoke --network testnet --id CBMVK2JK... -- get_assets
+[{"address":"CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
+  "strategies":[{"address":"CALLOM5I...","name":"USDC Blend Strategy","paused":false}]}]
+
+$ stellar contract invoke --network testnet --id CBIS5TEM... -- get_assets
+[{"address":"CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC",
+  "strategies":[{"address":"CCP4RBDW...","name":"CETES Blend Strategy","paused":false}]}]
+
+$ stellar contract invoke --network testnet --id CBIS5TEM... -- fetch_total_managed_funds
+[{"asset":"CC72F57Y...","idle_amount":"30000000","invested_amount":"2000228743",
+  "strategy_allocations":[{"amount":"2000228743","paused":false,"strategy_address":"CCP4RBDW..."}],
+  "total_amount":"2030228743"}]
+```
+
+The contract bindings in `apps/shared/src/contracts/generated/defindexVault.ts` are
+generated from the deployed WASM with `stellar contract bindings typescript`, so the
+interface in this repo is the interface the chain exposes.
+
+---
+
+## Configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `TREASURY_SOURCE_PUBLIC_KEY` | Account holding the platform fee. Falls back to `STELLAR_ADMIN_PUBLIC_KEY`. |
+| `TREASURY_SOURCE_SECRET` | Signing key for deposits/withdrawals. Falls back to `STELLAR_ADMIN_SECRET`. |
+| `OPERATIONS_BACKEND_CREDENTIAL` | Value of the `x-internal-api-key` header required for movements. |
+| `STELLAR_NETWORK` | `testnet` or `mainnet`; selects the venue defaults. |
+| `STELLAR_RPC_URL` | Soroban RPC endpoint. |
+
+Read endpoints work with only `TREASURY_SOURCE_PUBLIC_KEY` set. Without a public key
+the API still reports vault totals but the platform's own position reads as zero.
+
+---
+
+## Endpoints
+
+Read-only, no auth (the data is public on the ledger anyway):
+
+```
+GET /api/v1/treasury                    # position across every configured venue
+GET /api/v1/treasury/venues/:venue      # one venue
+GET /api/v1/treasury/history?limit=20   # recorded movements and snapshots
+```
+
+Admin, requires `x-internal-api-key`:
+
+```
+POST /api/v1/treasury/deposit   {"venue":"defindex-blend","amount":25,"slippageBps":50}
+POST /api/v1/treasury/withdraw  {"venue":"defindex-blend","amount":25,"slippageBps":50}
+```
+
+`amount` is in whole units of the venue's underlying asset. `slippageBps` defaults to
+50 (0.5%) and is capped at 1000.
+
+---
+
+## Symptoms and responses
+
+Every failure below is a typed contract error decoded from the chain, not a guess.
+The API surfaces the contract error name and code in `details.venueError` and
+`details.contractErrorCode`, so the response says exactly which contract rejected the
+call and why.
+
+| API code | HTTP | Contract error | What happened | Action |
+| --- | --- | --- | --- | --- |
+| `TREASURY_VENUE_PAUSED` | 503 | `StrategyPaused` (144), `StrategyPausedOrNotFound` (141) | DeFindex paused the strategy, usually as an emergency measure | Do not retry. Check DeFindex status; funds already deposited are still in the vault and can normally still be withdrawn. |
+| `TREASURY_INSUFFICIENT_VENUE_LIQUIDITY` | 409 | `InsufficientManagedFunds` (114), `UnwindMoreThanAvailable` (128), `AmountOverTotalSupply` (124) | The withdrawal is larger than the venue can service right now | Retry with a smaller amount, or wait for Blend liquidity to recover. |
+| `TREASURY_INSUFFICIENT_BALANCE` | 409 | SAC `BalanceError` (10), `InsufficientBalance` (111) | The treasury account does not hold enough of the asset | Confirm the platform fee balance before retrying. |
+| `TREASURY_TRUSTLINE_MISSING` | 409 | SAC `TrustlineMissingError` (13) | The treasury account has no trustline for USDC/CETES | Establish the trustline, then retry. This is the first failure a brand-new treasury account hits. |
+| `TREASURY_ASSET_NOT_AUTHORIZED` | 409 | SAC `BalanceDeauthorizedError` (11) | The issuer has not authorized the account to hold the asset | Contact the issuer. |
+| `TREASURY_AMOUNT_REJECTED` | 422 | `AmountBelowMinDust` (451), `InsufficientAmount` (117) | Amount below the venue's minimum | Increase the amount. |
+| `TREASURY_SLIPPAGE_EXCEEDED` | 409 | `UnderlyingAmountBelowMin` (452), `BTokensAmountBelowMin` (453) | The movement would settle below the slippage floor | Retry with a wider `slippageBps`. |
+| `TREASURY_DEADLINE_EXPIRED` | 409 | `DeadlineExpired` (421) | The strategy's deadline passed mid-flight | Retry. |
+| `TREASURY_UNAUTHORIZED` | 403 | `Unauthorized` (130) | The configured key is not permitted for this operation | Check `TREASURY_SOURCE_SECRET`. |
+| `TREASURY_VENUE_REJECTED` | 502 | `ExternalError` (422), `SupplyNotFound` (455), `StrategyInvestError` (143) | Blend itself rejected the call | Check Blend pool status. A Blend-side pricing failure surfaces here. |
+| `TREASURY_VENUE_ERROR` | 502 | anything else | An unmodelled venue failure | Read `details.contractErrorCode` and add a mapping if it recurs. |
+| `TREASURY_VENUE_NOT_CONFIGURED` | 503 | — | No addresses for this venue on this network | Set the env vars above. |
+| `TREASURY_SOURCE_NOT_CONFIGURED` | 503 | — | No signing key | Set `TREASURY_SOURCE_SECRET`. |
+| `TREASURY_VENUE_ASSET_MISMATCH` | 502 | — | The configured vault does not manage the configured asset | The vault or the config changed. Re-verify addresses against the registry before moving any funds. |
+
+### A note on price staleness
+
+These two vaults are single-asset. Their deposit and withdraw paths do not consult a
+price oracle — confirmed by simulating a real deposit against the deployed testnet
+vault and reading the call tree, which contains only balance reads, a token transfer
+and the strategy call. There is therefore no staleness check to perform on this path.
+A Blend-side pricing failure would arrive as a strategy `ExternalError` and is mapped
+to `TREASURY_VENUE_REJECTED`.
+
+This is unrelated to the platform's own valuation oracle; see
+[`runbook-oracle-failure.md`](./runbook-oracle-failure.md) for that.
+
+---
+
+## Failed movements are recorded
+
+A rejected deposit is written to `treasury_transactions` with `status = 'failed'` and
+the contract error, before the error is returned to the caller. `GET /history`
+therefore shows attempts that did not land, not only the ones that did. Do not delete
+these rows to tidy up a report — a history that only shows successes is not the
+checkable record this track exists to produce.
+
+---
+
+## Running the integration tests
+
+These run against the real deployed vaults. Reads are simulations and move no funds;
+the deposit test funds a throwaway testnet account via friendbot and simulates a real
+`deposit`, which the vault rejects at the token transfer.
+
+```bash
+cd apps/api
+RUN_TREASURY_INTEGRATION_TESTS=1 bun test src/tests/treasury.integration.test.ts
+```
+
+They are opt-in because they need outbound access to Stellar testnet and friendbot,
+so the required CI workflows stay hermetic.
+
+### SDK version requirement
+
+`apps/shared` and `apps/api` require `@stellar/stellar-sdk` **>= 14**. On 13.3.0 every
+read of the CETES vault fails with `TypeError: Bad union switch: 1` — that SDK cannot
+parse the Soroban transaction data the current testnet RPC returns for that contract.
+The USDC vault is unaffected, and the Rust CLI reads both fine, so the failure is
+purely client-side. 14.0.0 is the verified minimum; the workspace is on `^14.2.0`,
+matching `apps/akkuea-land`. `apps/webapp` stays on 13.3.0 — it never talks to these
+vaults directly.
+
+Do not downgrade those two packages below 14 without re-checking this.
+
+---
+
+## Making the first deposit
+
+The integration tests exercise the deposit call path against the live vaults but
+cannot land a deposit, because that needs the treasury account to actually hold USDC
+and CETES. Run the steps below with the treasury key to make the first real deposit
+in each venue.
+
+### 1. Confirm the treasury account can hold both assets
+
+A brand-new account has no trustlines, and the first thing a deposit hits is the
+token transfer, so this must come first.
+
+```bash
+export TREASURY=G...   # TREASURY_SOURCE_PUBLIC_KEY
+
+stellar tx new change-trust --source-account treasury --network testnet \
+  --line USDC:GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56
+
+stellar tx new change-trust --source-account treasury --network testnet \
+  --line CETES:GC3CW7EDYRTWQ635VDIGY6S4ZUF5L6TQ7AA4MWS7LEQDBLUSZXV7UPS4
+```
+
+Skipping this yields `TREASURY_TRUSTLINE_MISSING` / SAC error `#13`.
+Having the trustline but no balance yields `TREASURY_INSUFFICIENT_BALANCE` / `#10`.
+
+### 2. Dry-run the deposit
+
+`--send=no` simulates against the real contract without submitting. Amounts are in
+the asset's smallest unit (7 decimals), so `100000000` is 10.0.
+
+```bash
+stellar contract invoke --network testnet --source-account treasury --send=no \
+  --id CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN \
+  -- deposit \
+  --amounts_desired '["100000000"]' --amounts_min '["99500000"]' \
+  --from $TREASURY --invest true
+```
+
+A clean simulation returns the amounts deposited and the shares that would be minted.
+Any `Error(Contract, #N)` maps to the table above.
+
+### 3. Deposit through the API
+
+Prefer this over the CLI for the real movement: it records the transaction, writes an
+audit entry, and returns the explorer link.
+
+```bash
+curl -sS -X POST http://localhost:3001/api/v1/treasury/deposit \
+  -H "content-type: application/json" \
+  -H "x-internal-api-key: $OPERATIONS_BACKEND_CREDENTIAL" \
+  -d '{"venue":"defindex-blend","amount":10,"slippageBps":50}'
+
+curl -sS -X POST http://localhost:3001/api/v1/treasury/deposit \
+  -H "content-type: application/json" \
+  -H "x-internal-api-key: $OPERATIONS_BACKEND_CREDENTIAL" \
+  -d '{"venue":"etherfuse-stablebond","amount":10,"slippageBps":50}'
+```
+
+Each response carries `txHash` and `explorerUrl`.
+
+### 4. Confirm the position moved
+
+```bash
+curl -sS http://localhost:3001/api/v1/treasury | jq '.data.positions[] | {venue, positionValue, shares}'
+```
+
+`positionValue` should now be non-zero for both venues, and the same figures should
+appear on the treasury panel and on stellar.expert at the `explorerUrl` from step 3.


### PR DESCRIPTION
Closes #1062

## What this does

Builds the Phase 1a treasury track: the accumulated platform fee is deposited into DeFi venues that are already deployed and already audited, so it earns a return instead of sitting idle, and the whole position stays checkable on chain by anyone.

## Architecture note worth reviewing first

Etherfuse publishes no direct Soroban mint/redeem interface for Stablebonds. The documented on-chain path is a DeFindex strategy, so **both venues resolve to DeFindex vaults running the same WASM**, and one contract client covers both:

| Venue | Vault | Asset | Strategy (read off-chain) |
| --- | --- | --- | --- |
| `defindex-blend` | `CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN` | USDC | `USDC Blend Strategy` |
| `etherfuse-stablebond` | `CBIS5TEMTNNOTBE3WXPQUAGUEDYZZVIWAKTXEQCOUJ34OJJ3FJ5NLF2P` | CETES | `CETES Blend Strategy` |

CETES is Etherfuse's tokenized Mexican sovereign-debt Stablebond. Addresses come from the [upstream deployment registry](https://github.com/defindex-io/stellar-contracts/blob/main/public/testnet.contracts.json) and were verified against the live contracts, not against documentation — transcript is in the runbook. Mainnet has no committed defaults because DeFindex vaults there are deployed per partner through the factory.

## Not built against an assumed interface

The bindings in `apps/shared/src/contracts/generated/defindexVault.ts` are generated from the deployed testnet vault WASM with `stellar contract bindings typescript`. The interface in this repo is the interface the chain exposes.

## Failure modes

Every external call maps the real contract error to a response that says what went wrong on chain, using codes taken from the deployed contracts' enums — the vault's `ContractError`, DeFindex's `StrategyError`, and the Stellar Asset Contract codes a deposit reaches through the vault's `transfer`:

- paused strategy → `503 TREASURY_VENUE_PAUSED`
- venue cannot service the size → `409 TREASURY_INSUFFICIENT_VENUE_LIQUIDITY`
- treasury account has no trustline → `409 TREASURY_TRUSTLINE_MISSING`
- Blend rejected the call → `502 TREASURY_VENUE_REJECTED`
- anything unmodelled → `502`, rather than dressed up as something known

On price staleness: these vaults are single-asset and their deposit/withdraw paths consult no oracle — confirmed by simulating a deposit against the deployed vault and reading the call tree, which contains only balance reads, a token transfer and the strategy call. A Blend-side pricing failure arrives as a strategy `ExternalError` and is mapped accordingly. Full table in the runbook.

Failed movements are written to `treasury_transactions` before the error is returned, so history shows attempts that did not land.

## Dependency change

`@stellar/stellar-sdk` moves to `^14.2.0` in `apps/shared` and `apps/api`. On 13.3.0 **every read of the CETES vault fails** with `TypeError: Bad union switch: 1` — that version cannot parse the Soroban transaction data current testnet RPC returns for the contract. 14.0.0 is the verified minimum; `apps/akkuea-land` was already on `^14.6.1`, so this aligns rather than adds a version. `apps/webapp` stays on 13.3.0.

## Verification

- **11/11 integration tests pass against the real deployed contracts** (`RUN_TREASURY_INTEGRATION_TESTS=1 bun test src/tests/treasury.integration.test.ts`). No mocks. The deposit test friendbot-funds a throwaway account and simulates a genuine `deposit`, which the vault accepts and then rejects at the token transfer — proving the argument encoding against the live WASM and end-to-end error decoding.
- Suites green: api 317 pass, shared 171, webapp 185. Lint, prettier, type-check and build clean in all three packages.

## Acceptance criteria not yet met

**A real deposit has not been executed.** That needs the treasury account to actually hold USDC and CETES, which no public faucet provides for the DeFindex test issuers. The call path is verified against the real contracts as described above, but no funds have moved, so there is no stellar.expert record to link yet. The runbook has the exact procedure; hashes will be added here once the first deposit lands.

~~**Migration `0009` has not been run against a live Postgres locally.**~~ Resolved: the API workflow ran it against Postgres 16 on this branch — `Running migrations...` → `Migrations completed successfully`.

## Notes for reviewers

- **This PR touches `.github/workflows/monorepo-ci.yml`**, which is shared infrastructure. The Security Compliance Check grepped for a bare `eval` substring, so the word "Retrieval" in a generated doc comment failed the job as "unsafe eval usage"; any file mentioning "retrieval" or "evaluation" would have done the same. The pattern is now anchored to real call sites (`eval(`, `new Function(`). Patching the generated artifact instead would have broken again on the next regeneration, but this is a one-line commit and trivial to split out if you would rather fix it separately.
- `docs/strategy/roadmap.md`, `integration-decisions.md` and `recommendations.md` referenced in the issue do not exist in the repo, nor does `docs/planning/cycles/cycle-6/`. The UI copy was written to the framing described in the issue body itself; worth a check that it matches what those documents say.
- Read endpoints are public and unauthenticated, so position reads are cached briefly and snapshots throttled per venue — otherwise page loads become unbounded RPC calls and one DB row per request.

