### PR TITLE
feat(webapp): add playwright e2e suite for pilot whitelist flow

### DIFF
--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -78,16 +78,6 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
 
-      # - name: E2E tests
-      #   run: |
-      #     cd apps/webapp
-
-      #     # Install Playwright
-      #     bunx playwright install
-
-      #     # Run E2E tests
-      #     echo "Skipping E2E tests - no test:e2e script defined"
-
       - name: Analyze bundle size
         run: |
           cd apps/webapp
@@ -183,3 +173,62 @@ jobs:
               echo "Warning: No CSP configuration found"
             fi
           fi
+
+  e2e-tests:
+    name: Playwright E2E Tests
+    runs-on: ubuntu-latest
+
+    # Deliberately independent of build-and-test: this suite boots its own
+    # dev server and mocks every API call (see apps/webapp/e2e), so it does
+    # not need that job's build output, and a failure or slowdown here must
+    # never block or delay the unit-test job's own result.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build shared library (required for webapp)
+        run: |
+          cd apps/shared
+          bun run build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('apps/webapp/bun.lock', '**/bun.lock') }}
+
+      - name: Install Playwright's Chromium browser
+        run: |
+          cd apps/webapp
+          bunx playwright install --with-deps chromium
+
+      - name: Run Playwright e2e suite
+        run: |
+          cd apps/webapp
+          bun run test:e2e
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/webapp/playwright-report/
+          retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,9 @@ bun run test
 cd apps/api && bun test
 cd apps/webapp && bun test
 cd apps/contracts && cargo test
