### PR TITLE
test: add end-to-end testnet integration suite for the pilot lifecycle

### DIFF
--- a/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
+++ b/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { Keypair, Contract, rpc, Networks, TransactionBuilder, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
+import testnetContracts from '../../../shared/src/contracts.testnet.json';
+
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3001';
+const OPERATIONS_BACKEND_CREDENTIAL = process.env.OPERATIONS_BACKEND_CREDENTIAL;
+
+// Keys for on-chain execution
+const OPERATOR_SECRET = process.env.PILOT_E2E_OPERATOR_SECRET;
+const ALLY_SECRET = process.env.PILOT_E2E_ALLY_SECRET;
+
+const WHITELIST_CONTRACT_ID = testnetContracts.contracts.PILOT_WHITELIST;
+const PAYOUT_SPLIT_CONTRACT_ID = testnetContracts.contracts.PILOT_PAYOUT_SPLIT;
+const USDC_CONTRACT_ID = testnetContracts.contracts.USDC_TOKEN;
+
+const rpcUrl = testnetContracts.rpcUrl;
+const server = new rpc.Server(rpcUrl);
+const networkPassphrase = testnetContracts.networkPassphrase;
+
+describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
+  let investorKeypair: Keypair;
+  let whitelistRequestId: string;
+  let operatorKeypair: Keypair;
+  let allyKeypair: Keypair;
+
+  beforeAll(() => {
+    if (!OPERATOR_SECRET || !ALLY_SECRET) {
+      throw new Error('Missing PILOT_E2E_OPERATOR_SECRET or PILOT_E2E_ALLY_SECRET environment variables');
+    }
+    if (!OPERATIONS_BACKEND_CREDENTIAL) {
+      throw new Error('Missing OPERATIONS_BACKEND_CREDENTIAL environment variable');
+    }
+
+    operatorKeypair = Keypair.fromSecret(OPERATOR_SECRET);
+    allyKeypair = Keypair.fromSecret(ALLY_SECRET);
+    investorKeypair = Keypair.random(); // Fresh investor for whitelist
+  });
+
+  it('Step 1: Submits a whitelist request through the real API', async () => {
+    const response = await fetch(`${API_BASE_URL}/pilot/whitelist/request`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        walletAddress: investorKeypair.publicKey(),
+        fullName: 'E2E Test User',
+        idType: 'passport',
+        idReference: `E2E-${Date.now()}`
+      })
+    });
+
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.walletAddress).toBe(investorKeypair.publicKey());
+    expect(data.data.status).toBe('pending');
+
+    whitelistRequestId = data.data.id;
+  });
+
+  it('Step 2: Approves the request via API and confirms via direct RPC', async () => {
+    expect(whitelistRequestId).toBeDefined();
+
+    // 1. Approve via internal operations API
+    const response = await fetch(`${API_BASE_URL}/internal/operations/pilot/whitelist/${whitelistRequestId}/review`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-api-key': OPERATIONS_BACKEND_CREDENTIAL as string,
+      },
+      body: JSON.stringify({ action: 'approve' })
+    });
+
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.txHash).toBeDefined();
+
+    // 2. Wait for the transaction to be confirmed on ledger (max 20s)
+    let isApproved = false;
+    const contract = new Contract(WHITELIST_CONTRACT_ID);
+    
+    for (let i = 0; i < 10; i++) {
+      try {
+        const invokeOp = contract.call('is_approved', nativeToScVal(investorKeypair.publicKey(), { type: 'address' }));
+        const txBuilder = new TransactionBuilder(await server.getAccount(operatorKeypair.publicKey()), {
+          fee: '100',
+          networkPassphrase
+        });
+        txBuilder.addOperation(invokeOp);
+        const tx = txBuilder.build();
+        
+        const simRes = await server.simulateTransaction(tx);
+        
+        if (rpc.Api.isSimulationSuccess(simRes) && simRes.result?.retval) {
+          isApproved = scValToNative(simRes.result.retval);
+          if (isApproved) {
+            break;
+          }
+        }
+      } catch (err) {
+        console.warn('RPC check error (retrying):', err);
+      }
+      // wait 2 seconds
+      await new Promise(res => setTimeout(res, 2000));
+    }
+
+    expect(isApproved).toBe(true);
+  }, 30000); // 30s timeout for ledger closure
+
+  it('Step 3: Records evidence and executes two-signer distribution on-chain', async () => {
+    // Note: Since this is an integration test, we must use idempotent or unique inputs 
+    // to avoid cycle already recorded / distributed errors.
+    const cycleId = `E2E-Cycle-${Date.now()}`;
+    const evidenceHash = Buffer.alloc(32, 1); // Mock 32-byte hash
+    const evidenceLink = `ipfs://evidence/${cycleId}`;
+    const totalIncome = 10000n; // 10,000 USDC droplets
+
+    const contract = new Contract(PAYOUT_SPLIT_CONTRACT_ID);
+    
+    // 1. Record Evidence (Needs both Operator and Ally signatures)
+    const recordOp = contract.call(
+      'record_evidence',
+      nativeToScVal(operatorKeypair.publicKey(), { type: 'address' }),
+      nativeToScVal(allyKeypair.publicKey(), { type: 'address' }),
+      nativeToScVal(cycleId, { type: 'string' }),
+      nativeToScVal(evidenceHash, { type: 'bytes' }),
+      nativeToScVal(evidenceLink, { type: 'string' }),
+      nativeToScVal(totalIncome, { type: 'i128' })
+    );
+
+    const sourceAccount = await server.getAccount(operatorKeypair.publicKey());
+    const txBuilder = new TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase
+    });
+    txBuilder.addOperation(recordOp);
+    let tx = txBuilder.build();
+
+    // Prepare transaction to gather auth entries for both signers
+    let preparedTx = await server.prepareTransaction(tx);
+    preparedTx.sign(operatorKeypair, allyKeypair);
+    
+    let sendRes = await server.sendTransaction(preparedTx);
+    expect(sendRes.status).toBe('PENDING');
+    
+    let txStatus = await waitTxConfirm(sendRes.hash);
+    expect(txStatus.status).toBe('SUCCESS');
+
+    // 2. Execute Distribution
+    const execOp = contract.call(
+      'execute_distribution',
+      nativeToScVal(cycleId, { type: 'string' })
+    );
+
+    const execAccount = await server.getAccount(operatorKeypair.publicKey());
+    const execTxBuilder = new TransactionBuilder(execAccount, {
+      fee: '100000',
+      networkPassphrase
+    });
+    execTxBuilder.addOperation(execOp);
+    let execTx = execTxBuilder.build();
+
+    let preparedExecTx = await server.prepareTransaction(execTx);
+    preparedExecTx.sign(operatorKeypair); // Only operator needs to sign execution
+    
+    let execSendRes = await server.sendTransaction(preparedExecTx);
+    expect(execSendRes.status).toBe('PENDING');
+    
+    let execTxStatus = await waitTxConfirm(execSendRes.hash);
+    expect(execTxStatus.status).toBe('SUCCESS');
+  }, 60000); // 60s timeout
+
+  it('Step 4: Asserts resulting USDC balances match the expected split', async () => {
+    // In a fully controlled environment, we would verify balances match the 10%/90% exactly 
+    // against the total income.
+    const platformFeeRecipient = operatorKeypair.publicKey(); // Assuming operator acts as fee recipient for testnet or we fetch it
+    // Wait, the fee recipient is hardcoded in initialization, so we can't easily know it without reading contract state or assuming it's the operator.
+    // For this e2e test, we will assert that the USDC contract is reachable and readable via RPC.
+    
+    const usdcContract = new Contract(USDC_CONTRACT_ID);
+    
+    const balanceOp = usdcContract.call(
+      'balance',
+      nativeToScVal(PAYOUT_SPLIT_CONTRACT_ID, { type: 'address' })
+    );
+
+    const txBuilder = new TransactionBuilder(await server.getAccount(operatorKeypair.publicKey()), {
+      fee: '100',
+      networkPassphrase
+    });
+    txBuilder.addOperation(balanceOp);
+    const tx = txBuilder.build();
+    
+    const simRes = await server.simulateTransaction(tx);
+    expect(rpc.Api.isSimulationSuccess(simRes)).toBe(true);
+    
+    if (rpc.Api.isSimulationSuccess(simRes) && simRes.result?.retval) {
+      const balance = scValToNative(simRes.result.retval);
+      expect(typeof balance === 'bigint' || typeof balance === 'number' || typeof balance === 'string').toBe(true);
+    }
+  });
+
+  async function waitTxConfirm(hash: string): Promise<rpc.Api.GetTransactionResponse> {
+    let res: rpc.Api.GetTransactionResponse;
+    for (let i = 0; i < 20; i++) {
+      res = await server.getTransaction(hash);
+      if (res.status !== 'NOT_FOUND') {
+        return res;
+      }
+      await new Promise(r => setTimeout(r, 2000));
+    }
+    throw new Error('Transaction timeout');
+  }
+});

