### PR TITLE
feat(api): wire pilot whitelist approve/reject into audit trail

### DIFF
--- a/apps/api/src/__tests__/WhitelistService.audit.test.ts
+++ b/apps/api/src/__tests__/WhitelistService.audit.test.ts
@@ -12,7 +12,9 @@ import { describe, expect, it, mock, beforeEach } from 'bun:test';
 // Jest's jest.mock: declarations are hoisted before imports.
 // ---------------------------------------------------------------------------
 
-const mockLogAction = mock(() => Promise.resolve());
+import type { AuditLogActionInput } from '../services/AuditService';
+
+const mockLogAction = mock((_input: AuditLogActionInput) => Promise.resolve());
 
 mock.module('../services/AuditService', () => ({
   auditService: { logAction: mockLogAction },

--- a/apps/api/src/__tests__/WhitelistService.audit.test.ts
+++ b/apps/api/src/__tests__/WhitelistService.audit.test.ts
@@ -1,0 +1,232 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Unit tests for WhitelistService audit trail.
+ * Verifies that auditService.logAction is called with the correct fields when
+ * approving or rejecting a whitelist request.
+ */
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mock dependencies before importing the module under test.
+// Bun's mock.module uses the same top-level-await/static-import constraint as
+// Jest's jest.mock: declarations are hoisted before imports.
+// ---------------------------------------------------------------------------
+
+const mockLogAction = mock(() => Promise.resolve());
+
+mock.module('../services/AuditService', () => ({
+  auditService: { logAction: mockLogAction },
+}));
+
+mock.module('../services/StellarService', () => ({
+  stellarService: {
+    submitWhitelistApprove: mock(() => Promise.resolve('mock_tx_hash_unit')),
+  },
+}));
+
+mock.module('../config/contracts', () => ({
+  getPilotWhitelistContractId: () => 'mock_contract_id_unit',
+}));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const OPERATOR_WALLET = 'GOPERATOR_WALLET_12345678901234567890123456789012345678901';
+const MOCK_WALLET = 'GINVESTOR_WALLET_12345678901234567890123456789012345678901';
+const REQUEST_UUID = '550e8400-e29b-41d4-a716-446655440099';
+
+// ---------------------------------------------------------------------------
+// db mock — re-applied in beforeEach so each test starts clean.
+// ---------------------------------------------------------------------------
+
+import { db } from '../db';
+
+const pendingRequest = {
+  id: REQUEST_UUID,
+  walletAddress: MOCK_WALLET,
+  status: 'pending' as const,
+  rejectionReason: null,
+  reviewedAt: null,
+};
+
+function wirePendingRequestMock() {
+  (db as any).query = {
+    pilotWhitelistRequests: {
+      findFirst: mock(() => Promise.resolve(pendingRequest)),
+    },
+  };
+  (db as any).update = mock(() => ({
+    set: () => ({ where: () => Promise.resolve() }),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Import the module under test AFTER mocks are declared.
+// ---------------------------------------------------------------------------
+
+import { WhitelistService } from '../services/WhitelistService';
+
+process.env.STELLAR_ADMIN_PUBLIC_KEY = 'GADMIN_PUBLIC_KEY_PLACEHOLDER_00000000000000000000000';
+process.env.STELLAR_ADMIN_SECRET = 'SADMIN_SECRET_PLACEHOLDER';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WhitelistService audit trail', () => {
+  beforeEach(() => {
+    mockLogAction.mockClear();
+    wirePendingRequestMock();
+  });
+
+  describe('approveRequest', () => {
+    it('calls auditService.logAction after DB update', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      expect(mockLogAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the correct actor (operator wallet)', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.actor).toBe(OPERATOR_WALLET);
+    });
+
+    it('uses action "whitelist.approve"', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.action).toBe('whitelist.approve');
+    });
+
+    it('sets entityType to "pilot_whitelist_request"', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.entityType).toBe('pilot_whitelist_request');
+    });
+
+    it('sets entityId to the request UUID', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.entityId).toBe(REQUEST_UUID);
+    });
+
+    it('records before status as "pending"', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.beforeValue?.status).toBe('pending');
+    });
+
+    it('records after status as "approved"', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.afterValue?.status).toBe('approved');
+    });
+
+    it('includes walletAddress and txHash in metadata', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.metadata?.walletAddress).toBe(MOCK_WALLET);
+      expect(call.metadata?.txHash).toBe('mock_tx_hash_unit');
+    });
+
+    it('defaults actor to "system" when actorWallet is omitted', async () => {
+      const svc = new WhitelistService();
+      await svc.approveRequest(REQUEST_UUID);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.actor).toBe('system');
+    });
+  });
+
+  describe('rejectRequest', () => {
+    const REJECTION_REASON = 'Identity document not legible';
+
+    it('calls auditService.logAction after DB update', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      expect(mockLogAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the correct actor (operator wallet)', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.actor).toBe(OPERATOR_WALLET);
+    });
+
+    it('uses action "whitelist.reject"', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.action).toBe('whitelist.reject');
+    });
+
+    it('sets entityType to "pilot_whitelist_request"', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.entityType).toBe('pilot_whitelist_request');
+    });
+
+    it('records before status as "pending"', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.beforeValue?.status).toBe('pending');
+    });
+
+    it('records after status as "rejected"', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.afterValue?.status).toBe('rejected');
+    });
+
+    it('records rejection reason in afterValue', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.afterValue?.rejectionReason).toBe(REJECTION_REASON);
+    });
+
+    it('includes walletAddress and reason in metadata', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON, OPERATOR_WALLET);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.metadata?.walletAddress).toBe(MOCK_WALLET);
+      expect(call.metadata?.reason).toBe(REJECTION_REASON);
+    });
+
+    it('defaults actor to "system" when actorWallet is omitted', async () => {
+      const svc = new WhitelistService();
+      await svc.rejectRequest(REQUEST_UUID, REJECTION_REASON);
+
+      const call = mockLogAction.mock.calls[0]![0] as any;
+      expect(call.actor).toBe('system');
+    });
+  });
+});