+
+# Run the webapp's Playwright e2e suite (see apps/webapp/README.md#testing)
+cd apps/webapp && bun run test:e2e
 ```
 
 ### What makes a good test
@@ -373,7 +376,7 @@ Akkuea runs five GitHub Actions workflows on every pull request. **All five must
 | ------------------ | --------------------------------------------------------------------------------------------------------- |
 | `monorepo-ci.yml`  | Workspace integrity, dependency consistency, cross-workspace type compatibility, security compliance scan |
 | `api-ci.yml`       | API lint, type-check, unit and integration tests, build                                                   |
-| `webapp-ci.yml`    | Webapp lint, type-check, unit tests, build                                                                |
+| `webapp-ci.yml`    | Webapp lint, type-check, unit tests, build, Playwright e2e tests (isolated job)                            |
 | `shared-ci.yml`    | Shared library lint, type-check, build                                                                    |
 | `contracts-ci.yml` | Rust format (`rustfmt`), linting (`cargo clippy`), unit tests, WASM build                                 |
 

--- a/apps/webapp/.gitignore
+++ b/apps/webapp/.gitignore
@@ -13,6 +13,12 @@
 # testing
 /coverage
 
+# playwright e2e
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
+
 # next.js
 /.next/
 /out/

--- a/apps/webapp/README.md
+++ b/apps/webapp/README.md
@@ -22,6 +22,67 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Testing
+
+Unit tests (`bun test`, colocated with the source they cover):
+
+```bash
+bun test
+```
+
+### End-to-end tests (Playwright)
+
+`e2e/` holds the Playwright suite covering the pilot whitelist onboarding and
+review flow (`WhitelistOnboardingForm` and `WhitelistReviewQueue`). It is
+isolated from the unit test suite above: it boots a real Next.js dev server
+and drives it in a real browser, but every whitelist API call is mocked at
+the network layer (see `e2e/fixtures/whitelist-api.ts`), so it needs no
+backend process and never touches a testnet transaction.
+
+Run it locally with a single command:
+
+```bash
+bun run test:e2e
+```
+
+This installs nothing by itself; the first time you run it, install
+Playwright's browser binary once with:
+
+```bash
+bunx playwright install chromium
+```
+
+Other useful variants:
+
+```bash
+bun run test:e2e:ui       # interactive UI mode, step through each test
+bun run test:e2e:report   # open the HTML report from the last run
+```
+
+`bun run test:e2e` boots its own dev server on port 3100 (see
+`playwright.config.ts`) and shuts it down when the run finishes. If that
+fails to start in your shell (for example, some Windows setups have trouble
+with Playwright spawning a `bun run` script directly), start it yourself in
+one terminal and point Playwright at it in another:
+
+```bash
+# terminal 1
+bun run dev:e2e
+
+# terminal 2
+PLAYWRIGHT_SKIP_WEBSERVER=1 bun run test:e2e
+```
+
+**Seam for a real environment**: this suite intentionally only exercises the
+mocked path. To point the same specs at a real, seeded backend later, set
+`PLAYWRIGHT_BASE_URL` to that deployment's URL and `PLAYWRIGHT_SKIP_WEBSERVER=1`,
+then remove or make conditional the `page.route()` mocks in the specs that
+would otherwise shadow real network calls.
+
+In CI, this suite runs as its own `e2e-tests` job in `webapp-ci.yml`,
+independent of the unit-test job, so it can never slow that job down or make
+it flaky.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/webapp/bunfig.toml
+++ b/apps/webapp/bunfig.toml
@@ -1,0 +1,10 @@
+# Scopes `bun test`'s file discovery to unit tests under `src/`.
+#
+# Without this, `bun test` recursively picks up every `*.spec.ts` in the
+# project, including the Playwright specs under `e2e/`. Those are written for
+# Playwright's own runner (`playwright test`, see playwright.config.ts) and
+# import `test`/`expect` from `@playwright/test`, not `bun:test`; bun trying
+# to load them crashes with "Playwright Test did not expect test.describe()
+# to be called here" and fails the whole unit-test run.
+[test]
+root = "./src"

--- a/apps/webapp/e2e/fixtures/wallet.ts
+++ b/apps/webapp/e2e/fixtures/wallet.ts
@@ -1,0 +1,47 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * localStorage key the auth Zustand store (see
+ * `src/components/auth/store/data/slices/authentication.slice.ts`) persists
+ * wallet connection state under.
+ */
+const WALLET_STORAGE_KEY = "akkuea-wallet-storage";
+
+export const MOCK_OPERATOR_WALLET =
+  "GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAX2";
+
+/**
+ * Seeds the persisted wallet store in `localStorage` so the app believes a
+ * Stellar wallet is already connected on first render, without driving a real
+ * wallet extension (no browser extension is available in a headless CI
+ * browser, and the pilot flow doesn't warrant standing up one just for this
+ * suite).
+ *
+ * Must be called before `page.goto()`: `addInitScript` only affects
+ * navigations that happen after it's registered.
+ */
+export async function mockConnectedWallet(
+  page: Page,
+  address = MOCK_OPERATOR_WALLET,
+): Promise<void> {
+  await page.addInitScript(
+    ({ key, addr }) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({
+          state: {
+            address: addr,
+            balance: null,
+            balanceStatus: null,
+            balanceError: null,
+            isConnected: true,
+            selectedWalletId: "stellar-wallets-kit",
+            network: "testnet",
+          },
+          version: 2,
+        }),
+      );
+    },
+    { key: WALLET_STORAGE_KEY, addr: address },
+  );
+}

--- a/apps/webapp/e2e/fixtures/whitelist-api.ts
+++ b/apps/webapp/e2e/fixtures/whitelist-api.ts
@@ -1,0 +1,164 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Mocked API layer for the pilot whitelist onboarding/review flow.
+ *
+ * `WhitelistOnboardingForm` calls the external API directly
+ * (`NEXT_PUBLIC_API_URL/pilot/whitelist/...`), while `WhitelistReviewQueue`
+ * goes through the Next.js admin operations proxy
+ * (`/api/admin/operations/pilot/whitelist/...`). Both paths are matched by
+ * pathname suffix here so one set of helpers covers both components
+ * regardless of which host served the request.
+ *
+ * These mocks fully replace the backend: nothing in this suite talks to a
+ * real API server or a testnet transaction. To point these specs at a real
+ * environment instead, remove the relevant `page.route()` call in a given
+ * test and provide a live, seeded backend at the configured API URL.
+ */
+
+export type WhitelistStatus = "none" | "pending" | "approved" | "rejected";
+
+export interface WhitelistRequestFixture {
+  id: string;
+  walletAddress: string;
+  fullName: string;
+  idType: string;
+  idReference: string;
+  status: string;
+  createdAt: string;
+}
+
+export function buildWhitelistRequest(
+  overrides: Partial<WhitelistRequestFixture> = {},
+): WhitelistRequestFixture {
+  return {
+    id: "req-e2e-001",
+    walletAddress: "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBDQCQZVQQ6BRVV12BKHA",
+    fullName: "Maria Santos",
+    idType: "passport",
+    idReference: "P-84721934",
+    status: "pending",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** Mocks `GET /pilot/whitelist/status/:walletAddress`, used by the onboarding form. */
+export async function mockWhitelistStatus(
+  page: Page,
+  options: {
+    status?: WhitelistStatus;
+    rejectionReason?: string;
+    delayMs?: number;
+  } = {},
+): Promise<void> {
+  const { status = "none", rejectionReason, delayMs = 0 } = options;
+
+  await page.route(
+    (url) => /\/pilot\/whitelist\/status\//.test(url.pathname),
+    async (route) => {
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, status, rejectionReason }),
+      });
+    },
+  );
+}
+
+/** Mocks `POST /pilot/whitelist/request`, used to submit the onboarding form. */
+export async function mockWhitelistSubmit(
+  page: Page,
+  options: { fail?: boolean; message?: string } = {},
+): Promise<void> {
+  const { fail = false, message = "Failed to submit whitelist request" } =
+    options;
+
+  await page.route(
+    (url) => /\/pilot\/whitelist\/request$/.test(url.pathname),
+    async (route) => {
+      if (fail) {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ success: false, message }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { id: "new-e2e-req", status: "pending" },
+        }),
+      });
+    },
+  );
+}
+
+/**
+ * Mocks the pending-requests list and the approve/reject action used by
+ * `WhitelistReviewQueue`, keeping them consistent with each other: an
+ * approve or reject removes the request from the list the next time it's
+ * fetched, the same way the real API would after a review decision.
+ */
+export async function mockWhitelistQueue(
+  page: Page,
+  initialRequests: WhitelistRequestFixture[],
+  options: { delayMs?: number } = {},
+): Promise<{ getRequests: () => WhitelistRequestFixture[] }> {
+  let requests = [...initialRequests];
+  const { delayMs = 0 } = options;
+
+  await page.route(
+    (url) => /\/pilot\/whitelist\/pending$/.test(url.pathname),
+    async (route) => {
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: requests }),
+      });
+    },
+  );
+
+  await page.route(
+    (url) => /\/pilot\/whitelist\/[^/]+\/review$/.test(url.pathname),
+    (route) => {
+      const match = /\/pilot\/whitelist\/([^/]+)\/review$/.exec(
+        new URL(route.request().url()).pathname,
+      );
+      const id = match?.[1];
+      requests = requests.filter((r) => r.id !== id);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, txHash: "mock_tx_hash_e2e" }),
+      });
+    },
+  );
+
+  return { getRequests: () => requests };
+}
+
+/** Mocks `GET /pilot/whitelist/pending` returning an error, for the queue's error state. */
+export async function mockWhitelistQueueError(page: Page): Promise<void> {
+  await page.route(
+    (url) => /\/pilot\/whitelist\/pending$/.test(url.pathname),
+    (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          message: "Internal server error",
+        }),
+      }),
+  );
+}

--- a/apps/webapp/e2e/global-setup.ts
+++ b/apps/webapp/e2e/global-setup.ts
@@ -1,0 +1,35 @@
+import type { FullConfig } from "@playwright/test";
+
+/**
+ * Warms both pilot routes before any spec runs.
+ *
+ * The e2e web server runs Next's webpack dev server (see `dev:e2e` in
+ * package.json), which compiles each route lazily on its first request. That
+ * first compile can take far longer than a normal per-test timeout, so
+ * without a warm-up the first test to touch a given route flakes on
+ * `page.goto` while later tests against the same route pass instantly.
+ * Hitting each route once here, before Playwright's per-test clock starts,
+ * keeps every actual test fast and deterministic regardless of run order.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL = config.projects[0]?.use.baseURL;
+  if (!baseURL) return;
+
+  const routes = ["/en/pilot/onboarding", "/en/pilot/review/whitelist"];
+  const deadline = Date.now() + 90_000;
+
+  for (const route of routes) {
+    for (;;) {
+      try {
+        const res = await fetch(new URL(route, baseURL));
+        if (res.ok) break;
+      } catch {
+        // Server may not be accepting connections yet; keep retrying.
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out warming up route ${route} for e2e tests`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+}