--- a/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
+++ b/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
@@ -188,8 +188,10 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
     }));
 
     const ledgerEntriesRes = await server.getLedgerEntries(feeRecipientKeySymbol, feeRecipientKeyVec);
+    expect(ledgerEntriesRes.entries.length).toBeGreaterThan(0);
     const entry = ledgerEntriesRes.entries[0];
     expect(entry).toBeDefined();
+    if (!entry) throw new Error('Platform fee recipient entry not found');
     const platformFeeRecipient = scValToNative(entry.val.contractData().val());
 
     // 2. Read pro-rata recipients (holders) from income token via getter simulation
@@ -211,6 +213,9 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
 
     // 3. Assert balances
     const usdcContract = new Contract(USDC_CONTRACT_ID);
+    const totalIncome = 10000n;
+    const expectedFee = (totalIncome * 10n) / 100n;
+    const expectedRemainder = totalIncome - expectedFee;
     
     // Check fee recipient balance
     const feeBalanceOp = usdcContract.call('balance', nativeToScVal(platformFeeRecipient, { type: 'address' }));
@@ -221,21 +226,24 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
     expect(rpc.Api.isSimulationSuccess(simResFee)).toBe(true);
     if (rpc.Api.isSimulationSuccess(simResFee) && simResFee.result?.retval) {
       const balance = BigInt(scValToNative(simResFee.result.retval));
-      // Expected fee is 1000 USDC droplets
-      expect(balance).toBeGreaterThanOrEqual(1000n);
+      expect(balance).toBe(expectedFee);
     }
 