--- a/apps/api/src/controllers/WhitelistController.ts
+++ b/apps/api/src/controllers/WhitelistController.ts
@@ -54,16 +54,16 @@ export class WhitelistController {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static async review(ctx: any) {
     const { id } = ctx.params;
-    const { action, reason } = ctx.body;
+    const { action, reason, actorWallet } = ctx.body;
 
     if (action === 'approve') {
-      const txHash = await whitelistService.approveRequest(id);
+      const txHash = await whitelistService.approveRequest(id, actorWallet);
       return { success: true, txHash };
     } else if (action === 'reject') {
       if (!reason) {
         throw new Error('Rejection reason is required');
       }
-      await whitelistService.rejectRequest(id, reason);
+      await whitelistService.rejectRequest(id, reason, actorWallet);
       return { success: true };
     } else {
       throw new Error('Invalid action');

--- a/apps/api/src/routes/internalOperations.ts
+++ b/apps/api/src/routes/internalOperations.ts
@@ -122,6 +122,11 @@ const reviewPropertyRoute = new Elysia()
 const reviewWhitelistSchema = t.Object({
   action: t.Union([t.Literal('approve'), t.Literal('reject')]),
   reason: t.Optional(t.String()),
+  /**
+   * The Stellar public key of the operator performing the review.
+   * Required so the audit trail can record who approved or rejected the request.
+   */
+  actorWallet: t.String({ minLength: 50, maxLength: 64 }),
 });
 
 const whitelistOperationsRoute = new Elysia({ prefix: '/pilot/whitelist' })

--- a/apps/api/src/routes/whitelist.test.ts
+++ b/apps/api/src/routes/whitelist.test.ts
@@ -1,38 +1,50 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+/**
+ * Route-level tests for whitelist endpoints.
+ *
+ * Service-level audit-trail tests live in
+ * src/__tests__/WhitelistService.audit.test.ts so that the WhitelistService
+ * mock used here doesn't shadow the real implementation.
+ */
 import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
 import { db } from '../db';
-import { whitelistService } from '../services/WhitelistService';
 import Elysia from 'elysia';
 import { whitelistRoutes } from './whitelist';
-// Mock whitelist service
-mock.module('../services/WhitelistService', () => {
-  return {
-    whitelistService: {
-      approveRequest: mock(() => Promise.resolve('mock_tx_hash')),
-      rejectRequest: mock(() => Promise.resolve()),
-    },
-  };
-});
 
-// Setup a minimal app for testing routes
+// Mock whitelist service so route tests are isolated from the real service.
+mock.module('../services/WhitelistService', () => ({
+  whitelistService: {
+    approveRequest: mock(() => Promise.resolve('mock_tx_hash')),
+    rejectRequest: mock(() => Promise.resolve()),
+  },
+}));
+
+// Setup a minimal app for testing routes.
 import { internalOperationsRoutes } from './internalOperations';
+import { whitelistService } from '../services/WhitelistService';
+
 const testApp = new Elysia().use(whitelistRoutes).use(internalOperationsRoutes);
 
 process.env.OPERATIONS_BACKEND_CREDENTIAL = 'test-secret';
 
+// ---------------------------------------------------------------------------
+// Helper constants
+// ---------------------------------------------------------------------------
+const MOCK_WALLET = 'GDK7PZZY4QJ6GZ46X34PXZY2C46Y7PZZY4QJ6GZ46X34PXZY2C46Y7PZ';
+const OPERATOR_WALLET = 'GOPERATOR_WALLET_123456789012345678901234567890123456789012';
+
+// ---------------------------------------------------------------------------
+// Route-level tests
+// ---------------------------------------------------------------------------
 describe('Whitelist API Routes', () => {
-  const mockWallet = 'GDK7PZZY4QJ6GZ46X34PXZY2C46Y7PZZY4QJ6GZ46X34PXZY2C46Y7PZ';
   let mockDbStore: any[] = [];
 
   beforeEach(() => {
     mockDbStore = [];
 
-    // Mock db queries
     (db as any).query = {
       pilotWhitelistRequests: {
-        findFirst: mock(async ({ where }) => {
-          return mockDbStore.find((r) => r.walletAddress === mockWallet); // Simplified mock
-        }),
+        findFirst: mock(async () => mockDbStore.find((r) => r.walletAddress === MOCK_WALLET)),
         findMany: mock(async () => mockDbStore),
       },
     };
@@ -50,9 +62,7 @@ describe('Whitelist API Routes', () => {
     (db as any).update = mock(() => ({
       set: (val: any) => ({
         where: async () => {
-          if (mockDbStore.length > 0) {
-            Object.assign(mockDbStore[0], val);
-          }
+          if (mockDbStore.length > 0) Object.assign(mockDbStore[0], val);
         },
       }),
     }));
@@ -68,7 +78,7 @@ describe('Whitelist API Routes', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          walletAddress: mockWallet,
+          walletAddress: MOCK_WALLET,
           fullName: 'Test User',
           idType: 'passport',
           idReference: 'A1234567',
@@ -77,27 +87,22 @@ describe('Whitelist API Routes', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.status).toBe(200);
     const result = await response.json();
     expect(result.success).toBe(true);
-    expect(result.data.walletAddress).toBe(mockWallet);
+    expect(result.data.walletAddress).toBe(MOCK_WALLET);
     expect(result.data.status).toBe('pending');
     expect(mockDbStore.length).toBe(1);
   });
 
   it('should fail to submit a duplicate request', async () => {
-    mockDbStore.push({
-      id: 'existing_id',
-      walletAddress: mockWallet,
-      status: 'pending',
-    });
+    mockDbStore.push({ id: 'existing_id', walletAddress: MOCK_WALLET, status: 'pending' });
 
     const response = await testApp.handle(
       new Request('http://localhost/pilot/whitelist/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          walletAddress: mockWallet,
+          walletAddress: MOCK_WALLET,
           fullName: 'Test User 2',
           idType: 'national_id',
           idReference: 'B7654321',
@@ -109,11 +114,7 @@ describe('Whitelist API Routes', () => {
   });
 
   it('should fetch pending requests', async () => {
-    mockDbStore.push({
-      id: 'pending_id',
-      walletAddress: mockWallet,
-      status: 'pending',
-    });
+    mockDbStore.push({ id: 'pending_id', walletAddress: MOCK_WALLET, status: 'pending' });
 
     const response = await testApp.handle(
       new Request('http://localhost/internal/operations/pilot/whitelist/pending', {
@@ -128,21 +129,35 @@ describe('Whitelist API Routes', () => {
     expect(result.data.length).toBe(1);
   });
 
-  it('should review a request', async () => {
+  it('should review a request and pass actorWallet to the service', async () => {
     const response = await testApp.handle(
       new Request('http://localhost/internal/operations/pilot/whitelist/req_id_1/review', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-internal-api-key': 'test-secret' },
-        body: JSON.stringify({ action: 'approve' }),
+        body: JSON.stringify({
+          action: 'approve',
+          actorWallet: OPERATOR_WALLET,
+        }),
       }),
     );
 
-    const status = response.status;
+    expect(response.status).toBe(200);
     const result = await response.json();
-    console.log('REVIEW RESPONSE:', status, result);
-    expect(status).toBe(200);
     expect(result.success).toBe(true);
     expect(result.txHash).toBe('mock_tx_hash');
-    expect(whitelistService.approveRequest).toHaveBeenCalledWith('req_id_1');
+    expect(whitelistService.approveRequest).toHaveBeenCalledWith('req_id_1', OPERATOR_WALLET);
+  });
+
+  it('should reject a review request with missing actorWallet', async () => {
+    const response = await testApp.handle(
+      new Request('http://localhost/internal/operations/pilot/whitelist/req_id_1/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-internal-api-key': 'test-secret' },
+        body: JSON.stringify({ action: 'approve' }), // actorWallet intentionally omitted
+      }),
+    );
+
+    // Elysia returns 422 (Unprocessable Entity) for body validation failures.
+    expect([400, 422]).toContain(response.status);
   });
 });

--- a/apps/api/src/services/WhitelistService.ts
+++ b/apps/api/src/services/WhitelistService.ts
@@ -3,12 +3,19 @@ import { db } from '../db';
 import { pilotWhitelistRequests } from '../db/schema/pilotWhitelist';
 import { getPilotWhitelistContractId } from '../config/contracts';
 import { stellarService } from './StellarService';
+import { auditService } from './AuditService';
 
 export class WhitelistService {
   /**
    * Approves a whitelist request in the database and submits the transaction to the C6-001 contract.
+   *
+   * @param requestId - UUID of the pilot_whitelist_requests row to approve.
+   * @param actorWallet - Stellar public key of the operator performing the action.
+   *   Recorded in the audit trail so there is an accountable identity for every approval.
+   *   Falls back to 'system' if not provided (e.g. automated flows), though the review
+   *   route requires it explicitly.
    */
-  async approveRequest(requestId: string): Promise<string> {
+  async approveRequest(requestId: string, actorWallet = 'system'): Promise<string> {
     const request = await db.query.pilotWhitelistRequests.findFirst({
       where: eq(pilotWhitelistRequests.id, requestId),
     });
@@ -36,6 +43,11 @@ export class WhitelistService {
       request.walletAddress,
     );
 
+    const beforeValue = {
+      status: request.status,
+      reviewedAt: request.reviewedAt,
+    };
+
     // Update database status
     await db
       .update(pilotWhitelistRequests)
@@ -45,10 +57,36 @@ export class WhitelistService {
       })
       .where(eq(pilotWhitelistRequests.id, requestId));
 
+    const afterValue = {
+      status: 'approved',
+      reviewedAt: new Date(),
+    };
+
+    await auditService.logAction({
+      actor: actorWallet,
+      action: 'whitelist.approve',
+      entityType: 'pilot_whitelist_request',
+      entityId: requestId,
+      beforeValue: beforeValue as unknown as Record<string, unknown>,
+      afterValue: afterValue as unknown as Record<string, unknown>,
+      metadata: {
+        walletAddress: request.walletAddress,
+        txHash,
+      },
+    });
+
     return txHash;
   }
 
-  async rejectRequest(requestId: string, reason: string): Promise<void> {
+  /**
+   * Rejects a whitelist request, recording the reason in the database and the audit trail.
+   *
+   * @param requestId - UUID of the pilot_whitelist_requests row to reject.
+   * @param reason - Human-readable rejection reason provided by the operator.
+   * @param actorWallet - Stellar public key of the operator performing the action.
+   *   Falls back to 'system' if not provided.
+   */
+  async rejectRequest(requestId: string, reason: string, actorWallet = 'system'): Promise<void> {
     const request = await db.query.pilotWhitelistRequests.findFirst({
       where: eq(pilotWhitelistRequests.id, requestId),
     });
@@ -61,6 +99,12 @@ export class WhitelistService {
       throw new Error('Cannot reject an already approved request');
     }
 
+    const beforeValue = {
+      status: request.status,
+      rejectionReason: request.rejectionReason,
+      reviewedAt: request.reviewedAt,
+    };
+
     await db
       .update(pilotWhitelistRequests)
       .set({
@@ -69,6 +113,25 @@ export class WhitelistService {
         reviewedAt: new Date(),
       })
       .where(eq(pilotWhitelistRequests.id, requestId));
+
+    const afterValue = {
+      status: 'rejected',
+      rejectionReason: reason,
+      reviewedAt: new Date(),
+    };
+
+    await auditService.logAction({
+      actor: actorWallet,
+      action: 'whitelist.reject',
+      entityType: 'pilot_whitelist_request',
+      entityId: requestId,
+      beforeValue: beforeValue as unknown as Record<string, unknown>,
+      afterValue: afterValue as unknown as Record<string, unknown>,
+      metadata: {
+        walletAddress: request.walletAddress,
+        reason,
+      },
+    });
   }
 }
 

--- a/docs/operations/pilot-audit-trail.md
+++ b/docs/operations/pilot-audit-trail.md
@@ -1,0 +1,86 @@
+# Pilot Operator Actions — Audit Trail Extension Point
+
+**Relates to**: C7-008, issue #1084  
+**Last updated**: 2026-08-26
+
+---
+
+## What exists today
+
+`WhitelistService.approveRequest` and `WhitelistService.rejectRequest` both call
+`auditService.logAction(...)` immediately after the database update.  The pattern is identical to
+the one already used in `KYCController.verifyDocument` and
+`OperationalPropertyController.applyReviewAction` — no second audit-logging mechanism was
+introduced.
+
+Audit entries written by these two paths use:
+
+| Field        | approve                   | reject                    |
+|--------------|---------------------------|---------------------------|
+| `actor`      | operator's Stellar wallet | operator's Stellar wallet |
+| `action`     | `whitelist.approve`       | `whitelist.reject`        |
+| `entityType` | `pilot_whitelist_request` | `pilot_whitelist_request` |
+| `entityId`   | UUID of the row           | UUID of the row           |
+| `beforeValue`| `{ status, reviewedAt }`  | `{ status, rejectionReason, reviewedAt }` |
+| `afterValue` | `{ status: 'approved', reviewedAt }` | `{ status: 'rejected', rejectionReason, reviewedAt }` |
+| `metadata`   | `{ walletAddress, txHash }` | `{ walletAddress, reason }` |
+
+The operator wallet is supplied via the `actorWallet` field in the request body (required,
+50–64 characters), enforced by `reviewWhitelistSchema` in `routes/internalOperations.ts`.
+
+---
+
+## How to wire a future pilot operator action into the same trail
+
+The following three-step pattern applies to any new operator action in the pilot (e.g. evidence
+approval, distribution trigger — see #1061 / C6-002):
+
+### 1. Add `actorWallet` to the route body schema
+
+In `routes/internalOperations.ts`, add `actorWallet: t.String({ minLength: 50, maxLength: 64 })`
+to the Elysia `t.Object` schema for the new route.  This enforces the field at the HTTP layer and
+makes it available to the controller via `ctx.body.actorWallet`.
+
+### 2. Receive `actorWallet` in the service method
+
+Add `actorWallet = 'system'` as a parameter to the service method responsible for the DB update.
+The `'system'` default exists only for automated/internal calls that have no operator identity;
+the review route always provides it explicitly.
+
+### 3. Call `auditService.logAction(...)` after the DB update
+
+```typescript
+import { auditService } from './AuditService';
+
+// After updating the database row:
+await auditService.logAction({
+  actor: actorWallet,
+  action: 'pilot.<your_action>',          // namespaced, e.g. pilot.evidence_approve
+  entityType: '<your_entity_type>',        // e.g. pilot_distribution_event
+  entityId: recordId,                      // UUID of the DB row
+  beforeValue: { /* snapshot before */ },
+  afterValue:  { /* snapshot after  */ },
+  metadata: { /* any extra context   */ },
+});
+```
+
+Use the same namespace convention as the existing whitelist actions (`whitelist.approve`,
+`whitelist.reject`) so audit-log queries can filter by action prefix.
+
+### No new infrastructure needed
+
+`AuditService`, `AuditLogRepository`, and the `audit_log` table are already in place.  Adding a
+new action requires only the three steps above — no schema migration, no new service class, no
+new repository.
+
+---
+
+## Querying pilot audit entries
+
+```
+GET /api/v1/admin/audit-log?action=whitelist.approve
+GET /api/v1/admin/audit-log?action=whitelist.reject
+GET /api/v1/admin/audit-log?actor=<operator_wallet>
+```
+
+Future pilot actions will be queryable via their own `action` value once wired in.


### PR DESCRIPTION
## Summary

Closes #1084.

Connects `WhitelistController`'s approve and reject actions to the project's existing `AuditService` / `AuditLogRepository` infrastructure. No second audit-logging mechanism is introduced — the same `auditService.logAction()` pattern already used in `KYCController.verifyDocument` and `OperationalPropertyController.applyReviewAction` is reused.

## Changes

**`routes/internalOperations.ts`**
- Added required `actorWallet` field (50–64 chars) to `reviewWhitelistSchema`, matching the property review route's pattern

**`services/WhitelistService.ts`**
- Added `actorWallet` parameter to `approveRequest` and `rejectRequest` (defaults to `'system'` for automated callers)
- Captures `beforeValue` snapshot before each DB update
- Calls `auditService.logAction()` after each DB update with: `actor`, `action` (`whitelist.approve` / `whitelist.reject`), `entityType` (`pilot_whitelist_request`), `entityId`, `beforeValue`, `afterValue`, `metadata` (`walletAddress` + `txHash`/`reason`)

**`controllers/WhitelistController.ts`**
- Extracts `actorWallet` from `ctx.body` and passes it through to both service methods

**`routes/whitelist.test.ts`**
- Updated existing review test to pass `actorWallet` and assert it is forwarded to the service
- Added test asserting that a missing `actorWallet` is rejected at the schema layer (400/422)

**`src/__tests__/WhitelistService.audit.test.ts`** (new)
- 18 service-level unit tests covering approve and reject paths: verifies `auditService.logAction` is called with the correct `actor`, `action`, `entityType`, `entityId`, `beforeValue`, `afterValue`, `metadata`, and the `'system'` fallback when no wallet is provided

**`docs/operations/pilot-audit-trail.md`** (new)
- Documents the three-step extension point for future pilot operator actions (evidence approval, distribution trigger — #1061 / C6-002): add `actorWallet` to route schema → receive it in service → call `auditService.logAction()` after DB update

## Tests

Full suite: **343 pass, 0 fail, 106 skip** (all skips are pre-existing DB/network-integration tests).
New tests: **23 pass** across `whitelist.test.ts` and `WhitelistService.audit.test.ts`.