--- a/apps/webapp/e2e/whitelist-onboarding.spec.ts
+++ b/apps/webapp/e2e/whitelist-onboarding.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+import { mockConnectedWallet } from "./fixtures/wallet";
+import {
+  mockWhitelistStatus,
+  mockWhitelistSubmit,
+} from "./fixtures/whitelist-api";
+
+/**
+ * Covers the four states `WhitelistOnboardingForm` must handle: loading,
+ * error, success, and disconnected-wallet.
+ */
+test.describe("WhitelistOnboardingForm", () => {
+  test("disconnected wallet: blocks progress past the wallet step until a wallet is connected", async ({
+    page,
+  }) => {
+    // No mockConnectedWallet() call: the app starts with no wallet connected.
+    await mockWhitelistStatus(page, { status: "none" });
+
+    await page.goto("/en/pilot/onboarding");
+
+    await expect(page.getByText("No Whitelist Application")).toBeVisible();
+
+    await page.getByRole("button", { name: "Start Application" }).click();
+
+    await page.getByPlaceholder("John Doe").fill("Jane Tester");
+    await page.getByPlaceholder("Document Number").fill("P-00000000");
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Connect Your Wallet" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Connect Wallet" }),
+    ).toBeVisible();
+
+    // The stepper's own "Continue" is disabled while disconnected, so the
+    // form can't be pushed into the review step without a wallet.
+    await expect(page.getByRole("button", { name: "Continue" })).toBeDisabled();
+  });
+
+  test("loading: shows a loading indicator while the whitelist status is being checked", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistStatus(page, { status: "none", delayMs: 1000 });
+
+    await page.goto("/en/pilot/onboarding");
+
+    await expect(
+      page.getByText("Loading your whitelist status..."),
+    ).toBeVisible();
+    await expect(page.getByText("Loading your whitelist status...")).toBeHidden(
+      { timeout: 5000 },
+    );
+
+    await expect(page.getByText("No Whitelist Application")).toBeVisible();
+  });
+
+  test("error: shows an error message when the submission fails", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistStatus(page, { status: "none" });
+    await mockWhitelistSubmit(page, {
+      fail: true,
+      message: "Server error, please try again later.",
+    });
+
+    await page.goto("/en/pilot/onboarding");
+    await page.getByRole("button", { name: "Start Application" }).click();
+
+    await page.getByPlaceholder("John Doe").fill("Jane Tester");
+    await page.getByPlaceholder("Document Number").fill("P-00000000");
+    // With the wallet already connected, submitting step 1 auto-advances
+    // past the wallet-connection step straight to the review step.
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Submit Request" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Submit Request" }).click();
+
+    // apiClient retries 5xx responses (up to 3 times with backoff) before
+    // surfacing the failure, so give this assertion more room than the
+    // suite's default.
+    await expect(
+      page.getByText("Server error, please try again later."),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("success: submits the application and shows the pending-review state", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistStatus(page, { status: "none" });
+    await mockWhitelistSubmit(page, { fail: false });
+
+    await page.goto("/en/pilot/onboarding");
+    await page.getByRole("button", { name: "Start Application" }).click();
+
+    await page.getByPlaceholder("John Doe").fill("Jane Tester");
+    await page.getByPlaceholder("Document Number").fill("P-00000000");
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(page.getByText("Jane Tester")).toBeVisible();
+    await page.getByRole("button", { name: "Submit Request" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Review Pending" }),
+    ).toBeVisible();
+  });
+});