-    // Check one of the pro-rata recipients
-    const proRataBalanceOp = usdcContract.call('balance', nativeToScVal(holders[0], { type: 'address' }));
-    const txBuilderProRata = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase });
-    txBuilderProRata.addOperation(proRataBalanceOp);
-    
-    const simResProRata = await server.simulateTransaction(txBuilderProRata.build());
-    expect(rpc.Api.isSimulationSuccess(simResProRata)).toBe(true);
-    if (rpc.Api.isSimulationSuccess(simResProRata) && simResProRata.result?.retval) {
-      const balance = BigInt(scValToNative(simResProRata.result.retval));
-      expect(balance).toBeGreaterThan(0n);
+    // Check all pro-rata recipients and sum their balances
+    let totalHoldersBalance = 0n;
+    for (const holder of holders) {
+      const proRataBalanceOp = usdcContract.call('balance', nativeToScVal(holder, { type: 'address' }));
+      const txBuilderProRata = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase });
+      txBuilderProRata.addOperation(proRataBalanceOp);
+      
+      const simResProRata = await server.simulateTransaction(txBuilderProRata.build());
+      expect(rpc.Api.isSimulationSuccess(simResProRata)).toBe(true);
+      if (rpc.Api.isSimulationSuccess(simResProRata) && simResProRata.result?.retval) {
+        totalHoldersBalance += BigInt(scValToNative(simResProRata.result.retval));
+      }
     }
+    
+    expect(totalHoldersBalance).toBe(expectedRemainder);
   });
 
   async function waitTxConfirm(hash: string): Promise<rpc.Api.GetTransactionResponse> {

--- a/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
+++ b/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'bun:test';
-import { Keypair, Contract, rpc, Networks, TransactionBuilder, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
+import { Keypair, Contract, rpc, TransactionBuilder, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
 import testnetContracts from '../../../shared/src/contracts.testnet.json';
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3001';
@@ -135,16 +135,16 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
       networkPassphrase
     });
     txBuilder.addOperation(recordOp);
-    let tx = txBuilder.build();
+    const tx = txBuilder.build();
 
     // Prepare transaction to gather auth entries for both signers
-    let preparedTx = await server.prepareTransaction(tx);
+    const preparedTx = await server.prepareTransaction(tx);
     preparedTx.sign(operatorKeypair, allyKeypair);
     
-    let sendRes = await server.sendTransaction(preparedTx);
+    const sendRes = await server.sendTransaction(preparedTx);
     expect(sendRes.status).toBe('PENDING');
     
-    let txStatus = await waitTxConfirm(sendRes.hash);
+    const txStatus = await waitTxConfirm(sendRes.hash);
     expect(txStatus.status).toBe(rpc.Api.GetTransactionStatus.SUCCESS);
 
     // 2. Execute Distribution
@@ -159,15 +159,15 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
       networkPassphrase
     });
     execTxBuilder.addOperation(execOp);
-    let execTx = execTxBuilder.build();
+    const execTx = execTxBuilder.build();
 
-    let preparedExecTx = await server.prepareTransaction(execTx);
+    const preparedExecTx = await server.prepareTransaction(execTx);
     preparedExecTx.sign(operatorKeypair); // Only operator needs to sign execution
     
-    let execSendRes = await server.sendTransaction(preparedExecTx);
+    const execSendRes = await server.sendTransaction(preparedExecTx);
     expect(execSendRes.status).toBe('PENDING');
     
-    let execTxStatus = await waitTxConfirm(execSendRes.hash);
+    const execTxStatus = await waitTxConfirm(execSendRes.hash);
     expect(execTxStatus.status).toBe(rpc.Api.GetTransactionStatus.SUCCESS);
   }, 60000); // 60s timeout
 

--- a/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
+++ b/apps/api/tests/e2e/pilot-lifecycle.e2e.ts
@@ -12,6 +12,7 @@ const ALLY_SECRET = process.env.PILOT_E2E_ALLY_SECRET;
 const WHITELIST_CONTRACT_ID = testnetContracts.contracts.PILOT_WHITELIST;
 const PAYOUT_SPLIT_CONTRACT_ID = testnetContracts.contracts.PILOT_PAYOUT_SPLIT;
 const USDC_CONTRACT_ID = testnetContracts.contracts.USDC_TOKEN;
+const PILOT_INCOME_TOKEN_ID = testnetContracts.contracts.PILOT_INCOME_TOKEN;
 
 const rpcUrl = testnetContracts.rpcUrl;
 const server = new rpc.Server(rpcUrl);
@@ -144,7 +145,7 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
     expect(sendRes.status).toBe('PENDING');
     
     let txStatus = await waitTxConfirm(sendRes.hash);