--- a/apps/webapp/e2e/whitelist-review-queue.spec.ts
+++ b/apps/webapp/e2e/whitelist-review-queue.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "@playwright/test";
+import { mockConnectedWallet } from "./fixtures/wallet";
+import {
+  buildWhitelistRequest,
+  mockWhitelistQueue,
+  mockWhitelistQueueError,
+} from "./fixtures/whitelist-api";
+
+/**
+ * Covers `WhitelistReviewQueue`'s approve and reject actions, plus its
+ * loading and error states as an operator navigating to the queue would
+ * encounter them.
+ */
+test.describe("WhitelistReviewQueue", () => {
+  test("loading: shows a loading indicator while requests are being fetched", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistQueue(page, [buildWhitelistRequest()], {
+      delayMs: 1000,
+    });
+
+    await page.goto("/en/pilot/review/whitelist");
+
+    await expect(page.getByText("Loading pending requests...")).toBeVisible();
+    await expect(page.getByText("Maria Santos")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("error: shows a retry fallback when the queue fails to load", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistQueueError(page);
+
+    await page.goto("/en/pilot/review/whitelist");
+
+    await expect(
+      page.getByText("Failed to load whitelist queue"),
+    ).toBeVisible();
+
+    // Retry re-runs the same (still failing) fetch; the fallback should stay
+    // visible rather than the UI getting stuck in an inconsistent state.
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(
+      page.getByText("Failed to load whitelist queue"),
+    ).toBeVisible();
+  });
+
+  test("approve: approving a request removes it from the pending queue", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistQueue(page, [buildWhitelistRequest()]);
+
+    await page.goto("/en/pilot/review/whitelist");
+
+    await expect(page.getByText("Maria Santos")).toBeVisible();
+    await page.getByRole("button", { name: "Review" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Approve & Whitelist" }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText("No Pending Requests")).toBeVisible();
+  });
+
+  test("reject: requires a reason, then removes the request once rejected", async ({
+    page,
+  }) => {
+    await mockConnectedWallet(page);
+    await mockWhitelistQueue(page, [buildWhitelistRequest()]);
+
+    await page.goto("/en/pilot/review/whitelist");
+
+    await page.getByRole("button", { name: "Review" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const rejectButton = dialog.getByRole("button", {
+      name: "Reject Request",
+    });
+    await expect(rejectButton).toBeDisabled();
+
+    await dialog
+      .getByPlaceholder("Required if rejecting...")
+      .fill("Unable to verify the submitted ID reference.");
+    await expect(rejectButton).toBeEnabled();
+    await rejectButton.click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText("No Pending Requests")).toBeVisible();
+  });
+});

--- a/apps/webapp/messages/en.json
+++ b/apps/webapp/messages/en.json
@@ -201,5 +201,8 @@
     "retry": "Retry",
     "readAtNote": "Read live from Stellar {network}. Treasury account: {account}.",
     "noAccountConfigured": "not configured"
+  },
+  "PilotAdmin": {
+    "title": "Admin"
   }
 }

--- a/apps/webapp/messages/es.json
+++ b/apps/webapp/messages/es.json
@@ -201,5 +201,8 @@
     "retry": "Reintentar",
     "readAtNote": "Leído en vivo de Stellar {network}. Cuenta de tesorería: {account}.",
     "noAccountConfigured": "sin configurar"
+  },
+  "PilotAdmin": {
+    "title": "Administrador"
   }
 }

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:e2e": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
@@ -11,6 +12,9 @@
     "test": "NEXT_PUBLIC_API_URL=http://localhost:3001 bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
     "clean": "rm -rf .next",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
@@ -38,6 +42,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@storybook/addon-actions": "^8.6.0",
     "@storybook/addon-essentials": "^8.6.0",
     "@storybook/addon-interactions": "^8.6.0",

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -1,0 +1,75 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for the pilot whitelist onboarding/review e2e suite.
+ *
+ * This suite is deliberately isolated from `bun test` (unit tests): it lives in
+ * `e2e/`, runs against a real Next.js dev server, and mocks every whitelist API
+ * call at the browser network layer via `page.route()` (see `e2e/mocks`). No
+ * backend process or testnet transaction is required to run it.
+ *
+ * Seam for pointing this suite at a real environment later: set
+ * `PLAYWRIGHT_BASE_URL` to a running deployment and `PLAYWRIGHT_SKIP_WEBSERVER=1`
+ * so Playwright reuses it instead of booting a local dev server. The specs
+ * would then need their `page.route()` mocks removed or made conditional; that
+ * change is intentionally left for whoever takes on that later, real-environment
+ * pass, this suite's job is the fast, deterministic mocked path.
+ */
+
+const PORT = process.env.PLAYWRIGHT_PORT ?? "3100";
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Warms both pilot routes once before any spec runs; see the file for why.
+  globalSetup: require.resolve("./e2e/global-setup"),
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["html", { open: "never" }]],
+  // Generous relative to a typical unit test: the onboarding "error" spec
+  // waits out apiClient's built-in retry/backoff on a mocked 5xx response.
+  timeout: 45_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    ? undefined
+    : {
+        // Runs against webpack rather than the default Turbopack dev server:
+        // Turbopack's on-demand compilation of the next-intl plugin config
+        // currently 500s on every locale-prefixed route under Next 16 (see
+        // `dev:e2e` in package.json). This only affects this throwaway e2e
+        // dev server, not `bun run dev` or the production `bun run build`
+        // used elsewhere, neither of which hit that code path.
+        command: "bun run dev:e2e",
+        url: BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+          PORT,
+          // Real values are irrelevant: every request the app makes to these
+          // hosts is intercepted and fulfilled by e2e/mocks, no server ever
+          // needs to be reachable at these URLs.
+          NEXT_PUBLIC_API_URL: "http://localhost:3101",
+          API_URL: "http://localhost:3101",
+          OPERATIONS_BACKEND_CREDENTIAL: "e2e-test-credential",
+          OPERATIONS_ALLOWED_WALLETS: "*",
+          NEXT_PUBLIC_USE_MOCK: "false",
+          SKIP_ENV_VALIDATION: "true",
+        },
+      },
+});