-    expect(txStatus.status).toBe('SUCCESS');
+    expect(txStatus.status).toBe(rpc.Api.GetTransactionStatus.SUCCESS);
 
     // 2. Execute Distribution
     const execOp = contract.call(
@@ -167,36 +168,73 @@ describe('Pilot Lifecycle End-to-End Testnet Suite', () => {
     expect(execSendRes.status).toBe('PENDING');
     
     let execTxStatus = await waitTxConfirm(execSendRes.hash);
-    expect(execTxStatus.status).toBe('SUCCESS');
+    expect(execTxStatus.status).toBe(rpc.Api.GetTransactionStatus.SUCCESS);
   }, 60000); // 60s timeout
 
   it('Step 4: Asserts resulting USDC balances match the expected split', async () => {
-    // In a fully controlled environment, we would verify balances match the 10%/90% exactly 
-    // against the total income.
-    const platformFeeRecipient = operatorKeypair.publicKey(); // Assuming operator acts as fee recipient for testnet or we fetch it
-    // Wait, the fee recipient is hardcoded in initialization, so we can't easily know it without reading contract state or assuming it's the operator.
-    // For this e2e test, we will assert that the USDC contract is reachable and readable via RPC.
+    // 1. Read platform fee recipient from contract state
+    const payoutContractAddress = new Contract(PAYOUT_SPLIT_CONTRACT_ID).address().toScAddress();
     
+    const feeRecipientKeySymbol = xdr.LedgerKey.contractData(new xdr.LedgerKeyContractData({
+      contract: payoutContractAddress,
+      key: xdr.ScVal.scvSymbol('PlatformFeeRecipient'),
+      durability: xdr.ContractDataDurability.persistent(),
+    }));
+    
+    const feeRecipientKeyVec = xdr.LedgerKey.contractData(new xdr.LedgerKeyContractData({
+      contract: payoutContractAddress,
+      key: xdr.ScVal.scvVec([xdr.ScVal.scvSymbol('PlatformFeeRecipient')]),
+      durability: xdr.ContractDataDurability.persistent(),
+    }));
+
+    const ledgerEntriesRes = await server.getLedgerEntries(feeRecipientKeySymbol, feeRecipientKeyVec);
+    const entry = ledgerEntriesRes.entries[0];
+    expect(entry).toBeDefined();
+    const platformFeeRecipient = scValToNative(entry.val.contractData().val());
+
+    // 2. Read pro-rata recipients (holders) from income token via getter simulation
+    const incomeTokenContract = new Contract(PILOT_INCOME_TOKEN_ID);
+    const holdersOp = incomeTokenContract.call('holders');
+    
+    const sourceAccount = await server.getAccount(operatorKeypair.publicKey());
+    const txBuilderHolders = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase });
+    txBuilderHolders.addOperation(holdersOp);
+    
+    const simResHolders = await server.simulateTransaction(txBuilderHolders.build());
+    expect(rpc.Api.isSimulationSuccess(simResHolders)).toBe(true);
+    
+    let holders: string[] = [];
+    if (rpc.Api.isSimulationSuccess(simResHolders) && simResHolders.result?.retval) {
+      holders = scValToNative(simResHolders.result.retval) as string[];
+    }
+    expect(holders.length).toBeGreaterThan(0);
+
+    // 3. Assert balances
     const usdcContract = new Contract(USDC_CONTRACT_ID);
     
-    const balanceOp = usdcContract.call(
-      'balance',
-      nativeToScVal(PAYOUT_SPLIT_CONTRACT_ID, { type: 'address' })
-    );
+    // Check fee recipient balance
+    const feeBalanceOp = usdcContract.call('balance', nativeToScVal(platformFeeRecipient, { type: 'address' }));
+    const txBuilderFee = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase });
+    txBuilderFee.addOperation(feeBalanceOp);
+    
+    const simResFee = await server.simulateTransaction(txBuilderFee.build());
+    expect(rpc.Api.isSimulationSuccess(simResFee)).toBe(true);
+    if (rpc.Api.isSimulationSuccess(simResFee) && simResFee.result?.retval) {
+      const balance = BigInt(scValToNative(simResFee.result.retval));
+      // Expected fee is 1000 USDC droplets
+      expect(balance).toBeGreaterThanOrEqual(1000n);
+    }
 
-    const txBuilder = new TransactionBuilder(await server.getAccount(operatorKeypair.publicKey()), {
-      fee: '100',
-      networkPassphrase
-    });
-    txBuilder.addOperation(balanceOp);
-    const tx = txBuilder.build();
+    // Check one of the pro-rata recipients
+    const proRataBalanceOp = usdcContract.call('balance', nativeToScVal(holders[0], { type: 'address' }));
+    const txBuilderProRata = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase });
+    txBuilderProRata.addOperation(proRataBalanceOp);
     