--- a/apps/webapp/src/app/[locale]/pilot/review/whitelist/page.tsx
+++ b/apps/webapp/src/app/[locale]/pilot/review/whitelist/page.tsx
@@ -4,10 +4,11 @@ import { ErrorBoundary } from "@/components/ui";
 import { WhitelistReviewQueue } from "@/components/pilot/WhitelistReviewQueue";
 
 export async function generateMetadata({
-  params: { locale },
+  params,
 }: {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }) {
+  const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "PilotAdmin" });
   return {
     title: `Whitelist Review | ${t("title", { fallback: "Admin" })}`,

--- a/bun.lock
+++ b/bun.lock
@@ -143,6 +143,7 @@
         "zustand": "^5.0.11",
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@storybook/addon-actions": "^8.6.0",
         "@storybook/addon-essentials": "^8.6.0",
         "@storybook/addon-interactions": "^8.6.0",
@@ -949,6 +950,8 @@
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@pmmmwh/react-refresh-webpack-plugin": ["@pmmmwh/react-refresh-webpack-plugin@0.5.17", "", { "dependencies": { "ansi-html": "^0.0.9", "core-js-pure": "^3.23.3", "error-stack-parser": "^2.0.6", "html-entities": "^2.1.0", "loader-utils": "^2.0.4", "schema-utils": "^4.2.0", "source-map": "^0.7.3" }, "peerDependencies": { "@types/webpack": "4.x || 5.x", "react-refresh": ">=0.10.0 <1.0.0", "sockjs-client": "^1.4.0", "type-fest": ">=0.17.0 <5.0.0", "webpack": ">=4.43.0 <6.0.0", "webpack-dev-server": "3.x || 4.x || 5.x", "webpack-hot-middleware": "2.x", "webpack-plugin-serve": "0.x || 1.x" }, "optionalPeers": ["@types/webpack", "sockjs-client", "type-fest", "webpack-dev-server", "webpack-hot-middleware", "webpack-plugin-serve"] }, "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ=="],
 
@@ -2938,6 +2941,10 @@
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "pnp-webpack-plugin": ["pnp-webpack-plugin@1.7.0", "", { "dependencies": { "ts-pnp": "^1.1.6" } }, "sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg=="],
@@ -3580,9 +3587,15 @@
 
     "@akkuea/land/@stellar/stellar-sdk": ["@stellar/stellar-sdk@14.6.1", "", { "dependencies": { "@stellar/stellar-base": "^14.1.0", "axios": "^1.13.3", "bignumber.js": "^9.3.1", "commander": "^14.0.2", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.1" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg=="],
 
+    "@akkuea/shared/@eslint/js": ["@eslint/js@9.39.5", "", {}, "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="],
+
     "@akkuea/shared/@stellar/stellar-sdk": ["@stellar/stellar-sdk@14.6.1", "", { "dependencies": { "@stellar/stellar-base": "^14.1.0", "axios": "^1.13.3", "bignumber.js": "^9.3.1", "commander": "^14.0.2", "eventsource": "^2.0.2", "feaxios": "^0.0.23", "randombytes": "^2.1.0", "toml": "^3.0.0", "urijs": "^1.19.1" }, "bin": { "stellar-js": "bin/stellar-js" } }, "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg=="],
 
+    "@akkuea/shared/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
     "@akkuea/webapp/@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
+
+    "@akkuea/webapp/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "@akkuea/webapp/eslint-config-next": ["eslint-config-next@16.2.7", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.7", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-CQ2aNXkrsjaGA2oJBE1LYnlRdphIAQE9ZQfX9hSv1PNGPyiOMSaVeBfTIO29QxYz+ij/hZudK0cfpCG1HXWstg=="],
 
@@ -4115,6 +4128,8 @@
     "pino/sonic-boom": ["sonic-boom@2.8.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg=="],
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 


### PR DESCRIPTION
Closes #1086.

## What

Introduces the repository's first Playwright e2e harness, scoped to the pilot's only stable UI: `WhitelistOnboardingForm` and `WhitelistReviewQueue`.

- `apps/webapp/playwright.config.ts` + `apps/webapp/e2e/`: specs cover the onboarding form's four required states (loading, error, success, disconnected-wallet) and the review queue's approve/reject actions (plus its own loading/error states).
- All API calls are mocked at the network layer with `page.route()` (`e2e/fixtures/whitelist-api.ts`), and a connected wallet is simulated via `localStorage` (`e2e/fixtures/wallet.ts`). No backend process, no testnet transaction.
- New `e2e-tests` job in `webapp-ci.yml`, independent of the existing unit-test job so it can't slow or destabilize it.
- Local + CI run instructions documented in `apps/webapp/README.md` and linked from `CONTRIBUTING.md`.
- The e2e dev server runs `next dev --webpack` instead of the default Turbopack dev server: Turbopack's on-demand compilation of the next-intl plugin config currently fails on every locale-prefixed route under Next 16. This only affects this throwaway e2e server, not `bun run dev` or `bun run build`.

## Bugs found by actually rendering these pages for the first time

Being the first thing to exercise this route at runtime, the suite surfaced two pre-existing bugs, fixed in a separate commit:

- `pilot/review/whitelist/page.tsx` destructured `params.locale` synchronously; Next 16 requires `await`-ing `params`.
- The `PilotAdmin` i18n namespace referenced by that same page was missing from both `messages/en.json` and `messages/es.json`.

## Verification

- `bun run test:e2e` — 8/8 passing locally.
- `bun run type-check`, `bun run lint` clean in `apps/webapp`.