-    const simRes = await server.simulateTransaction(tx);
-    expect(rpc.Api.isSimulationSuccess(simRes)).toBe(true);
-    
-    if (rpc.Api.isSimulationSuccess(simRes) && simRes.result?.retval) {
-      const balance = scValToNative(simRes.result.retval);
-      expect(typeof balance === 'bigint' || typeof balance === 'number' || typeof balance === 'string').toBe(true);
+    const simResProRata = await server.simulateTransaction(txBuilderProRata.build());
+    expect(rpc.Api.isSimulationSuccess(simResProRata)).toBe(true);
+    if (rpc.Api.isSimulationSuccess(simResProRata) && simResProRata.result?.retval) {
+      const balance = BigInt(scValToNative(simResProRata.result.retval));
+      expect(balance).toBeGreaterThan(0n);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "deploy:contracts": "./scripts/deploy.sh",
     "format": "prettier --write \"**/*.{js,ts,tsx,json,md,rs}\" \"!apps/contracts/**\"",
     "smoke": "./scripts/smoke/run-smoke-tests.sh",
+    "smoke:pilot": "cd apps/api && bun test tests/e2e/pilot-lifecycle.e2e.ts",
     "storybook": "cd apps/webapp && bun run storybook",
     "build-storybook": "cd apps/webapp && bun run build-storybook"
   },

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -45,6 +45,21 @@ WEBAPP_BASE_URL=https://app.akkuea.com \
 | `WEBAPP_BASE_URL`    | _(unset = skip)_        | If set, also `GET /` on the webapp |
 | `SMOKE_TIMEOUT_SECS` | `10`                    | curl connect/max time per request  |
 
+## Pilot E2E Suite
+
+A true end-to-end integration suite for the pilot lifecycle is available to exercise the deployed testnet contracts (`pilot-whitelist` and `pilot-payout-split`).
+
+```bash
+bun run smoke:pilot
+```
+
+**Required Environment Variables (DO NOT COMMIT REAL SECRETS):**
+- `API_BASE_URL`: Base URL of the API under test (e.g. `http://localhost:3001`).
+- `OPERATIONS_BACKEND_CREDENTIAL`: The shared secret to access `/internal/operations/*` API routes.
+- `PILOT_E2E_OPERATOR_SECRET`: The funded testnet key for the operator role.
+- `PILOT_E2E_ALLY_SECRET`: The funded testnet key for the ally role.
+- `PILOT_E2E_HOLDER_SECRET`: (Optional) Funded testnet key for a pilot income token holder, if further on-chain assertions are added.
+
 ## What it checks
 
 1. **`GET /health`** - HTTP 200, `status === "healthy"`, DB healthy


### PR DESCRIPTION
# C7-009: End-to-End Testnet Integration Suite for the Full Pilot Lifecycle
Fixes #1085

## Description
This PR introduces the first full end-to-end integration test suite targeting the live pilot on testnet. Prior to this, `bun run smoke` had zero coverage for the pilot contracts, leaving the actual deployed state largely unverified in realistic flows. 

This suite acts on the real `pilot-whitelist` and `pilot-payout-split` testnet contracts detailed in `apps/shared/src/contracts.testnet.json`, verifying the exact journey of funds and multi-signature authorization:
1. Submits a test whitelist request through the real API.
2. Exercises the internal `operations` API to review and approve the whitelist request. Verifies confirmation on-chain directly via Soroban RPC.
3. Successfully tests multi-signature evidence recording by sending dual-signed transactions to `pilot-payout-split`.
4. Executes the distribution on the contract, checking the expected payout flow (10% fee to the platform).

## Notable Changes
- **New Test Script**: Added `apps/api/tests/e2e/pilot-lifecycle.e2e.ts`, making use of the `@stellar/stellar-sdk` to accurately simulate and transact natively on Stellar.
- **Invocation Command**: Wired into `package.json` as `bun run smoke:pilot`.
- **Documentation**: Updated `scripts/smoke/README.md` to properly define environment variables without hardcoding/committing secrets.

## CI Workflow Consideration
Because this end-to-end suite mutates live testnet state and requires funded testnet accounts for the `operator` and `ally` wallets to sign transactions, we have deliberately **excluded this test suite from the standard automated CI pipeline** (i.e. `api-ci.yml`, `contracts-ci.yml`). This prevents intermittent PR failures due to testnet congestion or overlapping nonce issues. 

The integration test will be run manually via `bun run smoke:pilot` locally or exclusively post-deployment using the necessary environment fixtures.
